### PR TITLE
fix: honour 5-min retention in Reconciler orphan sweep

### DIFF
--- a/lib/camelot/runtime/reconciler.ex
+++ b/lib/camelot/runtime/reconciler.ex
@@ -38,6 +38,7 @@ defmodule Camelot.Runtime.Reconciler do
   require Logger
 
   @tick_ms 60_000
+  @log_retention_ms 300_000
   @name __MODULE__
 
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -194,9 +195,14 @@ defmodule Camelot.Runtime.Reconciler do
   end
 
   defp sweep_orphan_services(live_session_ids) do
+    cutoff = DateTime.add(DateTime.utc_now(), -@log_retention_ms, :millisecond)
+
     valid =
       Session
-      |> Ash.Query.filter(status in [:queued, :running])
+      |> Ash.Query.filter(
+        status in [:queued, :running] or
+          (not is_nil(finished_at) and finished_at > ^cutoff)
+      )
       |> Ash.Query.select([:id])
       |> Ash.read!()
       |> MapSet.new(& &1.id)


### PR DESCRIPTION
## Summary

Follow-up to #9. The runner GenServer was correctly scheduling a 5-minute cleanup on `:exit_code`, but `Reconciler.sweep_orphan_services/1` reaped any Swarm runner whose session wasn't `:queued`/`:running`. Sessions move to `:failed` within milliseconds of exit, so the Reconciler tick (every 60s) deleted the service well inside the retention window — empirically observed: `docker service ls --filter name=camelot-runner` returned empty almost immediately after each container exited.

Extend the "valid sessions" filter to include sessions whose `finished_at` is within the last `@log_retention_ms` (5 minutes). After the window elapses, the orphan sweep reaps them naturally; the runner GenServer's own `:cleanup` timer remains a belt-and-braces delete (a `Req.delete` on an already-removed id is rescued harmlessly in `swarm.ex`).

## Test plan

- [x] `mix format`, `mix compile --warnings-as-errors`, `mix test`, `mix credo --strict` — all clean locally
- [ ] After deploy: dispatch a task and confirm `docker service ls --filter name=camelot-runner` shows the runner for ~5 minutes after container exit; `docker service logs camelot-runner-<session_id>` is readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)