### PR TITLE
feat: rename Reset Agent to Reset Task and resume work on click

### DIFF
--- a/lib/camelot/board/task.ex
+++ b/lib/camelot/board/task.ex
@@ -294,6 +294,23 @@ defmodule Camelot.Board.Task do
       change(set_attribute(:state, :queued))
     end
 
+    update :reset do
+      accept([])
+      require_atomic?(false)
+
+      validate(fn changeset, _ctx ->
+        stage = Ash.Changeset.get_attribute(changeset, :stage)
+
+        if stage in [:todo, :planning, :executing, :pr] do
+          :ok
+        else
+          {:error, field: :stage, message: "cannot reset task in stage #{inspect(stage)}"}
+        end
+      end)
+
+      change(set_attribute(:state, :queued))
+    end
+
     update :pr_created do
       accept([:pr_url, :pr_number])
 

--- a/lib/camelot_web/live/task_live.ex
+++ b/lib/camelot_web/live/task_live.ex
@@ -207,31 +207,13 @@ defmodule CamelotWeb.TaskLive do
     end
   end
 
-  def handle_event("reset_agent", _params, socket) do
+  def handle_event("reset_task", _params, socket) do
     task = socket.assigns.task
 
-    if Ash.Resource.loaded?(task, :agent) && task.agent do
-      case Ash.update(task.agent, %{}, action: :mark_idle) do
-        {:ok, _} ->
-          task =
-            Ash.load!(task, [
-              :project,
-              :agent,
-              :creator,
-              :sessions,
-              :messages
-            ])
-
-          {:noreply,
-           socket
-           |> assign(task: task)
-           |> put_flash(:info, "Agent reset to idle")}
-
-        {:error, _} ->
-          {:noreply, put_flash(socket, :error, "Failed to reset agent")}
-      end
-    else
+    if not Ash.Resource.loaded?(task, :agent) or is_nil(task.agent) do
       {:noreply, put_flash(socket, :error, "No agent assigned")}
+    else
+      reset_task_and_agent(socket, task)
     end
   end
 
@@ -255,6 +237,32 @@ defmodule CamelotWeb.TaskLive do
 
       {:error, _} ->
         {:noreply, put_flash(socket, :error, "Cannot cancel task")}
+    end
+  end
+
+  defp reset_task_and_agent(socket, task) do
+    stop_agent_process(task.agent.id)
+
+    with {:ok, _agent} <- Ash.update(task.agent, %{}, action: :mark_idle),
+         {:ok, updated} <- Ash.update(task, %{}, action: :reset) do
+      broadcast_update(updated)
+      updated = Ash.load!(updated, @task_load)
+
+      {:noreply,
+       socket
+       |> assign(task: updated)
+       |> put_flash(:info, "Task reset — work will resume shortly")}
+    else
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Failed to reset task")}
+    end
+  end
+
+  defp stop_agent_process(agent_id) do
+    case Camelot.Runtime.AgentSupervisor.stop_agent(agent_id) do
+      :ok -> :ok
+      {:error, :not_found} -> :ok
+      _ -> :ok
     end
   end
 
@@ -329,11 +337,11 @@ defmodule CamelotWeb.TaskLive do
           </button>
           <button
             :if={agent_stuck?(@task)}
-            phx-click="reset_agent"
-            data-confirm="Reset agent to idle?"
+            phx-click="reset_task"
+            data-confirm="Reset task and agent? Work will resume from this stage."
             class="btn btn-sm btn-ghost text-warning"
           >
-            Reset Agent
+            Reset Task
           </button>
           <button
             :if={@task.state == :error}

--- a/lib/camelot_web/live/task_live.ex
+++ b/lib/camelot_web/live/task_live.ex
@@ -262,7 +262,6 @@ defmodule CamelotWeb.TaskLive do
     case Camelot.Runtime.AgentSupervisor.stop_agent(agent_id) do
       :ok -> :ok
       {:error, :not_found} -> :ok
-      _ -> :ok
     end
   end
 

--- a/test/camelot/board/task_test.exs
+++ b/test/camelot/board/task_test.exs
@@ -344,6 +344,53 @@ defmodule Camelot.Board.TaskTest do
     end
   end
 
+  describe "reset" do
+    test "executing/in_progress → executing/queued", ctx do
+      {:ok, task} = create_task(ctx.project, ctx.user)
+
+      {:ok, task} =
+        Ash.update(
+          task,
+          %{agent_id: ctx.agent.id},
+          action: :begin_work
+        )
+
+      {:ok, task} =
+        Ash.update(task, %{plan: "plan"}, action: :submit_plan)
+
+      {:ok, task} = Ash.update(task, %{}, action: :approve_plan)
+
+      {:ok, task} =
+        Ash.update(
+          task,
+          %{agent_id: ctx.agent.id},
+          action: :begin_work
+        )
+
+      assert task.stage == :executing
+      assert task.state == :in_progress
+
+      assert {:ok, reset} = Ash.update(task, %{}, action: :reset)
+      assert reset.stage == :executing
+      assert reset.state == :queued
+    end
+
+    test "todo/queued stays queued", ctx do
+      {:ok, task} = create_task(ctx.project, ctx.user)
+
+      assert {:ok, reset} = Ash.update(task, %{}, action: :reset)
+      assert reset.stage == :todo
+      assert reset.state == :queued
+    end
+
+    test "rejects terminal stages", ctx do
+      {:ok, task} = create_task(ctx.project, ctx.user)
+      {:ok, done} = Ash.update(task, %{}, action: :cancel)
+
+      assert {:error, _} = Ash.update(done, %{}, action: :reset)
+    end
+  end
+
   describe "stages/0" do
     test "returns all stages" do
       stages = Task.stages()

--- a/test/camelot_web/live/task_live_test.exs
+++ b/test/camelot_web/live/task_live_test.exs
@@ -3,6 +3,7 @@ defmodule CamelotWeb.TaskLiveTest do
 
   import Phoenix.LiveViewTest
 
+  alias Camelot.Agents.Agent
   alias Camelot.Board.Task
   alias Camelot.Projects.Project
 
@@ -42,6 +43,52 @@ defmodule CamelotWeb.TaskLiveTest do
       assert view
              |> element("button", "Cancel")
              |> render_click() =~ "cancelled"
+    end
+  end
+
+  describe "reset_task" do
+    test "re-queues task and marks agent idle", %{conn: conn, project: project, user: user} do
+      {:ok, agent} =
+        Ash.create(Agent, %{
+          name: "stuck-agent",
+          template_id: agent_template!("claude_code").id,
+          project_id: project.id,
+          user_id: user.id
+        })
+
+      {:ok, task} =
+        Ash.create(Task, %{
+          title: "Stuck task",
+          project_id: project.id,
+          creator_id: user.id
+        })
+
+      {:ok, task} =
+        Ash.update(task, %{agent_id: agent.id}, action: :begin_work)
+
+      {:ok, _busy} = Ash.update(agent, %{}, action: :mark_busy)
+
+      assert task.stage == :planning
+      assert task.state == :in_progress
+
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.id}")
+
+      html =
+        view
+        |> element("button", "Reset Task")
+        |> render_click()
+
+      assert html =~ "work will resume"
+
+      {:ok, reloaded} = Ash.get(Task, task.id, load: [:agent])
+      assert reloaded.state == :queued
+      assert reloaded.stage == :planning
+      assert reloaded.agent.status == :idle
+    end
+
+    test "button is hidden when no agent is assigned", %{conn: conn, task: task} do
+      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.id}")
+      refute html =~ "Reset Task"
     end
   end
 


### PR DESCRIPTION
## Summary
- Renames the Reset Agent button on the task detail page to **Reset Task** and makes one click do the whole reset: stops the in-memory `AgentProcess`, marks the agent `:idle`, and re-queues the task via a new `Task.reset` action.
- Stage stays put (work resumes from where it stopped); state goes back to `:queued`, so the existing `Agents.Changes.DispatchTasks` Oban cron picks the task up on the next tick.
- Closes the manual-flip gap the user hit yesterday on test.camelotai.tech for task `6245fb24-…` — they had to reset the agent *and* hand-flip the card to queued for work to resume.

## Why stop the AgentProcess?
Its in-memory `current_session_id` / `current_task_id` still reference the dead session, so the next `AgentProcess.dispatch/4` from `DispatchTasks` would return `{:error, :busy}` and silently fail. `DispatchTasks.ensure_agent_process/1` re-spawns a fresh one on the next tick with clean state.

## Test plan
- [x] `mix compile --warnings-as-errors`
- [x] `mix format`
- [x] `mix credo lib/camelot/board/task.ex lib/camelot_web/live/task_live.ex`
- [x] `mix test` — 139 tests, 0 failures
- [x] New `describe "reset"` in `task_test.exs`: executing/in_progress → executing/queued; todo/queued stays queued; rejects terminal stages.
- [x] New `describe "reset_task"` in `task_live_test.exs`: click re-queues task + idles agent; button hidden when no agent assigned.
- [ ] Manual smoke on dev: stick a task at `(executing, in_progress)` with agent `:busy`, click **Reset Task**, confirm `:queued` + agent `:idle` in DB and that the next `dispatch_tasks` tick re-dispatches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)