### PR TITLE
fix: re-verify cached task container/service on every get

### DIFF
--- a/lib/camelot/runtime/runner/docker_engine/exec_session.ex
+++ b/lib/camelot/runtime/runner/docker_engine/exec_session.ex
@@ -186,11 +186,19 @@ defmodule Camelot.Runtime.Runner.DockerEngine.ExecSession do
   # `sk-ant-oat*` value is an OAuth access token that Claude reads
   # from CLAUDE_CODE_OAUTH_TOKEN (sending it on x-api-key would 401).
   # Everything else is a plain API key.
+  # When the OAuth path is in play, also explicitly clear
+  # ANTHROPIC_API_KEY in the exec env so that any stale value
+  # baked into the container (e.g. from a previous credential or
+  # the old TaskContainer mapping) can't beat us. claude treats
+  # an empty value as unset and falls back to CLAUDE_CODE_OAUTH_TOKEN.
   defp secret_to_env(%{kind: :claude_api_key, value: "sk-ant-oat" <> _ = v}) do
-    ["CLAUDE_CODE_OAUTH_TOKEN=#{v}"]
+    ["CLAUDE_CODE_OAUTH_TOKEN=#{v}", "ANTHROPIC_API_KEY="]
   end
 
-  defp secret_to_env(%{kind: :claude_api_key, value: v}), do: ["ANTHROPIC_API_KEY=#{v}"]
+  defp secret_to_env(%{kind: :claude_api_key, value: v}) do
+    ["ANTHROPIC_API_KEY=#{v}", "CLAUDE_CODE_OAUTH_TOKEN="]
+  end
+
   defp secret_to_env(%{kind: :openai_api_key, value: v}), do: ["OPENAI_API_KEY=#{v}"]
   defp secret_to_env(%{kind: :codex_api_key, value: v}), do: ["OPENAI_API_KEY=#{v}"]
 

--- a/lib/camelot/runtime/runner/docker_engine/exec_session.ex
+++ b/lib/camelot/runtime/runner/docker_engine/exec_session.ex
@@ -166,10 +166,39 @@ defmodule Camelot.Runtime.Runner.DockerEngine.ExecSession do
     end
   end
 
-  defp session_env(%Spec{mcp_config_json: nil}), do: nil
+  # Build the per-exec `Env` array. Always re-materialises secrets
+  # from the current Spec so a credential rotation in the UI takes
+  # effect on the next session without rebuilding the container.
+  # The exec-wrapper treats /tmp/camelot.env as a fallback only;
+  # these values override anything baked in at container start.
+  defp session_env(%Spec{} = spec) do
+    secret_env(spec) ++ mcp_env(spec)
+  end
 
-  defp session_env(%Spec{mcp_config_json: json}) do
-    ["PROJECT_MCP_CONFIG_JSON=#{json}"]
+  defp secret_env(%Spec{secrets: secrets}) do
+    Enum.flat_map(secrets, &secret_to_env/1)
+  end
+
+  defp mcp_env(%Spec{mcp_config_json: nil}), do: []
+  defp mcp_env(%Spec{mcp_config_json: json}), do: ["PROJECT_MCP_CONFIG_JSON=#{json}"]
+
+  # Mirror runner-images/base/entrypoint.sh#materialise_one — an
+  # `sk-ant-oat*` value is an OAuth access token that Claude reads
+  # from CLAUDE_CODE_OAUTH_TOKEN (sending it on x-api-key would 401).
+  # Everything else is a plain API key.
+  defp secret_to_env(%{kind: :claude_api_key, value: "sk-ant-oat" <> _ = v}) do
+    ["CLAUDE_CODE_OAUTH_TOKEN=#{v}"]
+  end
+
+  defp secret_to_env(%{kind: :claude_api_key, value: v}), do: ["ANTHROPIC_API_KEY=#{v}"]
+  defp secret_to_env(%{kind: :openai_api_key, value: v}), do: ["OPENAI_API_KEY=#{v}"]
+  defp secret_to_env(%{kind: :codex_api_key, value: v}), do: ["OPENAI_API_KEY=#{v}"]
+
+  defp secret_to_env(%{kind: kind, value: v}) when kind in [:github_pat, :github_oauth],
+    do: ["GH_TOKEN=#{v}", "GITHUB_TOKEN=#{v}"]
+
+  defp secret_to_env(%{kind: kind, value: v}) do
+    ["CAMELOT_SECRET_#{String.upcase(Atom.to_string(kind))}=#{v}"]
   end
 
   defp kick_off_streams(%__MODULE__{} = state) do
@@ -209,14 +238,16 @@ defmodule Camelot.Runtime.Runner.DockerEngine.ExecSession do
     Process.put(:de_demux_buf, rest)
   end
 
+  # An exec inspect returns `Running: false, ExitCode: nil` between
+  # `POST /containers/<id>/exec` (which creates the exec) and
+  # `POST /exec/<id>/start` (which actually starts it). Treat that
+  # pre-start state the same as "still running" — only ExitCode as
+  # an integer means the process has actually exited.
   defp poll_exec_exit(exec_id, parent) do
     case Req.get(DockerApi.request(), url: "/exec/#{exec_id}/json") do
       {:ok, %Req.Response{status: 200, body: %{"Running" => false, "ExitCode" => code}}}
       when is_integer(code) ->
         send(parent, {:exit_code, code})
-
-      {:ok, %Req.Response{status: 200, body: %{"Running" => false}}} ->
-        send(parent, {:exit_code, 1})
 
       _ ->
         Process.sleep(@exit_poll_ms)

--- a/lib/camelot/runtime/runner/docker_engine/exec_session.ex
+++ b/lib/camelot/runtime/runner/docker_engine/exec_session.ex
@@ -121,7 +121,7 @@ defmodule Camelot.Runtime.Runner.DockerEngine.ExecSession do
     payload = %{
       "AttachStdout" => false,
       "AttachStderr" => false,
-      "Cmd" => ["test", "-f", "/run/camelot-ready"]
+      "Cmd" => ["test", "-f", "/tmp/camelot-ready"]
     }
 
     with {:ok, %Req.Response{status: 201, body: %{"Id" => exec_id}}} <-

--- a/lib/camelot/runtime/runner/docker_engine/exec_session.ex
+++ b/lib/camelot/runtime/runner/docker_engine/exec_session.ex
@@ -68,6 +68,11 @@ defmodule Camelot.Runtime.Runner.DockerEngine.ExecSession do
   def handle_cast(:stop, state), do: {:stop, :normal, state}
 
   @impl GenServer
+  def format_status(status) do
+    update_in(status.state.spec, &Spec.redact/1)
+  end
+
+  @impl GenServer
   def handle_info({:chunk, bytes}, %__MODULE__{} = state) do
     send(state.owner, {:runner_data, self(), bytes})
     {:noreply, state}

--- a/lib/camelot/runtime/runner/docker_engine/exec_session.ex
+++ b/lib/camelot/runtime/runner/docker_engine/exec_session.ex
@@ -18,8 +18,12 @@ defmodule Camelot.Runtime.Runner.DockerEngine.ExecSession do
 
   require Logger
 
+  # Polling intervals only — no wall-clock deadlines. Container
+  # setup (pull, clone, asdf install) and agent runtime can each
+  # legitimately take many minutes; bounding either with a timeout
+  # would just convert a slow-but-correct dispatch into a spurious
+  # failure. Real upstream failures break the loop via {:error, _}.
   @ready_poll_ms 500
-  @ready_timeout_ms 60_000
   @exit_poll_ms 1_000
 
   defstruct [
@@ -100,22 +104,13 @@ defmodule Camelot.Runtime.Runner.DockerEngine.ExecSession do
   end
 
   defp wait_for_ready(container_id) do
-    deadline = System.monotonic_time(:millisecond) + @ready_timeout_ms
-    do_wait_for_ready(container_id, deadline)
-  end
-
-  defp do_wait_for_ready(container_id, deadline) do
     case ready_check(container_id) do
       :ok ->
         :ok
 
       :not_ready ->
-        if System.monotonic_time(:millisecond) > deadline do
-          {:error, :ready_timeout}
-        else
-          Process.sleep(@ready_poll_ms)
-          do_wait_for_ready(container_id, deadline)
-        end
+        Process.sleep(@ready_poll_ms)
+        wait_for_ready(container_id)
 
       {:error, _} = err ->
         err

--- a/lib/camelot/runtime/runner/docker_engine/task_container.ex
+++ b/lib/camelot/runtime/runner/docker_engine/task_container.ex
@@ -122,6 +122,14 @@ defmodule Camelot.Runtime.Runner.DockerEngine.TaskContainer do
     {:stop, :normal, state}
   end
 
+  # Redact secret values from the state dumped by GenServer
+  # crash logs. The Spec's `secrets` list otherwise gets
+  # inspect()'d verbatim — including API keys.
+  @impl GenServer
+  def format_status(status) do
+    update_in(status.state.spec, &Spec.redact/1)
+  end
+
   # --- Container lifecycle ---
 
   defp ensure_container(%__MODULE__{task_id: task_id, spec: spec}) do
@@ -159,6 +167,23 @@ defmodule Camelot.Runtime.Runner.DockerEngine.TaskContainer do
   end
 
   defp create_container(task_id, %Spec{} = spec) do
+    case do_create_container(task_id, spec) do
+      {:error, {:create_failed, 404, %{"message" => "No such image:" <> _}}} ->
+        Logger.info(
+          "DockerEngine.TaskContainer #{task_id}: image #{inspect(spec.image)} " <>
+            "not present locally; pulling"
+        )
+
+        with :ok <- pull_image(spec.image) do
+          do_create_container(task_id, spec)
+        end
+
+      other ->
+        other
+    end
+  end
+
+  defp do_create_container(task_id, %Spec{} = spec) do
     name = Spec.task_runner_name(task_id)
     payload = container_create_payload(spec)
 
@@ -172,6 +197,31 @@ defmodule Camelot.Runtime.Runner.DockerEngine.TaskContainer do
 
       {:ok, resp} ->
         {:error, {:create_failed, resp.status, resp.body}}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  defp pull_image(nil), do: {:error, :no_image_to_pull}
+
+  defp pull_image(ref) do
+    # The Docker pull endpoint streams a JSON-lines progress body
+    # and only returns 200 OK once the pull is fully complete. We
+    # drain (and ignore) the body so we know when to retry create.
+    # `fromImage` accepts the full reference including tag/digest
+    # (e.g. `ghcr.io/org/name:tag`), so no need to split it.
+    case Req.post(DockerApi.request(),
+           url: "/images/create",
+           params: [fromImage: ref],
+           receive_timeout: 600_000,
+           into: fn {:data, _chunk}, acc -> {:cont, acc} end
+         ) do
+      {:ok, %Req.Response{status: status}} when status in 200..299 ->
+        :ok
+
+      {:ok, resp} ->
+        {:error, {:pull_failed, resp.status, resp.body}}
 
       {:error, _} = err ->
         err

--- a/lib/camelot/runtime/runner/docker_engine/task_container.ex
+++ b/lib/camelot/runtime/runner/docker_engine/task_container.ex
@@ -99,7 +99,16 @@ defmodule Camelot.Runtime.Runner.DockerEngine.TaskContainer do
 
   @impl GenServer
   def handle_call(:get_container_id, _from, %__MODULE__{container_id: id} = state) when is_binary(id) do
-    {:reply, {:ok, id}, state}
+    if container_alive?(id) do
+      {:reply, {:ok, id}, state}
+    else
+      Logger.info("DockerEngine.TaskContainer #{state.task_id}: cached container #{id} is gone; recreating")
+
+      case create_and_persist(state.task_id, state.spec) do
+        {:ok, new_id} -> {:reply, {:ok, new_id}, %{state | container_id: new_id}}
+        {:error, reason} -> {:reply, {:error, reason}, state}
+      end
+    end
   end
 
   def handle_call(:get_container_id, _from, state) do

--- a/lib/camelot/runtime/runner/docker_engine/task_container.ex
+++ b/lib/camelot/runtime/runner/docker_engine/task_container.ex
@@ -345,6 +345,13 @@ defmodule Camelot.Runtime.Runner.DockerEngine.TaskContainer do
     base ++ secret_env ++ extras
   end
 
+  # `sk-ant-oat*` is an OAuth access token. Anthropic returns 401
+  # if it's sent on the `x-api-key` header (ANTHROPIC_API_KEY). Claude
+  # CLI reads it from CLAUDE_CODE_OAUTH_TOKEN and uses Bearer auth.
+  defp secret_to_env(%{kind: :claude_api_key, value: "sk-ant-oat" <> _ = v}) do
+    ["CLAUDE_CODE_OAUTH_TOKEN=#{v}"]
+  end
+
   defp secret_to_env(%{kind: :claude_api_key, value: v}), do: ["ANTHROPIC_API_KEY=#{v}"]
   defp secret_to_env(%{kind: :openai_api_key, value: v}), do: ["OPENAI_API_KEY=#{v}"]
   defp secret_to_env(%{kind: :codex_api_key, value: v}), do: ["OPENAI_API_KEY=#{v}"]

--- a/lib/camelot/runtime/runner/docker_engine/task_container.ex
+++ b/lib/camelot/runtime/runner/docker_engine/task_container.ex
@@ -50,9 +50,15 @@ defmodule Camelot.Runtime.Runner.DockerEngine.TaskContainer do
     end
   end
 
+  # First-call timeout has to cover an image pull plus the
+  # subsequent /containers/create — multi-hundred-MB layers can
+  # take several minutes on a slow link. Matches the
+  # `receive_timeout` set on the pull request itself.
+  @get_container_id_timeout 600_000
+
   @spec get_container_id(pid()) :: {:ok, String.t()} | {:error, term()}
   def get_container_id(pid) do
-    GenServer.call(pid, :get_container_id, 60_000)
+    GenServer.call(pid, :get_container_id, @get_container_id_timeout)
   end
 
   @spec stop_task(String.t()) :: :ok

--- a/lib/camelot/runtime/runner/docker_engine/task_container.ex
+++ b/lib/camelot/runtime/runner/docker_engine/task_container.ex
@@ -17,12 +17,18 @@ defmodule Camelot.Runtime.Runner.DockerEngine.TaskContainer do
 
   require Logger
 
-  defstruct [:task_id, :container_id, :spec]
+  defstruct task_id: nil,
+            spec: nil,
+            container_id: nil,
+            ensure_task: nil,
+            waiters: []
 
   @type state :: %__MODULE__{
           task_id: String.t(),
+          spec: Spec.t() | nil,
           container_id: String.t() | nil,
-          spec: Spec.t() | nil
+          ensure_task: Elixir.Task.t() | nil,
+          waiters: [GenServer.from()]
         }
 
   # --- Public API ---
@@ -50,15 +56,14 @@ defmodule Camelot.Runtime.Runner.DockerEngine.TaskContainer do
     end
   end
 
-  # First-call timeout has to cover an image pull plus the
-  # subsequent /containers/create — multi-hundred-MB layers can
-  # take several minutes on a slow link. Matches the
-  # `receive_timeout` set on the pull request itself.
-  @get_container_id_timeout 600_000
-
+  # No timeout — pulls and recreates may legitimately take many
+  # minutes for large images. The GenServer parks callers in
+  # `state.waiters` while an async ensure task runs in the
+  # background, so this call only blocks for as long as the
+  # actual container provisioning takes.
   @spec get_container_id(pid()) :: {:ok, String.t()} | {:error, term()}
   def get_container_id(pid) do
-    GenServer.call(pid, :get_container_id, @get_container_id_timeout)
+    GenServer.call(pid, :get_container_id, :infinity)
   end
 
   @spec stop_task(String.t()) :: :ok
@@ -87,38 +92,28 @@ defmodule Camelot.Runtime.Runner.DockerEngine.TaskContainer do
   @impl GenServer
   def init(%Spec{} = spec) do
     state = %__MODULE__{task_id: spec.task_id, spec: spec}
-    {:ok, state, {:continue, :ensure_container}}
+    {:ok, kick_off_ensure(state)}
   end
 
   @impl GenServer
-  def handle_continue(:ensure_container, %__MODULE__{} = state) do
-    case ensure_container(state) do
-      {:ok, container_id} ->
-        {:noreply, %{state | container_id: container_id}}
-
-      {:error, reason} ->
-        Logger.error("DockerEngine.TaskContainer #{state.task_id}: ensure failed: #{inspect(reason)}")
-
-        {:stop, reason, state}
-    end
+  def handle_call(:get_container_id, from, %__MODULE__{container_id: nil} = state) do
+    # Provisioning still in flight — park the caller.
+    {:noreply, %{state | waiters: [from | state.waiters]}}
   end
 
-  @impl GenServer
-  def handle_call(:get_container_id, _from, %__MODULE__{container_id: id} = state) when is_binary(id) do
+  def handle_call(:get_container_id, from, %__MODULE__{container_id: id} = state) do
     if container_alive?(id) do
       {:reply, {:ok, id}, state}
     else
-      Logger.info("DockerEngine.TaskContainer #{state.task_id}: cached container #{id} is gone; recreating")
+      Logger.info(
+        "DockerEngine.TaskContainer #{state.task_id}: cached container #{id} " <>
+          "is gone; recreating"
+      )
 
-      case create_and_persist(state.task_id, state.spec) do
-        {:ok, new_id} -> {:reply, {:ok, new_id}, %{state | container_id: new_id}}
-        {:error, reason} -> {:reply, {:error, reason}, state}
-      end
+      state = kick_off_ensure(%{state | container_id: nil, waiters: [from | state.waiters]})
+
+      {:noreply, state}
     end
-  end
-
-  def handle_call(:get_container_id, _from, state) do
-    {:reply, {:error, :not_ready}, state}
   end
 
   @impl GenServer
@@ -127,6 +122,33 @@ defmodule Camelot.Runtime.Runner.DockerEngine.TaskContainer do
     clear_runner_handle(state.task_id)
     {:stop, :normal, state}
   end
+
+  # Ensure-task finished. Reply to every parked caller with the
+  # result and update state. Errors stop the GenServer so the
+  # parked callers also surface the failure (via :infinity call
+  # → {:noproc, …}).
+  @impl GenServer
+  def handle_info({ref, result}, %__MODULE__{ensure_task: %Elixir.Task{ref: ref}} = state) do
+    Process.demonitor(ref, [:flush])
+
+    case result do
+      {:ok, container_id} ->
+        Enum.each(state.waiters, &GenServer.reply(&1, {:ok, container_id}))
+        {:noreply, %{state | container_id: container_id, ensure_task: nil, waiters: []}}
+
+      {:error, reason} ->
+        Enum.each(state.waiters, &GenServer.reply(&1, {:error, reason}))
+        {:stop, reason, %{state | ensure_task: nil, waiters: []}}
+    end
+  end
+
+  # Ensure-task crashed unexpectedly. Surface to waiters and stop.
+  def handle_info({:DOWN, ref, :process, _, reason}, %__MODULE__{ensure_task: %Elixir.Task{ref: ref}} = state) do
+    Enum.each(state.waiters, &GenServer.reply(&1, {:error, {:ensure_crashed, reason}}))
+    {:stop, reason, %{state | ensure_task: nil, waiters: []}}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
 
   # Redact secret values from the state dumped by GenServer
   # crash logs. The Spec's `secrets` list otherwise gets
@@ -138,7 +160,16 @@ defmodule Camelot.Runtime.Runner.DockerEngine.TaskContainer do
 
   # --- Container lifecycle ---
 
-  defp ensure_container(%__MODULE__{task_id: task_id, spec: spec}) do
+  # Run the slow container-provisioning work (DB load, image pull,
+  # /containers/create, /containers/<id>/start) in a linked Task so
+  # the GenServer's mailbox stays responsive. The result lands as
+  # `{ref, {:ok, container_id} | {:error, reason}}` in handle_info/2.
+  defp kick_off_ensure(%__MODULE__{task_id: task_id, spec: spec} = state) do
+    task = Elixir.Task.async(fn -> ensure_container(task_id, spec) end)
+    %{state | ensure_task: task}
+  end
+
+  defp ensure_container(task_id, spec) do
     case load_task_handle(task_id) do
       {:ok, nil} ->
         create_and_persist(task_id, spec)
@@ -147,7 +178,10 @@ defmodule Camelot.Runtime.Runner.DockerEngine.TaskContainer do
         if container_alive?(handle) do
           {:ok, handle}
         else
-          Logger.info("DockerEngine.TaskContainer #{task_id}: stored container #{handle} is gone; recreating")
+          Logger.info(
+            "DockerEngine.TaskContainer #{task_id}: stored container #{handle} " <>
+              "is gone; recreating"
+          )
 
           create_and_persist(task_id, spec)
         end
@@ -220,7 +254,7 @@ defmodule Camelot.Runtime.Runner.DockerEngine.TaskContainer do
     case Req.post(DockerApi.request(),
            url: "/images/create",
            params: [fromImage: ref],
-           receive_timeout: 600_000,
+           receive_timeout: :infinity,
            into: fn {:data, _chunk}, acc -> {:cont, acc} end
          ) do
       {:ok, %Req.Response{status: status}} when status in 200..299 ->

--- a/lib/camelot/runtime/runner/spec.ex
+++ b/lib/camelot/runtime/runner/spec.ex
@@ -70,4 +70,17 @@ defmodule Camelot.Runtime.Runner.Spec do
   """
   @spec task_runner_name(String.t()) :: String.t()
   def task_runner_name(task_id), do: "camelot-task-#{task_id}"
+
+  @doc """
+  Returns a copy of the spec with secret values replaced
+  by `:redacted`. Used by `format_status/1` in runner
+  GenServers so a crash log doesn't leak API tokens via
+  the state dump.
+  """
+  @spec redact(t()) :: t()
+  def redact(%__MODULE__{} = spec) do
+    %{spec | secrets: Enum.map(spec.secrets, &Map.put(&1, :value, :redacted))}
+  end
+
+  def redact(other), do: other
 end

--- a/lib/camelot/runtime/runner/swarm/exec_session.ex
+++ b/lib/camelot/runtime/runner/swarm/exec_session.ex
@@ -251,11 +251,17 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
   defp mcp_env(%Spec{mcp_config_json: nil}), do: []
   defp mcp_env(%Spec{mcp_config_json: json}), do: ["PROJECT_MCP_CONFIG_JSON=#{json}"]
 
+  # Mirror DockerEngine — also clear the opposite var so a stale
+  # value baked into the container at boot can't beat the per-exec
+  # injection. Empty value is treated as unset by claude.
   defp secret_to_env(%{kind: :claude_api_key, value: "sk-ant-oat" <> _ = v}) do
-    ["CLAUDE_CODE_OAUTH_TOKEN=#{v}"]
+    ["CLAUDE_CODE_OAUTH_TOKEN=#{v}", "ANTHROPIC_API_KEY="]
   end
 
-  defp secret_to_env(%{kind: :claude_api_key, value: v}), do: ["ANTHROPIC_API_KEY=#{v}"]
+  defp secret_to_env(%{kind: :claude_api_key, value: v}) do
+    ["ANTHROPIC_API_KEY=#{v}", "CLAUDE_CODE_OAUTH_TOKEN="]
+  end
+
   defp secret_to_env(%{kind: :openai_api_key, value: v}), do: ["OPENAI_API_KEY=#{v}"]
   defp secret_to_env(%{kind: :codex_api_key, value: v}), do: ["OPENAI_API_KEY=#{v}"]
 

--- a/lib/camelot/runtime/runner/swarm/exec_session.ex
+++ b/lib/camelot/runtime/runner/swarm/exec_session.ex
@@ -234,10 +234,36 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
     end
   end
 
-  defp session_env(%Spec{mcp_config_json: nil}), do: nil
+  # Build the per-exec `Env` array. Re-materialises secrets from
+  # the current Spec on every exec so a credential rotation in the
+  # UI takes effect on the next session without rebuilding the
+  # Swarm service. The exec-wrapper treats /tmp/camelot.env as a
+  # fallback only; these values override anything mounted from
+  # /run/secrets/ at container-start time.
+  defp session_env(%Spec{} = spec) do
+    secret_env(spec) ++ mcp_env(spec)
+  end
 
-  defp session_env(%Spec{mcp_config_json: json}) do
-    ["PROJECT_MCP_CONFIG_JSON=#{json}"]
+  defp secret_env(%Spec{secrets: secrets}) do
+    Enum.flat_map(secrets, &secret_to_env/1)
+  end
+
+  defp mcp_env(%Spec{mcp_config_json: nil}), do: []
+  defp mcp_env(%Spec{mcp_config_json: json}), do: ["PROJECT_MCP_CONFIG_JSON=#{json}"]
+
+  defp secret_to_env(%{kind: :claude_api_key, value: "sk-ant-oat" <> _ = v}) do
+    ["CLAUDE_CODE_OAUTH_TOKEN=#{v}"]
+  end
+
+  defp secret_to_env(%{kind: :claude_api_key, value: v}), do: ["ANTHROPIC_API_KEY=#{v}"]
+  defp secret_to_env(%{kind: :openai_api_key, value: v}), do: ["OPENAI_API_KEY=#{v}"]
+  defp secret_to_env(%{kind: :codex_api_key, value: v}), do: ["OPENAI_API_KEY=#{v}"]
+
+  defp secret_to_env(%{kind: kind, value: v}) when kind in [:github_pat, :github_oauth],
+    do: ["GH_TOKEN=#{v}", "GITHUB_TOKEN=#{v}"]
+
+  defp secret_to_env(%{kind: kind, value: v}) do
+    ["CAMELOT_SECRET_#{String.upcase(Atom.to_string(kind))}=#{v}"]
   end
 
   defp kick_off_streams(%__MODULE__{} = state) do
@@ -281,14 +307,16 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
     Process.put(:swarm_demux_buf, rest)
   end
 
+  # An exec inspect returns `Running: false, ExitCode: nil` between
+  # `POST /containers/<id>/exec` (which creates the exec) and
+  # `POST /exec/<id>/start` (which actually starts it). Treat that
+  # pre-start state the same as "still running" — only ExitCode as
+  # an integer means the process has actually exited.
   defp poll_exec_exit(node_req, exec_id, parent) do
     case Req.get(node_req, url: "/exec/#{exec_id}/json") do
       {:ok, %Req.Response{status: 200, body: %{"Running" => false, "ExitCode" => code}}}
       when is_integer(code) ->
         send(parent, {:exit_code, code})
-
-      {:ok, %Req.Response{status: 200, body: %{"Running" => false}}} ->
-        send(parent, {:exit_code, 1})
 
       _ ->
         Process.sleep(@exit_poll_ms)

--- a/lib/camelot/runtime/runner/swarm/exec_session.ex
+++ b/lib/camelot/runtime/runner/swarm/exec_session.ex
@@ -87,6 +87,11 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
   end
 
   @impl GenServer
+  def format_status(status) do
+    update_in(status.state.spec, &Spec.redact/1)
+  end
+
+  @impl GenServer
   def handle_info({:chunk, bytes}, %__MODULE__{} = state) do
     send(state.owner, {:runner_data, self(), bytes})
     {:noreply, state}

--- a/lib/camelot/runtime/runner/swarm/exec_session.ex
+++ b/lib/camelot/runtime/runner/swarm/exec_session.ex
@@ -24,9 +24,14 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
 
   require Logger
 
+  # Polling intervals — pure rate-limiters on the loops below.
+  # We deliberately do NOT bound these loops with a wall-clock
+  # deadline: container scheduling, image pulls on workers, and
+  # in-container clone+asdf install can each legitimately take
+  # arbitrarily long. Anything that's broken upstream surfaces
+  # as an :error from the Docker API and breaks the loop, so
+  # we never spin forever on a real failure.
   @ready_poll_ms 500
-  @ready_timeout_ms 60_000
-  @container_resolve_timeout_ms 30_000
   @exit_poll_ms 1_000
 
   defstruct [
@@ -130,11 +135,9 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
     end
   end
 
-  defp resolve_container(service_id, deadline \\ nil) do
-    deadline = deadline || System.monotonic_time(:millisecond) + @container_resolve_timeout_ms
-
+  defp resolve_container(service_id) do
     with {:ok, tasks} <- list_service_tasks(service_id) do
-      handle_pick(pick_running_task(tasks), service_id, deadline)
+      handle_pick(pick_running_task(tasks), service_id)
     end
   end
 
@@ -149,17 +152,13 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
     end
   end
 
-  defp handle_pick({:ok, container_id, node_id}, _service_id, _deadline) do
+  defp handle_pick({:ok, container_id, node_id}, _service_id) do
     {:ok, container_id, node_id}
   end
 
-  defp handle_pick(:pending, service_id, deadline) do
-    if System.monotonic_time(:millisecond) > deadline do
-      {:error, :container_resolve_timeout}
-    else
-      Process.sleep(@ready_poll_ms)
-      resolve_container(service_id, deadline)
-    end
+  defp handle_pick(:pending, service_id) do
+    Process.sleep(@ready_poll_ms)
+    resolve_container(service_id)
   end
 
   defp pick_running_task(tasks) do
@@ -179,22 +178,13 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
   end
 
   defp wait_for_ready(node_req, container_id) do
-    deadline = System.monotonic_time(:millisecond) + @ready_timeout_ms
-    do_wait_for_ready(node_req, container_id, deadline)
-  end
-
-  defp do_wait_for_ready(node_req, container_id, deadline) do
     case ready_check(node_req, container_id) do
       :ok ->
         :ok
 
       :not_ready ->
-        if System.monotonic_time(:millisecond) > deadline do
-          {:error, :ready_timeout}
-        else
-          Process.sleep(@ready_poll_ms)
-          do_wait_for_ready(node_req, container_id, deadline)
-        end
+        Process.sleep(@ready_poll_ms)
+        wait_for_ready(node_req, container_id)
 
       {:error, _} = err ->
         err

--- a/lib/camelot/runtime/runner/swarm/exec_session.ex
+++ b/lib/camelot/runtime/runner/swarm/exec_session.ex
@@ -195,7 +195,7 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
     payload = %{
       "AttachStdout" => false,
       "AttachStderr" => false,
-      "Cmd" => ["test", "-f", "/run/camelot-ready"]
+      "Cmd" => ["test", "-f", "/tmp/camelot-ready"]
     }
 
     with {:ok, %Req.Response{status: 201, body: %{"Id" => exec_id}}} <-

--- a/lib/camelot/runtime/runner/swarm/task_service.ex
+++ b/lib/camelot/runtime/runner/swarm/task_service.ex
@@ -124,7 +124,16 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
 
   @impl GenServer
   def handle_call(:get_service_id, _from, %__MODULE__{service_id: id} = state) when is_binary(id) do
-    {:reply, {:ok, id}, state}
+    if service_alive?(id) do
+      {:reply, {:ok, id}, state}
+    else
+      Logger.info("Swarm.TaskService #{state.task_id}: cached service #{id} is gone; recreating")
+
+      case create_and_persist(state.task_id, state.spec) do
+        {:ok, new_id} -> {:reply, {:ok, new_id}, %{state | service_id: new_id}}
+        {:error, reason} -> {:reply, {:error, reason}, state}
+      end
+    end
   end
 
   def handle_call(:get_service_id, _from, state) do

--- a/lib/camelot/runtime/runner/swarm/task_service.ex
+++ b/lib/camelot/runtime/runner/swarm/task_service.ex
@@ -147,6 +147,11 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
     {:stop, :normal, state}
   end
 
+  @impl GenServer
+  def format_status(status) do
+    update_in(status.state.spec, &Spec.redact/1)
+  end
+
   # --- Service lifecycle ---
 
   defp ensure_service(%__MODULE__{task_id: task_id, spec: spec}) do

--- a/lib/camelot/runtime/runner/swarm/task_service.ex
+++ b/lib/camelot/runtime/runner/swarm/task_service.ex
@@ -26,12 +26,18 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
 
   require Logger
 
-  defstruct [:task_id, :service_id, :spec]
+  defstruct task_id: nil,
+            spec: nil,
+            service_id: nil,
+            ensure_task: nil,
+            waiters: []
 
   @type state :: %__MODULE__{
           task_id: String.t(),
+          spec: Spec.t() | nil,
           service_id: String.t() | nil,
-          spec: Spec.t() | nil
+          ensure_task: Elixir.Task.t() | nil,
+          waiters: [GenServer.from()]
         }
 
   # --- Public API ---
@@ -67,20 +73,14 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
     end
   end
 
-  # Match the DockerEngine path: first call has to cover the
-  # full service-create roundtrip and any cluster-level setup
-  # latency. Swarm doesn't block on image pulls here (workers
-  # pull on schedule), but we keep the same generous ceiling
-  # to stay symmetric and survive transient slow managers.
-  @get_service_id_timeout 600_000
-
   @doc """
   Return the Swarm service id. Blocks until the service
-  is created or adopted on init.
+  is created or adopted; the GenServer parks the caller
+  while the async ensure task runs.
   """
   @spec get_service_id(pid()) :: {:ok, String.t()} | {:error, term()}
   def get_service_id(pid) do
-    GenServer.call(pid, :get_service_id, @get_service_id_timeout)
+    GenServer.call(pid, :get_service_id, :infinity)
   end
 
   @doc """
@@ -113,38 +113,25 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
   @impl GenServer
   def init(%Spec{} = spec) do
     state = %__MODULE__{task_id: spec.task_id, spec: spec}
-    {:ok, state, {:continue, :ensure_service}}
+    {:ok, kick_off_ensure(state)}
   end
 
   @impl GenServer
-  def handle_continue(:ensure_service, %__MODULE__{} = state) do
-    case ensure_service(state) do
-      {:ok, service_id} ->
-        {:noreply, %{state | service_id: service_id}}
-
-      {:error, reason} ->
-        Logger.error("Swarm.TaskService #{state.task_id}: failed to ensure service: #{inspect(reason)}")
-
-        {:stop, reason, state}
-    end
+  def handle_call(:get_service_id, from, %__MODULE__{service_id: nil} = state) do
+    # Provisioning still in flight — park the caller.
+    {:noreply, %{state | waiters: [from | state.waiters]}}
   end
 
-  @impl GenServer
-  def handle_call(:get_service_id, _from, %__MODULE__{service_id: id} = state) when is_binary(id) do
+  def handle_call(:get_service_id, from, %__MODULE__{service_id: id} = state) do
     if service_alive?(id) do
       {:reply, {:ok, id}, state}
     else
       Logger.info("Swarm.TaskService #{state.task_id}: cached service #{id} is gone; recreating")
 
-      case create_and_persist(state.task_id, state.spec) do
-        {:ok, new_id} -> {:reply, {:ok, new_id}, %{state | service_id: new_id}}
-        {:error, reason} -> {:reply, {:error, reason}, state}
-      end
-    end
-  end
+      state = kick_off_ensure(%{state | service_id: nil, waiters: [from | state.waiters]})
 
-  def handle_call(:get_service_id, _from, state) do
-    {:reply, {:error, :not_ready}, state}
+      {:noreply, state}
+    end
   end
 
   @impl GenServer
@@ -155,13 +142,40 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
   end
 
   @impl GenServer
+  def handle_info({ref, result}, %__MODULE__{ensure_task: %Elixir.Task{ref: ref}} = state) do
+    Process.demonitor(ref, [:flush])
+
+    case result do
+      {:ok, service_id} ->
+        Enum.each(state.waiters, &GenServer.reply(&1, {:ok, service_id}))
+        {:noreply, %{state | service_id: service_id, ensure_task: nil, waiters: []}}
+
+      {:error, reason} ->
+        Enum.each(state.waiters, &GenServer.reply(&1, {:error, reason}))
+        {:stop, reason, %{state | ensure_task: nil, waiters: []}}
+    end
+  end
+
+  def handle_info({:DOWN, ref, :process, _, reason}, %__MODULE__{ensure_task: %Elixir.Task{ref: ref}} = state) do
+    Enum.each(state.waiters, &GenServer.reply(&1, {:error, {:ensure_crashed, reason}}))
+    {:stop, reason, %{state | ensure_task: nil, waiters: []}}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  @impl GenServer
   def format_status(status) do
     update_in(status.state.spec, &Spec.redact/1)
   end
 
   # --- Service lifecycle ---
 
-  defp ensure_service(%__MODULE__{task_id: task_id, spec: spec}) do
+  defp kick_off_ensure(%__MODULE__{task_id: task_id, spec: spec} = state) do
+    task = Elixir.Task.async(fn -> ensure_service(task_id, spec) end)
+    %{state | ensure_task: task}
+  end
+
+  defp ensure_service(task_id, spec) do
     case load_task_handle(task_id) do
       {:ok, nil} ->
         create_and_persist(task_id, spec)

--- a/lib/camelot/runtime/runner/swarm/task_service.ex
+++ b/lib/camelot/runtime/runner/swarm/task_service.ex
@@ -67,13 +67,20 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
     end
   end
 
+  # Match the DockerEngine path: first call has to cover the
+  # full service-create roundtrip and any cluster-level setup
+  # latency. Swarm doesn't block on image pulls here (workers
+  # pull on schedule), but we keep the same generous ceiling
+  # to stay symmetric and survive transient slow managers.
+  @get_service_id_timeout 600_000
+
   @doc """
   Return the Swarm service id. Blocks until the service
   is created or adopted on init.
   """
   @spec get_service_id(pid()) :: {:ok, String.t()} | {:error, term()}
   def get_service_id(pid) do
-    GenServer.call(pid, :get_service_id, 60_000)
+    GenServer.call(pid, :get_service_id, @get_service_id_timeout)
   end
 
   @doc """

--- a/runner-images/base/exec-wrapper.sh
+++ b/runner-images/base/exec-wrapper.sh
@@ -1,14 +1,27 @@
 #!/usr/bin/env bash
 # Per-session `docker exec` invocations land here. The container's
-# entrypoint already ran materialise_secrets / merge_mcp_config /
-# clone / asdf install, and persisted the resolved env to
-# /tmp/camelot.env. We source it so the exec'd command sees the same
-# credentials and tooling the entrypoint set up.
+# entrypoint already persisted resolved env to /tmp/camelot.env at
+# boot, but those values can go stale (e.g. credential rotated via
+# the UI after the container started). Each exec from the BEAM also
+# passes the current `Env` over the Docker API, so we treat
+# /tmp/camelot.env as a fallback only — variables already set by
+# `docker exec` win.
 set -euo pipefail
 
 if [ -f /tmp/camelot.env ]; then
-  # shellcheck disable=SC1091
-  . /tmp/camelot.env
+  while IFS= read -r line; do
+    case "$line" in
+      export\ *=*) ;;
+      *) continue ;;
+    esac
+
+    var="${line#export }"
+    name="${var%%=*}"
+    # Only set if not already provided by the exec-time environment.
+    if [ -z "${!name+x}" ]; then
+      export "$var"
+    fi
+  done < /tmp/camelot.env
 fi
 
 # Ensure asdf shims are on PATH so `claude`, `codex`, etc. resolve


### PR DESCRIPTION
TaskContainer / TaskService cache the backend handle in GenServer state at init time. If the container/service is removed externally (stale row from a previous dev session, manual `docker rm`, daemon restart) the cache goes stale and every subsequent get_container_id / get_service_id returns the dead id. ExecSession then issues `POST /containers/<id>/exec` against the missing id and crashes with `{:bad_status, 404, "No such container: …"}`, which surfaces upstream as `error_message: "empty output"`, exit_code 1, no output_log — caught locally on task c69692f1-e6bd-45be-abaf-8e538e465b74.

Add a liveness probe to the `:get_container_id` / `:get_service_id` call: if the cached handle's `container_alive?` / `service_alive?` returns false, recreate the backing resource in-place and update the cached id. Init-time adoption logic is unchanged; this only covers the "fine at init, gone later" case.