### PR TITLE
feat: surface reason when a clean exit gets marked as task error

### DIFF
--- a/lib/camelot/agents/session.ex
+++ b/lib/camelot/agents/session.ex
@@ -218,5 +218,9 @@ defmodule Camelot.Agents.Session do
       accept([])
       change(set_attribute(:clarified, true))
     end
+
+    update :annotate_error do
+      accept([:error_message])
+    end
   end
 end

--- a/lib/camelot/runtime/agent_process.ex
+++ b/lib/camelot/runtime/agent_process.ex
@@ -562,6 +562,35 @@ defmodule Camelot.Runtime.AgentProcess do
     transition(task, :mark_error)
   end
 
+  # Variant used by paths where the CLI exited cleanly but the
+  # post-exit interpretation decided the task is in error (empty
+  # plan, no PR URL). `finish_session/4` has already written the
+  # session row with status :completed and an empty error_message;
+  # annotate it here so the UI can explain *why* the card jumped
+  # to :error instead of progressing.
+  defp mark_error_with_reason(state, task, reason) do
+    annotate_session_error(state.current_session_id, reason)
+    transition(task, :mark_error)
+  end
+
+  defp annotate_session_error(nil, _reason), do: :ok
+
+  defp annotate_session_error(session_id, reason) do
+    case Ash.get(Session, session_id) do
+      {:ok, session} ->
+        case Ash.update(session, %{error_message: reason}, action: :annotate_error) do
+          {:ok, _} ->
+            :ok
+
+          {:error, err} ->
+            Logger.warning("Failed to annotate session #{session_id} with error reason: #{inspect(err)}")
+        end
+
+      {:error, err} ->
+        Logger.warning("Failed to load session #{session_id} for error annotation: #{inspect(err)}")
+    end
+  end
+
   defp mark_session_running(session_id, runner_pid) do
     session = Ash.get!(Session, session_id)
 
@@ -609,7 +638,12 @@ defmodule Camelot.Runtime.AgentProcess do
 
       trimmed == "" ->
         Logger.warning("Empty plan for task #{task_id}, marking error")
-        transition(task, :mark_error)
+
+        mark_error_with_reason(
+          state,
+          task,
+          "Agent finished planning without producing a plan."
+        )
 
       true ->
         submit_plan(task, text, task_id)
@@ -651,7 +685,13 @@ defmodule Camelot.Runtime.AgentProcess do
       end
     else
       Logger.warning("Execution completed without PR for task #{task_id}")
-      transition(task, :mark_error)
+
+      mark_error_with_reason(
+        state,
+        task,
+        "Agent finished executing without opening a PR. " <>
+          "No PR URL was found in the agent's final output."
+      )
     end
   end
 

--- a/test/camelot/agents/session_test.exs
+++ b/test/camelot/agents/session_test.exs
@@ -131,4 +131,34 @@ defmodule Camelot.Agents.SessionTest do
       assert cancelled.finished_at
     end
   end
+
+  describe "annotate_error" do
+    test "sets error_message without changing status or finished_at", ctx do
+      {:ok, session} =
+        Ash.create(Session, %{
+          agent_id: ctx.agent.id,
+          task_id: ctx.task.id
+        })
+
+      {:ok, completed} =
+        Ash.update(
+          session,
+          %{output_log: "ok", exit_code: 0},
+          action: :complete
+        )
+
+      assert completed.error_message == nil
+
+      assert {:ok, annotated} =
+               Ash.update(
+                 completed,
+                 %{error_message: "Agent finished without opening a PR."},
+                 action: :annotate_error
+               )
+
+      assert annotated.error_message == "Agent finished without opening a PR."
+      assert annotated.status == :completed
+      assert annotated.finished_at == completed.finished_at
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Two `AgentProcess` paths can flip `Task.state = :error` after the agent exited with code 0: an empty plan in `:planning`, and no PR URL in `:executing`. Previously they only logged a `Logger.warning` and the session card showed exit 0 / no error_message, leaving the user staring at a Retry button with no explanation.
- New `Session.:annotate_error` action lets us write an `error_message` onto an already-finalised session without touching its status or `finished_at`.
- New `mark_error_with_reason/3` helper in `AgentProcess` calls the action and then runs the existing `:mark_error` transition. The two silent-error sites in `handle_task_result/5` use it; everything else is unchanged.

## Why it matters
The UI on `/tasks/:id` already renders `session.error_message` in the right-hand sessions panel — populating it is enough to surface the reason without any HEEx changes. This was the gap the user hit on task `6245fb24-…` where the agent finished its turn saying "still compiling, I'll wait for the notification" and Camelot silently jumped the card to error.

## Test plan
- [x] `mix compile --warnings-as-errors`
- [x] `mix format`
- [x] `mix credo lib/camelot/agents/session.ex lib/camelot/runtime/agent_process.ex`
- [x] `mix test` — 135 tests, 0 failures
- [x] New test on `Session.:annotate_error` confirms it updates `error_message` without changing `status` or `finished_at`.
- [ ] Manual: trigger a no-PR completion locally, verify the session card on `/tasks/<id>` shows "Agent finished executing without opening a PR…".

## Follow-ups not in this PR
- A top-of-page banner that lifts the latest session's error_message above the Sessions panel (lower priority — the panel already shows it inline).
- Same treatment for the third `transition(_, :mark_error)` site I noticed (`mark_task_error/1` at agent_process.ex:558) — that one already gets a reason via the prior `finish_session/4` call when `parsed == {:error, msg}`, so it's only silent if the parser returned `:ok` but the runner exited non-zero. Out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)