### PR TITLE
fix(secret-sync): keep ssh_private_key Swarm name under 64-char limit

### DIFF
--- a/lib/camelot/runtime/secret_sync.ex
+++ b/lib/camelot/runtime/secret_sync.ex
@@ -42,9 +42,19 @@ defmodule Camelot.Runtime.SecretSync do
   @doc """
   Returns the Swarm secret name for a given user and
   kind. Used by the Runner spec builder.
+
+  Docker caps secret names at 64 chars. `camelot_user_<uuid>_` is
+  already 49, leaving 15 chars for the kind suffix — `ssh_private_key`
+  itself is 15, but adding the underscore separator pushes us to 65.
+  Map long kind atoms to short suffixes here; everything outside this
+  module (kind atom, mounted file name in `/run/secrets/`, entrypoint
+  case) is unaffected.
   """
   @spec secret_name(String.t(), atom()) :: String.t()
-  def secret_name(user_id, kind), do: "camelot_user_#{user_id}_#{kind}"
+  def secret_name(user_id, kind), do: "camelot_user_#{user_id}_#{kind_suffix(kind)}"
+
+  defp kind_suffix(:ssh_private_key), do: "ssh_pk"
+  defp kind_suffix(kind), do: Atom.to_string(kind)
 
   @doc """
   Looks up the current secret id for `(user_id, kind)`.


### PR DESCRIPTION
## Summary

- `camelot_user_<uuid>_ssh_private_key` is 65 chars; Docker rejects any secret name over 64. The reconcile error was logged once at boot and never retried, so every user registered since #24 has been silently running runners without an SSH key mounted — `git clone git@github.com:…` fails with `Host key verification failed.`
- Map the long kind atom to a short Swarm-name suffix (`ssh_pk`) inside `SecretSync.secret_name/2`. Kind atom (`:ssh_private_key`), DB enum, mounted file path (`/run/secrets/ssh_private_key`), and the entrypoint case all stay exactly as they were — only the Swarm-level secret name (what Docker validates) changes.
- Length after fix: `camelot_user_<36>_ssh_pk` = 56 chars, comfortable headroom for any future kind name up to 14 chars.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix test test/camelot/runtime/agent_process_test.exs test/camelot/accounts/credential_test.exs test/camelot/accounts/user/changes/ensure_default_ssh_key_test.exs` — 16 tests, 0 failures
- [ ] Deploy to test.camelotai.tech; confirm bootstrap reconcile creates `camelot_user_<uuid>_ssh_pk` secret for the user that's been blocked
- [ ] Re-dispatch a task and confirm the runner clones the repo successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)