### PR TITLE
fix(swarm): self-heal stale services + handle 409 on recreate

### DIFF
--- a/lib/camelot/runtime/reconciler.ex
+++ b/lib/camelot/runtime/reconciler.ex
@@ -20,12 +20,18 @@ defmodule Camelot.Runtime.Reconciler do
     3. Sweeps orphan `camelot-runner-*` services that no
        longer have a `:queued` or `:running` session row.
     4. Sweeps tasks whose `runner_handle` points to a
-       missing backend service (node loss, manual
-       `docker service rm`) — marks them as
-       `state: :error` and clears `runner_handle` so the
-       user can retry. A 15-minute grace on
-       `updated_at` keeps in-flight dispatches from
-       being false-positives.
+       stale backend service (node partition, manual
+       `docker service rm`, swarm reschedule failure).
+       For Swarm services that still exist but have zero
+       runnable tasks, triggers a `force-redeploy` (bumps
+       `Spec.TaskTemplate.ForceUpdate`) so the swarm
+       reschedules without losing the service identity.
+       Only after the redeploy fails to yield a runnable
+       task within `@redeploy_wait_ms`, or when the service
+       is genuinely 404, the task is marked
+       `state: :error` and `runner_handle` cleared so the
+       user can retry. A 15-minute grace on `updated_at`
+       keeps in-flight dispatches from being false-positives.
 
   In steady state, the same sweep runs every 60s to
   catch any drift Camelot didn't notice (manual
@@ -48,6 +54,8 @@ defmodule Camelot.Runtime.Reconciler do
   @tick_ms 60_000
   @log_retention_ms 300_000
   @stale_runner_grace_ms 900_000
+  @redeploy_wait_ms 15_000
+  @redeploy_poll_ms 1_000
   @name __MODULE__
 
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -297,19 +305,68 @@ defmodule Camelot.Runtime.Reconciler do
 
   defp maybe_mark_runner_lost(%Task{} = task) do
     case probe_runner(task.runner_handle) do
-      :missing ->
-        Logger.warning(
-          "Reconciler: task #{task.id} runner_handle " <>
-            "#{task.runner_handle} is gone; marking task as " <>
-            "error and clearing runner_handle"
-        )
+      :present -> :ok
+      :gone -> mark_runner_lost(task, "service returned 404")
+      :no_tasks -> attempt_force_redeploy(task)
+      :unknown -> :ok
+    end
+  end
 
-        updated = Ash.update!(task, %{}, action: :mark_runner_lost)
-        broadcast_task_update(updated)
+  defp attempt_force_redeploy(%Task{} = task) do
+    Logger.info(
+      "Reconciler: task #{task.id} service #{task.runner_handle} " <>
+        "has zero runnable tasks; attempting force-redeploy"
+    )
+
+    case Swarm.TaskService.force_redeploy(task.runner_handle) do
+      :ok ->
+        if wait_for_runnable(task.runner_handle, @redeploy_wait_ms) do
+          Logger.info(
+            "Reconciler: task #{task.id} service #{task.runner_handle} " <>
+              "rescheduled by force-redeploy"
+          )
+        else
+          mark_runner_lost(
+            task,
+            "force-redeploy did not yield a runnable task within " <>
+              "#{@redeploy_wait_ms}ms (constraint likely unsatisfiable)"
+          )
+        end
+
+      {:error, :not_found} ->
+        mark_runner_lost(task, "service returned 404 to force-redeploy")
+
+      {:error, reason} ->
+        Logger.warning(
+          "Reconciler: force-redeploy failed for task #{task.id}: " <>
+            "#{inspect(reason)}; will retry next tick"
+        )
+    end
+  end
+
+  defp wait_for_runnable(_service_id, remaining_ms) when remaining_ms <= 0, do: false
+
+  defp wait_for_runnable(service_id, remaining_ms) do
+    case list_runnable_swarm_tasks(service_id) do
+      {:ok, [_ | _]} ->
+        true
 
       _ ->
-        :ok
+        step = min(@redeploy_poll_ms, remaining_ms)
+        Process.sleep(step)
+        wait_for_runnable(service_id, remaining_ms - step)
     end
+  end
+
+  defp mark_runner_lost(%Task{} = task, reason) do
+    Logger.warning(
+      "Reconciler: task #{task.id} runner_handle " <>
+        "#{task.runner_handle} treated as lost (#{reason}); " <>
+        "marking task as error and clearing runner_handle"
+    )
+
+    updated = Ash.update!(task, %{}, action: :mark_runner_lost)
+    broadcast_task_update(updated)
   end
 
   defp broadcast_task_update(%Task{id: id} = task) do
@@ -334,20 +391,25 @@ defmodule Camelot.Runtime.Reconciler do
     end
   end
 
-  # Mirror `Swarm.TaskService.service_alive?/1`: a service whose
-  # only replica got SIGKILLed (or whose node died) still answers
-  # 200 here but has zero tasks with `desired-state=running`, and
-  # the name slot is occupied so any recreate hits 409. Treat that
-  # corpse as :missing so the task gets surfaced to the user.
+  # Distinguish the recoverable case (service still exists in the
+  # swarm catalog but has zero runnable tasks — fixable with
+  # force-redeploy) from the terminal case (service truly gone),
+  # so the orphan sweep can self-heal transient node partitions
+  # before falling back to marking the task as error.
   defp probe_swarm_service(id) do
-    with {:ok, %Req.Response{status: 200}} <-
-           Req.get(DockerApi.request(), url: "/services/#{id}"),
-         {:ok, [_ | _]} <- list_runnable_swarm_tasks(id) do
-      :present
-    else
-      {:ok, %Req.Response{status: 404}} -> :missing
-      {:ok, []} -> :missing
-      _ -> :unknown
+    case Req.get(DockerApi.request(), url: "/services/#{id}") do
+      {:ok, %Req.Response{status: 200}} ->
+        case list_runnable_swarm_tasks(id) do
+          {:ok, [_ | _]} -> :present
+          {:ok, []} -> :no_tasks
+          _ -> :unknown
+        end
+
+      {:ok, %Req.Response{status: 404}} ->
+        :gone
+
+      _ ->
+        :unknown
     end
   rescue
     _ -> :unknown
@@ -371,7 +433,7 @@ defmodule Camelot.Runtime.Reconciler do
   defp probe_engine_container(id) do
     case Req.get(DockerApi.request(), url: "/containers/#{id}/json") do
       {:ok, %Req.Response{status: 200}} -> :present
-      {:ok, %Req.Response{status: 404}} -> :missing
+      {:ok, %Req.Response{status: 404}} -> :gone
       _ -> :unknown
     end
   rescue

--- a/lib/camelot/runtime/reconciler.ex
+++ b/lib/camelot/runtime/reconciler.ex
@@ -334,14 +334,38 @@ defmodule Camelot.Runtime.Reconciler do
     end
   end
 
+  # Mirror `Swarm.TaskService.service_alive?/1`: a service whose
+  # only replica got SIGKILLed (or whose node died) still answers
+  # 200 here but has zero tasks with `desired-state=running`, and
+  # the name slot is occupied so any recreate hits 409. Treat that
+  # corpse as :missing so the task gets surfaced to the user.
   defp probe_swarm_service(id) do
-    case Req.get(DockerApi.request(), url: "/services/#{id}") do
-      {:ok, %Req.Response{status: 200}} -> :present
+    with {:ok, %Req.Response{status: 200}} <-
+           Req.get(DockerApi.request(), url: "/services/#{id}"),
+         {:ok, [_ | _]} <- list_runnable_swarm_tasks(id) do
+      :present
+    else
       {:ok, %Req.Response{status: 404}} -> :missing
+      {:ok, []} -> :missing
       _ -> :unknown
     end
   rescue
     _ -> :unknown
+  end
+
+  defp list_runnable_swarm_tasks(service_id) do
+    case Req.get(DockerApi.request(),
+           url: "/tasks",
+           params: [
+             filters: ~s({"service":["#{service_id}"],"desired-state":["running"]})
+           ]
+         ) do
+      {:ok, %Req.Response{status: 200, body: tasks}} when is_list(tasks) ->
+        {:ok, tasks}
+
+      _ ->
+        :error
+    end
   end
 
   defp probe_engine_container(id) do

--- a/lib/camelot/runtime/runner/swarm/task_service.ex
+++ b/lib/camelot/runtime/runner/swarm/task_service.ex
@@ -97,6 +97,27 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
     :ok
   end
 
+  @doc """
+  Force swarm to redeploy the service's tasks without
+  deleting the service. Used to recover a service that
+  sits at `0/N` replicas after a transient node partition:
+  bumps `Spec.TaskTemplate.ForceUpdate` and POSTs the
+  current spec back, which makes swarm schedule a fresh
+  replica on whatever node matches the constraints.
+
+  Returns `{:error, :not_found}` if the service is genuinely
+  gone (caller should recreate), or `{:error, reason}` on
+  any other Docker API error.
+  """
+  @spec force_redeploy(String.t()) ::
+          :ok | {:error, :not_found} | {:error, term()}
+  def force_redeploy(service_id) when is_binary(service_id) do
+    with {:ok, %{"Version" => %{"Index" => version}, "Spec" => spec}} <-
+           fetch_service(service_id) do
+      post_service_update(service_id, version, bump_force_update(spec))
+    end
+  end
+
   # --- GenServer plumbing ---
 
   @doc false
@@ -273,6 +294,34 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
     :ok
   rescue
     _ -> :ok
+  end
+
+  defp fetch_service(id) do
+    case Req.get(DockerApi.request(), url: "/services/#{id}") do
+      {:ok, %Req.Response{status: 200, body: body}} -> {:ok, body}
+      {:ok, %Req.Response{status: 404}} -> {:error, :not_found}
+      {:ok, resp} -> {:error, {:fetch_failed, resp.status, resp.body}}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp bump_force_update(spec) do
+    template = Map.get(spec, "TaskTemplate", %{})
+    current = Map.get(template, "ForceUpdate", 0)
+    Map.put(spec, "TaskTemplate", Map.put(template, "ForceUpdate", current + 1))
+  end
+
+  defp post_service_update(id, version, spec) do
+    case Req.post(DockerApi.request(),
+           url: "/services/#{id}/update",
+           params: [version: version],
+           json: spec
+         ) do
+      {:ok, %Req.Response{status: status}} when status in 200..299 -> :ok
+      {:ok, %Req.Response{status: 404}} -> {:error, :not_found}
+      {:ok, resp} -> {:error, {:update_failed, resp.status, resp.body}}
+      {:error, _} = err -> err
+    end
   end
 
   # The service object alone isn't enough — a Swarm service whose

--- a/lib/camelot/runtime/runner/swarm/task_service.ex
+++ b/lib/camelot/runtime/runner/swarm/task_service.ex
@@ -219,10 +219,33 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
     name = Spec.task_runner_name(task_id)
     payload = service_create_payload(spec, name)
 
+    case post_create(payload) do
+      {:ok, id} ->
+        {:ok, id}
+
+      {:error, :name_conflict} ->
+        Logger.info(
+          "Swarm.TaskService #{task_id}: service name " <>
+            "#{name} already exists; deleting stale " <>
+            "service and retrying create"
+        )
+
+        delete_service_by_name(name)
+        post_create_strict(payload)
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  defp post_create(payload) do
     case Req.post(DockerApi.request(), url: "/services/create", json: payload) do
       {:ok, %Req.Response{status: status, body: %{"ID" => id}}}
       when status in 200..299 ->
         {:ok, id}
+
+      {:ok, %Req.Response{status: 409}} ->
+        {:error, :name_conflict}
 
       {:ok, resp} ->
         {:error, {:create_failed, resp.status, resp.body}}
@@ -230,6 +253,26 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  defp post_create_strict(payload) do
+    case post_create(payload) do
+      {:ok, id} ->
+        {:ok, id}
+
+      {:error, :name_conflict} ->
+        {:error, {:create_failed, 409, %{"message" => "service name still conflicts after delete-by-name retry"}}}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  defp delete_service_by_name(name) do
+    Req.delete(DockerApi.request(), url: "/services/#{name}")
+    :ok
+  rescue
+    _ -> :ok
   end
 
   # The service object alone isn't enough — a Swarm service whose


### PR DESCRIPTION
## Summary

Follow-up to #28 — two commits that didn't make the merge window. Together they let the reconciler recover from the failure mode diagnosed yesterday (transient swarm-overlay partition on \`instance-camelotai-02\`) without any user intervention.

### \`fix(swarm): break the 409-AlreadyExists recreate loop\`

When a node partitions and rejoins, the worker's task is marked \`Shutdown\` by the manager but the parent service stays in the catalog at \`0/N\` replicas. \`TaskService.service_alive?/1\` treats that corpse as not alive, so the next dispatch hits \`create_and_persist/2\` → \`POST /services/create\` with the same name → **409 AlreadyExists**, which propagates as \`:create_failed\` and \`AgentProcess\` flips the task to \`:error\`. User reset just lands back in the same 60 s loop.

- \`TaskService.create_service/2\` now treats 409 as a stale-name signal: \`DELETE /services/{name}\` then POST once more. A second 409 still surfaces as \`:create_failed\` so a genuinely contested name doesn't silently masquerade as success.
- \`Reconciler.probe_swarm_service/1\` updated to require both 200 *and* ≥1 task with \`desired-state=running\` (mirrors \`service_alive?/1\`) so the dead-but-cataloged service we hit on test.camelotai.tech is now correctly classified.

### \`fix(reconciler): force-redeploy stale swarm services before erroring\`

The cleaner recovery is \`docker service update --force\` — bumps \`Spec.TaskTemplate.ForceUpdate\` on the existing service and POSTs the spec back, which makes swarm schedule a fresh replica without changing the service identity. No DB churn, no name window, no user reset.

- New \`Swarm.TaskService.force_redeploy/1\`: \`GET /services/<id>\` → bump \`ForceUpdate\` → \`POST /services/<id>/update?version=<index>\`. Returns \`{:error, :not_found}\` for genuine 404 so the caller can fall back.
- Reconciler probe is now three-state: \`:present | :no_tasks | :gone | :unknown\`.
  - \`:present\` → leave alone.
  - \`:no_tasks\` → \`force_redeploy/1\` and poll \`list_runnable_swarm_tasks/1\` for up to 15 s. If a task appears, recovery is silent. If not (constraint genuinely unsatisfiable), fall through to \`:mark_runner_lost\`.
  - \`:gone\` → \`mark_runner_lost\` (clears handle; the 409-safe \`create_service\` recreates on next dispatch).
  - \`:unknown\` → leave alone, retry next tick.

For the kind of ~3 min partition we diagnosed yesterday, the very next 60 s reconciler tick now silently reschedules the runner — task stays \`:in_progress\`, \`runner_handle\` unchanged, user sees nothing. Only when the pinned node really doesn't come back does the task surface as \`:error\`.

## Test plan
- [x] \`mix compile --warnings-as-errors\`
- [x] \`mix credo --strict\` on the two changed files
- [x] \`mix test test/camelot/board test/camelot/runtime\` — 62 tests, 0 failures
- [ ] After deploy, simulate a partition: \`docker service update --replicas 0\` then \`--replicas 1\` on a task runner — confirm reconciler's force-redeploy path keeps the task \`:in_progress\`.
- [ ] Confirm a manual \`docker service rm camelot-task-<id>\` flips the task to \`:error\` via the \`:gone\` branch, and a subsequent reset creates a fresh service via the 409-safe path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)