### PR TITLE
fix: agent user_id + Swarm SecretID in service spec

### DIFF
--- a/lib/camelot/runtime/runner/swarm.ex
+++ b/lib/camelot/runtime/runner/swarm.ex
@@ -24,6 +24,7 @@ defmodule Camelot.Runtime.Runner.Swarm do
   alias Camelot.Runtime.Runner
   alias Camelot.Runtime.Runner.DockerApi
   alias Camelot.Runtime.Runner.Spec
+  alias Camelot.Runtime.SecretSync
 
   require Logger
 
@@ -185,16 +186,27 @@ defmodule Camelot.Runtime.Runner.Swarm do
   defp secrets(%Spec{secrets: []}), do: []
 
   defp secrets(%Spec{secrets: secrets}) do
-    Enum.map(secrets, fn %{kind: kind, name: name} ->
-      %{
-        "SecretName" => name,
-        "File" => %{
-          "Name" => Atom.to_string(kind),
-          "UID" => "0",
-          "GID" => "0",
-          "Mode" => 0o400
-        }
-      }
+    Enum.flat_map(secrets, fn %{kind: kind, name: name} ->
+      case SecretSync.lookup_id_by_name(name) do
+        {:ok, id} ->
+          [
+            %{
+              "SecretID" => id,
+              "SecretName" => name,
+              "File" => %{
+                "Name" => Atom.to_string(kind),
+                "UID" => "0",
+                "GID" => "0",
+                "Mode" => 0o400
+              }
+            }
+          ]
+
+        :error ->
+          Logger.warning("Swarm: secret #{name} not found in cluster; runner will start without /run/secrets/#{kind}")
+
+          []
+      end
     end)
   end
 

--- a/lib/camelot/runtime/secret_sync.ex
+++ b/lib/camelot/runtime/secret_sync.ex
@@ -54,6 +54,14 @@ defmodule Camelot.Runtime.SecretSync do
     GenServer.call(@name, {:lookup, user_id, kind})
   end
 
+  @doc """
+  Looks up the current secret id by its full Swarm name.
+  Stateless — bypasses the GenServer, suitable for hot paths
+  like runner-spec construction.
+  """
+  @spec lookup_id_by_name(String.t()) :: {:ok, String.t()} | :error
+  def lookup_id_by_name(name), do: fetch_secret_by_name(name)
+
   # --- GenServer ---
 
   @impl GenServer


### PR DESCRIPTION
## Summary

Two follow-up fixes from the test-cluster debug session that brought the Swarm runner up end-to-end.

- **Require `user_id` when creating an agent.** `Agent.user_id` was nullable both on the relationship and on the create-action argument, with a comment claiming the field is "required for new agents" — but nothing enforced it. The agents LiveView form was already omitting `user_id`, so freshly-created agents ran with no owning user. Downstream, `AgentProcess.build_secrets/2` short-circuits on `%Agent{user_id: nil}` and returns an empty secret list regardless of the template's `required_credential_kinds`, leading to runners that started without `/run/secrets/<kind>` and exited 1, surfaced as a misleading "container abandoned during backend restart" via the Reconciler. Tightens the create-action argument to `allow_nil?(false)` and passes `socket.assigns.current_user.id` from the LiveView. The `belongs_to` itself stays nullable so legacy rows still load.

- **Include `SecretID` in the Swarm `/services/create` payload.** Docker Swarm rejects a `SecretReference` that has only `SecretName` with `rpc error: code = InvalidArgument desc = malformed secret reference`. Adds `SecretSync.lookup_id_by_name/1` (stateless — bypasses the GenServer for the hot path) and uses it from `runner/swarm.ex` to inject `SecretID` alongside `SecretName`. Missing-secret case is logged and skipped instead of 400-ing the whole dispatch.

## Test plan

- [ ] CI green (`mix format`, `mix compile --warnings-as-errors`, `mix test`, `mix credo --strict`, `mix dialyzer`)
- [ ] After deploy: queueing a task on the test cluster produces a `camelot-runner-<session_id>` Swarm service with the `claude_api_key` secret mounted, and the task transitions out of `planning` without a `Swarm start failed` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)