### PR TITLE
fix(runner-image): ensure SSH private key file ends with a newline

### DIFF
--- a/runner-images/base/entrypoint.sh
+++ b/runner-images/base/entrypoint.sh
@@ -94,7 +94,11 @@ materialise_one() {
       ;;
     ssh_private_key)
       mkdir -p "$HOME/.ssh"
-      printf '%s' "$value" > "$HOME/.ssh/id_ed25519"
+      # OpenSSH requires the PEM file to end with a newline; reject as
+      # "invalid format" / "error in libcrypto" otherwise. Strip a
+      # trailing newline if the source already has one, then re-add
+      # exactly one — idempotent across sources that do and don't.
+      printf '%s\n' "${value%$'\n'}" > "$HOME/.ssh/id_ed25519"
       chmod 600 "$HOME/.ssh/id_ed25519"
       ssh-keyscan -t ed25519 github.com >> "$HOME/.ssh/known_hosts" 2>/dev/null || true
       ;;


### PR DESCRIPTION
## Summary

- OpenSSH/libcrypto rejects a private-key file that doesn't end with `\n` — "invalid format" (macOS) or "error in libcrypto" (Alpine/Linux), followed by `Permission denied (publickey)` on `git clone`. Repro'd against the exact bytes of an affected production credential.
- The `trim?: false` fix on `Credential.value` (#24 / 159d04a) only prevents future stripping. Credentials persisted before it shipped (e.g. the user `e7860782-…` whose key was generated 2026-06-18 — one day before the fix) are permanently missing the trailing newline; the ciphertext can't be patched in place. The Swarm secret is written from the trimmed value, mounted byte-for-byte into the runner, and `printf '%s'` passes it through unchanged.
- Make the entrypoint robust either way: strip a trailing `\n` if the source has one (`${value%$'\n'}`), then re-add exactly one (`printf '%s\n'`). Idempotent for sources that do and don't already terminate with a newline; also protects future user-pasted keys.

## Test plan

- [x] Verified `printf '%s\n' "${v%$'\n'}"` produces byte-identical output for `hello` and `hello\n` (od -c)
- [x] Confirmed the affected production credential loads cleanly with a trailing newline added: `ssh-keygen -y -f` returns the matching `ssh-ed25519` public key
- [ ] Merge → runner-images workflow rebuilds `ghcr.io/t0ha/camelot-runner-elixir` (triggers on `runner-images/**` push)
- [ ] Re-dispatch the stuck task and confirm the runner clones the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)