### PR TITLE
fix: retain Swarm runner services for 5 minutes after exit

### DIFF
--- a/lib/camelot/runtime/runner/swarm.ex
+++ b/lib/camelot/runtime/runner/swarm.ex
@@ -30,6 +30,7 @@ defmodule Camelot.Runtime.Runner.Swarm do
 
   @poll_interval_ms 2_000
   @pending_grace_ms 30_000
+  @log_retention_ms 300_000
 
   defstruct [
     :owner,
@@ -86,13 +87,18 @@ defmodule Camelot.Runtime.Runner.Swarm do
 
   def handle_info({:exit_code, code}, state) do
     send(state.owner, {:runner_exit, self(), code})
-    remove_service(state.service_id)
-    {:stop, :normal, state}
+    schedule_cleanup()
+    {:noreply, state}
   end
 
   def handle_info({:cluster_full, reason}, state) do
     send(state.owner, {:runner_data, self(), "[swarm] cluster_full: #{inspect(reason)}\n"})
     send(state.owner, {:runner_exit, self(), 125})
+    schedule_cleanup()
+    {:noreply, state}
+  end
+
+  def handle_info(:cleanup, state) do
     remove_service(state.service_id)
     {:stop, :normal, state}
   end
@@ -100,6 +106,10 @@ defmodule Camelot.Runtime.Runner.Swarm do
   def handle_info({ref, _}, state) when is_reference(ref), do: {:noreply, state}
   def handle_info({:DOWN, _, _, _, _}, state), do: {:noreply, state}
   def handle_info(_msg, state), do: {:noreply, state}
+
+  defp schedule_cleanup do
+    Process.send_after(self(), :cleanup, @log_retention_ms)
+  end
 
   # --- Service create ---
 


### PR DESCRIPTION
## Summary

The Swarm runner GenServer was deleting the service immediately on `:exit_code` (or `:cluster_full`), which also takes down its container and discards stdout/stderr. With sessions failing inside the container and `Session.output_log` going to the DB empty (separate streaming issue, see below), there was no way to diagnose without external log aggregation.

Schedule cleanup via `Process.send_after(self(), :cleanup, 300_000)` instead. The runner GenServer stays alive (idle) for the retention window, leaving the service in place so `docker service logs camelot-runner-<session_id>` is readable on a manager. After 5 minutes the GenServer removes the service and stops normally. Manual `stop/1` (cancel path) still tears it down immediately — only the natural-exit path is delayed.

## Follow-up worth noting

`Session.output_log` is empty across the three recent post-deploy failures even though the runner ran ~38s and the container clearly produced output (clone + asdf + claude). The streaming pipeline at `swarm.ex:280-296` follows `/services/:id/logs` and forwards chunks to AgentProcess, but no chunks are reaching `output_buffer`. Two likely causes I haven't chased yet:
1. Docker's multiplexed log frames (8-byte stream-type + size header + payload) — the parser may be choking and silently zeroing the buffer in a race
2. `follow=true` stream behaviour through the docker-socket-proxy

Either way, this PR is an immediate observability win — operators can inspect via `docker service logs` in the 5-minute window.

## Test plan

- [x] CI green locally (`mix format`, `mix compile --warnings-as-errors`, `mix test`, `mix credo --strict`)
- [ ] After deploy: dispatch a task and confirm `docker service ls --filter name=camelot-runner` shows the runner staying past container exit; `docker service logs camelot-runner-<session_id>` returns the entrypoint output + claude stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)