### PR TITLE
fix: mount Swarm secrets as the runner-image agent user

### DIFF
--- a/lib/camelot/runtime/runner/swarm.ex
+++ b/lib/camelot/runtime/runner/swarm.ex
@@ -195,8 +195,8 @@ defmodule Camelot.Runtime.Runner.Swarm do
               "SecretName" => name,
               "File" => %{
                 "Name" => Atom.to_string(kind),
-                "UID" => "0",
-                "GID" => "0",
+                "UID" => "1000",
+                "GID" => "1000",
                 "Mode" => 0o400
               }
             }


### PR DESCRIPTION
## Summary

`swarm.ex` was building each `SecretReference` with `UID="0" GID="0" Mode=0o400`, but the runner image runs as `agent` (uid 1000, per `runner-images/base/Dockerfile:50`). The secret mounted as `-r-------- 1 root root`, so the agent user got permission denied. `$(cat /run/secrets/claude_api_key)` in `entrypoint.sh:29` returned `""`, the OAuth branch in `materialise_one` was skipped, `ANTHROPIC_API_KEY=""` got exported, Claude 401'd and the container exited 1 within ~10 seconds — surfaced upstream by the Reconciler as the misleading "container abandoned during backend restart".

Switching the spec to `UID="1000" GID="1000"` aligns the file owner with the runtime user.

## Test plan

- [x] Reproduced the failure with a one-off Swarm probe at `uid=0,gid=0,mode=0400` — `cat` returned exit 1, payload empty
- [x] Verified the fix with `uid=1000,gid=1000,mode=0400` — claude returned `is_error:false`, service `Complete`
- [x] CI green locally (`mix format`, `mix compile --warnings-as-errors`, `mix test`, `mix credo --strict`)
- [ ] After deploy: dispatched task transitions out of `planning` with a non-error claude response

🤖 Generated with [Claude Code](https://claude.com/claude-code)