### PR TITLE
fix(runner-images): make entrypoint and exec-wrapper executable

### DIFF
--- a/runner-images/base/Dockerfile
+++ b/runner-images/base/Dockerfile
@@ -69,9 +69,10 @@ RUN bash -c "asdf global nodejs ${NODEJS_VERSION}"
 RUN mkdir -p /home/agent/.config/camelot
 COPY --chown=agent:agent mcp.defaults.json /etc/camelot/mcp.defaults.json
 
-# Entrypoint + per-exec wrapper
-COPY --chown=agent:agent entrypoint.sh /entrypoint.sh
-COPY --chown=agent:agent exec-wrapper.sh /exec-wrapper.sh
+# Entrypoint + per-exec wrapper. --chmod=0755 because the git-tracked
+# mode is 100644 and `tini` exec's these directly.
+COPY --chmod=0755 --chown=agent:agent entrypoint.sh /entrypoint.sh
+COPY --chmod=0755 --chown=agent:agent exec-wrapper.sh /exec-wrapper.sh
 
 WORKDIR /workspace
 


### PR DESCRIPTION
The git-tracked file mode for `entrypoint.sh` / `exec-wrapper.sh` is 100644, so `tini -- /entrypoint.sh` was failing with `exec /entrypoint.sh: Permission denied` on every `docker run`.

`COPY --chmod=0755` is the single-line fix — no `USER root` / `chmod` / `USER agent` dance required.