### PR TITLE
fix: make server-generated SSH keys actually work in runners

### DIFF
--- a/lib/camelot/accounts/credential.ex
+++ b/lib/camelot/accounts/credential.ex
@@ -55,6 +55,10 @@ defmodule Camelot.Accounts.Credential do
       allow_nil?(false)
       public?(true)
       sensitive?(true)
+      # Secrets are opaque — Ash's default trim?: true silently dropped
+      # the trailing newline from OpenSSH private keys, leaving us with
+      # files OpenSSH would reject as "invalid format".
+      constraints(trim?: false, allow_empty?: false)
       description("Secret value, encrypted at rest via AshCloak")
     end
 

--- a/runner-images/base/entrypoint.sh
+++ b/runner-images/base/entrypoint.sh
@@ -50,15 +50,19 @@ materialise_secrets() {
 
   # Generic CAMELOT_SECRET_* env var fallback for kinds without a
   # natural canonical env var (claude_oauth, ssh_private_key, generic).
-  local var name kind value
-  while IFS='=' read -r var value; do
+  #
+  # Iterate variable NAMES via compgen and look up values with bash
+  # indirect expansion — `env | while read` would split multi-line
+  # values (e.g. OpenSSH private keys) at the first newline.
+  local var kind
+  while IFS= read -r var; do
     case "$var" in
       CAMELOT_SECRET_*)
         kind="$(printf '%s' "${var#CAMELOT_SECRET_}" | tr '[:upper:]' '[:lower:]')"
-        materialise_one "$kind" "$value"
+        materialise_one "$kind" "${!var}"
         ;;
     esac
-  done < <(env)
+  done < <(compgen -e)
 }
 
 materialise_one() {

--- a/test/camelot/accounts/credential_test.exs
+++ b/test/camelot/accounts/credential_test.exs
@@ -3,6 +3,36 @@ defmodule Camelot.Accounts.CredentialTest do
 
   alias Camelot.Accounts.Credential
 
+  require Ash.Query
+
+  describe ":value attribute" do
+    test "preserves trailing whitespace verbatim across create + read" do
+      # OpenSSH private keys end in `\n`; Ash's default trim?: true on
+      # :string silently strips it and the resulting file is rejected
+      # by OpenSSH as "invalid format". This guards against regression.
+      user = user!()
+
+      value = "-----BEGIN OPENSSH PRIVATE KEY-----\nb64data==\n-----END OPENSSH PRIVATE KEY-----\n"
+
+      {:ok, cred} =
+        Ash.create(Credential, %{
+          user_id: user.id,
+          kind: :ssh_private_key,
+          name: "default",
+          value: value
+        })
+
+      {:ok, reloaded} =
+        Credential
+        |> Ash.Query.filter(id == ^cred.id)
+        |> Ash.Query.load(:value)
+        |> Ash.read_one()
+
+      assert reloaded.value == value
+      assert String.ends_with?(reloaded.value, "\n")
+    end
+  end
+
   describe ":rotate action" do
     test "replaces value, stamps rotated_at, preserves untouched metadata" do
       user = user!()


### PR DESCRIPTION
Follow-up to #24. The feature shipped but git clone via SSH still failed for users with a server-generated key — two stacked bugs swallowed the trailing newline of the private key and truncated the multi-line value before it reached `~/.ssh/id_ed25519`. OpenSSH rejected the resulting file with `Load key: error in libcrypto` → `Permission denied (publickey)`.

## Summary

- **`Credential.value` trimmed by Ash's default `:string` type.** `Ash.Type.String` defaults `trim?: true`. The OpenSSH v1 private-key format ends in `\n`; that newline was silently dropped between `Ash.create(value: priv)` and the AshCloak encrypt before-action. Set `constraints(trim?: false, allow_empty?: false)` so secrets pass through opaque.
- **Runner entrypoint truncated multi-line env vars.** `env | while IFS='=' read -r var value` reads one line at a time, so a multi-line `CAMELOT_SECRET_SSH_PRIVATE_KEY` only delivered its `-----BEGIN OPENSSH PRIVATE KEY-----` header to `materialise_one`. Iterate variable **names** via `compgen -e` and look up values with bash indirect expansion (`${!var}`) — preserves newlines.
- New regression test creates a Credential with a value ending in `\n` and asserts byte-exact round-trip through `Ash.read`.

## Test plan

- [x] `mix test` — 163 tests, 0 failures
- [x] `mix format --check-formatted`, `mix credo --strict`, `mix dialyzer` — clean for new code
- [x] Manually rotated the affected user's key and confirmed `ssh-keygen -y` accepts it
- [x] `docker run camelot/runner-elixir:dev` with the stored SSH key as `CAMELOT_SECRET_SSH_PRIVATE_KEY` — `~/.ssh/id_ed25519` lands at 444 bytes (matches DB), `ssh-keygen -y` succeeds
- [ ] Retry the failing task in the dev app — `git clone git@github.com:…` should succeed
- [ ] Note: runner images need a rebuild (already done locally for `:dev` tag; CI/registry image still needs publishing for prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)