### PR TITLE
fix: reconcile all credentials on SecretSync boot

### DIFF
--- a/lib/camelot/runtime/secret_sync.ex
+++ b/lib/camelot/runtime/secret_sync.ex
@@ -23,6 +23,7 @@ defmodule Camelot.Runtime.SecretSync do
   require Logger
 
   @name __MODULE__
+  @bootstrap_retry_ms 5_000
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
@@ -57,7 +58,24 @@ defmodule Camelot.Runtime.SecretSync do
 
   @impl GenServer
   def init(_opts) do
-    {:ok, %{}}
+    if swarm_backend?() do
+      {:ok, %{}, 0}
+    else
+      {:ok, %{}}
+    end
+  end
+
+  @impl GenServer
+  def handle_info(:timeout, state) do
+    case DockerApi.ping() do
+      :ok ->
+        reconcile_all_credentials()
+        {:noreply, state}
+
+      _ ->
+        Logger.debug("SecretSync: proxy not reachable yet, retrying")
+        {:noreply, state, @bootstrap_retry_ms}
+    end
   end
 
   @impl GenServer
@@ -87,6 +105,16 @@ defmodule Camelot.Runtime.SecretSync do
   # --- Internals ---
 
   defp swarm_backend?, do: Runner.backend() == Swarm
+
+  defp reconcile_all_credentials do
+    Credential
+    |> Ash.read!()
+    |> Enum.each(&do_reconcile(&1.user_id, &1.kind))
+  rescue
+    e ->
+      Logger.warning("SecretSync: bulk reconcile failed: #{Exception.message(e)}")
+      :ok
+  end
 
   defp do_reconcile(user_id, kind) do
     cred =


### PR DESCRIPTION
## Summary

- On `SecretSync.init/1`, bulk-reconcile every credential so the Swarm secret for each `(user_id, kind)` pair is created without waiting for a UI re-save. Fixes the test-cluster regression where pre-existing credentials never produced a `camelot_user_*` secret after a redeploy, leaving runners unable to authenticate (`Base.encode64(nil)` was the symptom, but the deeper miss was that reconcile only fired on credential mutations).
- Uses the GenServer timeout mechanism (`{:ok, state, 0}` / `{:noreply, state, 5_000}`) so the bootstrap retries every 5s while the docker-socket-proxy is unreachable — survives Camelot starting before the proxy service is up.

## Test plan

- [ ] CI: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix test`, `mix credo --strict`, `mix dialyzer` all green
- [ ] On test cluster: after redeploy, `docker secret ls` shows `camelot_user_<uid>_<kind>` for every credential in the DB, without any UI interaction
- [ ] Dispatched task no longer fails with "container abandoned during backend restart"

🤖 Generated with [Claude Code](https://claude.com/claude-code)