### PR TITLE
fix: require user_id when creating an agent

### DIFF
--- a/lib/camelot/agents/agent.ex
+++ b/lib/camelot/agents/agent.ex
@@ -141,7 +141,7 @@ defmodule Camelot.Agents.Agent do
       end
 
       argument :user_id, :uuid do
-        allow_nil?(true)
+        allow_nil?(false)
       end
 
       change(manage_relationship(:project_id, :project, type: :append))

--- a/lib/camelot_web/live/agent_live/index.ex
+++ b/lib/camelot_web/live/agent_live/index.ex
@@ -66,6 +66,7 @@ defmodule CamelotWeb.AgentLive.Index do
       params
       |> Map.take(@agent_fields)
       |> normalise_max_retries()
+      |> Map.put("user_id", socket.assigns.current_user.id)
 
     case Ash.create(Agent, agent_params) do
       {:ok, _agent} ->

--- a/test/camelot/agents/agent_test.exs
+++ b/test/camelot/agents/agent_test.exs
@@ -11,10 +11,11 @@ defmodule Camelot.Agents.AgentTest do
         path: "/tmp/agent-proj"
       })
 
+    user = user!()
     claude = agent_template!("claude_code")
     codex = agent_template!("codex")
 
-    %{project: project, claude: claude, codex: codex}
+    %{project: project, user: user, claude: claude, codex: codex}
   end
 
   describe "create" do
@@ -23,7 +24,8 @@ defmodule Camelot.Agents.AgentTest do
                Ash.create(Agent, %{
                  name: "Claude",
                  template_id: ctx.claude.id,
-                 project_id: ctx.project.id
+                 project_id: ctx.project.id,
+                 user_id: ctx.user.id
                })
 
       assert agent.name == "Claude"
@@ -35,7 +37,8 @@ defmodule Camelot.Agents.AgentTest do
       assert {:error, _} =
                Ash.create(Agent, %{
                  template_id: ctx.claude.id,
-                 project_id: ctx.project.id
+                 project_id: ctx.project.id,
+                 user_id: ctx.user.id
                })
     end
 
@@ -44,14 +47,16 @@ defmodule Camelot.Agents.AgentTest do
                Ash.create(Agent, %{
                  name: "A1",
                  template_id: ctx.claude.id,
-                 project_id: ctx.project.id
+                 project_id: ctx.project.id,
+                 user_id: ctx.user.id
                })
 
       assert {:ok, _} =
                Ash.create(Agent, %{
                  name: "A2",
                  template_id: ctx.codex.id,
-                 project_id: ctx.project.id
+                 project_id: ctx.project.id,
+                 user_id: ctx.user.id
                })
     end
   end
@@ -62,7 +67,8 @@ defmodule Camelot.Agents.AgentTest do
         Ash.create(Agent, %{
           name: "Toggler",
           template_id: ctx.claude.id,
-          project_id: ctx.project.id
+          project_id: ctx.project.id,
+          user_id: ctx.user.id
         })
 
       assert agent.status == :idle

--- a/test/camelot/agents/session_test.exs
+++ b/test/camelot/agents/session_test.exs
@@ -14,13 +14,6 @@ defmodule Camelot.Agents.SessionTest do
         path: "/tmp/session-proj"
       })
 
-    {:ok, agent} =
-      Ash.create(Agent, %{
-        name: "Agent",
-        template_id: agent_template!("claude_code").id,
-        project_id: project.id
-      })
-
     {:ok, hashed} =
       AshAuthentication.BcryptProvider.hash("Hello world!123")
 
@@ -28,6 +21,14 @@ defmodule Camelot.Agents.SessionTest do
       Ash.Seed.seed!(User, %{
         email: "session-test@example.com",
         hashed_password: hashed
+      })
+
+    {:ok, agent} =
+      Ash.create(Agent, %{
+        name: "Agent",
+        template_id: agent_template!("claude_code").id,
+        project_id: project.id,
+        user_id: user.id
       })
 
     {:ok, task} =

--- a/test/camelot/board/task_test.exs
+++ b/test/camelot/board/task_test.exs
@@ -26,7 +26,8 @@ defmodule Camelot.Board.TaskTest do
       Ash.create(Agent, %{
         name: "test-agent",
         template_id: agent_template!("claude_code").id,
-        project_id: project.id
+        project_id: project.id,
+        user_id: user.id
       })
 
     %{project: project, user: user, agent: agent}

--- a/test/camelot/runtime/agent_process_test.exs
+++ b/test/camelot/runtime/agent_process_test.exs
@@ -15,13 +15,6 @@ defmodule Camelot.Runtime.AgentProcessTest do
         path: "/tmp/proc-proj-#{System.unique_integer()}"
       })
 
-    {:ok, agent} =
-      Ash.create(Agent, %{
-        name: "ProcAgent",
-        template_id: agent_template!("claude_code").id,
-        project_id: project.id
-      })
-
     {:ok, hashed} =
       AshAuthentication.BcryptProvider.hash("Hello world!123")
 
@@ -29,6 +22,14 @@ defmodule Camelot.Runtime.AgentProcessTest do
       Ash.Seed.seed!(User, %{
         email: "proc-#{System.unique_integer()}@example.com",
         hashed_password: hashed
+      })
+
+    {:ok, agent} =
+      Ash.create(Agent, %{
+        name: "ProcAgent",
+        template_id: agent_template!("claude_code").id,
+        project_id: project.id,
+        user_id: user.id
       })
 
     {:ok, task} =

--- a/test/camelot_web/live/agent_live_test.exs
+++ b/test/camelot_web/live/agent_live_test.exs
@@ -8,7 +8,7 @@ defmodule CamelotWeb.AgentLiveTest do
 
   setup :register_and_log_in_user
 
-  setup do
+  setup %{user: user} do
     {:ok, project} =
       Ash.create(Project, %{
         name: "agent-live-proj",
@@ -21,7 +21,8 @@ defmodule CamelotWeb.AgentLiveTest do
       Ash.create(Agent, %{
         name: "LiveAgent",
         template_id: template.id,
-        project_id: project.id
+        project_id: project.id,
+        user_id: user.id
       })
 
     %{agent: agent, project: project, template: template}

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -43,6 +43,15 @@ defmodule Camelot.DataCase do
     |> Ash.read_one!()
   end
 
+  @doc """
+  Seeds a `Camelot.Accounts.User` with a unique email. Used
+  by tests that need an owning user for an `Agent` row.
+  """
+  def user!(attrs \\ %{}) do
+    defaults = %{email: "test-#{System.unique_integer([:positive])}@example.com"}
+    Ash.Seed.seed!(Camelot.Accounts.User, Map.merge(defaults, attrs))
+  end
+
   setup tags do
     Camelot.DataCase.setup_sandbox(tags)
     :ok


### PR DESCRIPTION
The Agent.user_id was nullable both on the relationship and on the create action's argument, with a comment noting the field is "required for new agents" — but nothing enforced it. The agents LiveView form omitted user_id entirely, so freshly-created agents ran with no owning user.

Downstream, AgentProcess.build_secrets/2 short-circuits on %Agent{user_id: nil} and returns an empty secret list regardless of the template's required_credential_kinds. The Swarm runner then launches without /run/secrets/<kind>, the CLI inside exits 1 on missing auth, and the Reconciler reaps the session with the misleading "container abandoned during backend restart" error.

Tighten the create-action argument to allow_nil?(false) and pass socket.assigns.current_user.id from the LiveView. The belongs_to relationship itself stays nullable so legacy rows still load.