### PR TITLE
fix(swarm): route exec by DesiredState, not stale running status

### DIFF
--- a/lib/camelot/runtime/agent_process.ex
+++ b/lib/camelot/runtime/agent_process.ex
@@ -253,42 +253,23 @@ defmodule Camelot.Runtime.AgentProcess do
 
   def handle_info({:runner_exit, handle, exit_code}, %{runner: handle} = state) do
     Logger.info("Agent #{state.agent_id} runner exited with code #{exit_code}")
-
-    parsed = OutputParser.parse(parser_for(state), state.output_buffer)
-    denials = extract_denials(parsed)
-    finish_session(state, exit_code, parsed, denials)
-    if state.current_session_id, do: SessionRegistry.unregister(state.current_session_id)
-
-    failed? = exit_code != 0 or match?({:error, _}, parsed)
-
-    if failed? and state.retry_count < state.max_retries do
-      release_pool_slot(state)
-      schedule_retry(state)
-    else
-      handle_cli_exit(state, exit_code, parsed)
-      if failed?, do: mark_task_error(state.current_task_id)
-      release_and_idle(state)
-
-      if denials == [] do
-        {:noreply, reset_runner(state)}
-      else
-        {:noreply, clear_runner(state)}
-      end
-    end
+    finalize_runner_exit(state, exit_code, nil)
   end
 
   # Runner GenServer died without sending us :runner_exit (e.g. a
-  # linked Task inside the runner crashed). Treat it as an exit-1
-  # so we finalise the session and clean up state — otherwise the
-  # AgentProcess sits forever pinned to a dead runner pid.
+  # linked Task inside the runner crashed, or the exec never
+  # started because the node proxy was unreachable). Finalise as
+  # exit-1 so we clean up — otherwise the AgentProcess sits forever
+  # pinned to a dead runner pid. The death `reason` is threaded
+  # through so the session records it instead of the misleading
+  # "empty output" the parser would infer from an empty buffer.
   def handle_info({:DOWN, _ref, :process, pid, reason}, %{runner: pid} = state) do
     Logger.warning(
       "Agent #{state.agent_id} runner #{inspect(pid)} died without " <>
         "sending exit: #{inspect(reason)}"
     )
 
-    send(self(), {:runner_exit, pid, 1})
-    {:noreply, state}
+    finalize_runner_exit(state, 1, reason)
   end
 
   def handle_info({:DOWN, _, _, _, _}, state), do: {:noreply, state}
@@ -313,6 +294,48 @@ defmodule Camelot.Runtime.AgentProcess do
   def handle_info(_msg, state), do: {:noreply, state}
 
   # --- Internals ---
+
+  # Shared finalisation for a runner leaving. A clean exit passes
+  # `died_reason: nil` and the result is parsed from the captured
+  # output buffer; an abnormal death passes the exit `reason`, whose
+  # message is recorded directly (the buffer is meaningless there).
+  defp finalize_runner_exit(state, exit_code, died_reason) do
+    parsed = parsed_for_exit(state, died_reason)
+    denials = extract_denials(parsed)
+    finish_session(state, exit_code, parsed, denials)
+    if state.current_session_id, do: SessionRegistry.unregister(state.current_session_id)
+
+    failed? = exit_code != 0 or match?({:error, _}, parsed)
+
+    if failed? and state.retry_count < state.max_retries do
+      release_pool_slot(state)
+      schedule_retry(state)
+    else
+      handle_cli_exit(state, exit_code, parsed)
+      if failed?, do: mark_task_error(state.current_task_id)
+      release_and_idle(state)
+
+      if denials == [] do
+        {:noreply, reset_runner(state)}
+      else
+        {:noreply, clear_runner(state)}
+      end
+    end
+  end
+
+  defp parsed_for_exit(state, nil) do
+    OutputParser.parse(parser_for(state), state.output_buffer)
+  end
+
+  defp parsed_for_exit(_state, reason) do
+    {:error, runner_died_message(reason)}
+  end
+
+  @doc false
+  @spec runner_died_message(term()) :: String.t()
+  def runner_died_message(reason) do
+    "runner exited before producing output (#{inspect(reason)})"
+  end
 
   defp parser_for(%__MODULE__{config: %AgentConfig{parser: p}}), do: p
   defp parser_for(_), do: :raw_text

--- a/lib/camelot/runtime/runner/swarm/exec_session.ex
+++ b/lib/camelot/runtime/runner/swarm/exec_session.ex
@@ -177,14 +177,30 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
     resolve_container(service_id, transport_budget_ms)
   end
 
-  defp pick_running_task(tasks) do
+  @doc """
+  Selects the container id + node id of the service's live
+  placement from a Docker `GET /tasks` list, or `:pending`
+  when no such task exists yet (the caller polls).
+
+  A task qualifies only when it is BOTH `DesiredState` and
+  `Status.State` `"running"`. Filtering on `DesiredState` is
+  essential: Swarm keeps historical task records, and a
+  shut-down replica on an unreachable or memory-starved node
+  can linger in `Status.State == "running"` long after a
+  reschedule created a new replica elsewhere. Selecting that
+  orphaned task would route every exec at a dead node until
+  the transport budget expires.
+  """
+  @spec pick_running_task([map()]) :: {:ok, String.t(), String.t()} | :pending
+  def pick_running_task(tasks) do
     Enum.find_value(tasks, :pending, fn task ->
+      desired = task["DesiredState"]
       state = get_in(task, ["Status", "State"])
       cid = get_in(task, ["Status", "ContainerStatus", "ContainerID"])
       node = task["NodeID"]
 
-      case {state, cid, node} do
-        {"running", cid, node} when is_binary(cid) and is_binary(node) ->
+      case {desired, state, cid, node} do
+        {"running", "running", cid, node} when is_binary(cid) and is_binary(node) ->
           {:ok, cid, node}
 
         _ ->

--- a/lib/camelot/runtime/runner/swarm/proxy_router.ex
+++ b/lib/camelot/runtime/runner/swarm/proxy_router.ex
@@ -77,10 +77,7 @@ defmodule Camelot.Runtime.Runner.Swarm.ProxyRouter do
 
     case Req.get(DockerApi.request(), url: "/tasks", params: [filters: filters]) do
       {:ok, %Req.Response{status: 200, body: tasks}} when is_list(tasks) ->
-        tasks
-        |> Enum.find(&match_running_on_node?(&1, node_id))
-        |> extract_overlay_ip()
-        |> case do
+        case proxy_ip_for_node(tasks, node_id) do
           nil ->
             Logger.warning("ProxyRouter: no proxy task on node #{node_id}")
             {:error, :no_proxy_on_node}
@@ -97,8 +94,25 @@ defmodule Camelot.Runtime.Runner.Swarm.ProxyRouter do
     end
   end
 
+  @doc """
+  Picks the overlay IP of the *desired-running* proxy task on
+  `node_id` from a Docker `GET /tasks` list, or `nil`.
+
+  Requires `DesiredState == "running"` so a rescheduled proxy's
+  orphaned old task — which can linger in `Status.State ==
+  "running"` advertising a stale overlay IP — is never chosen.
+  Routing to that IP would produce endless transport errors.
+  """
+  @spec proxy_ip_for_node([map()], String.t()) :: String.t() | nil
+  def proxy_ip_for_node(tasks, node_id) do
+    tasks
+    |> Enum.find(&match_running_on_node?(&1, node_id))
+    |> extract_overlay_ip()
+  end
+
   defp match_running_on_node?(task, node_id) do
     task["NodeID"] == node_id and
+      task["DesiredState"] == "running" and
       get_in(task, ["Status", "State"]) == "running"
   end
 

--- a/test/camelot/runtime/agent_process_test.exs
+++ b/test/camelot/runtime/agent_process_test.exs
@@ -172,4 +172,14 @@ defmodule Camelot.Runtime.AgentProcessTest do
                )
     end
   end
+
+  describe "runner_died_message/1" do
+    test "surfaces the transport reason instead of an empty-output guess" do
+      reason = %Req.TransportError{reason: :ehostunreach}
+      msg = AgentProcess.runner_died_message(reason)
+
+      assert msg =~ "runner exited before producing output"
+      assert msg =~ "ehostunreach"
+    end
+  end
 end

--- a/test/camelot/runtime/runner/swarm/exec_session_test.exs
+++ b/test/camelot/runtime/runner/swarm/exec_session_test.exs
@@ -1,0 +1,59 @@
+defmodule Camelot.Runtime.Runner.Swarm.ExecSessionTest do
+  use ExUnit.Case, async: true
+
+  alias Camelot.Runtime.Runner.Swarm.ExecSession
+
+  # Docker `GET /tasks` task shape, trimmed to the fields the
+  # picker reads.
+  defp task(desired, status, opts \\ []) do
+    %{
+      "DesiredState" => desired,
+      "NodeID" => Keyword.get(opts, :node, "node-a"),
+      "Status" => %{
+        "State" => status,
+        "ContainerStatus" => %{
+          "ContainerID" => Keyword.get(opts, :cid, "container-a")
+        }
+      }
+    }
+  end
+
+  describe "pick_running_task/1" do
+    test "picks the desired-running, status-running placement" do
+      tasks = [task("running", "running", node: "node-live", cid: "cid-live")]
+
+      assert ExecSession.pick_running_task(tasks) ==
+               {:ok, "cid-live", "node-live"}
+    end
+
+    test "ignores an orphaned replica still reporting status running" do
+      # The regression: a shut-down replica on an unreachable node
+      # lingers in Status.State == "running" and is listed first.
+      # The live placement must still be chosen.
+      orphan = task("shutdown", "running", node: "node-dead", cid: "cid-dead")
+      live = task("running", "running", node: "node-live", cid: "cid-live")
+
+      assert ExecSession.pick_running_task([orphan, live]) ==
+               {:ok, "cid-live", "node-live"}
+    end
+
+    test "is :pending when the only task is desired-shutdown" do
+      assert ExecSession.pick_running_task([task("shutdown", "running")]) ==
+               :pending
+    end
+
+    test "is :pending when the desired-running task has not started" do
+      assert ExecSession.pick_running_task([task("running", "pending")]) ==
+               :pending
+    end
+
+    test "skips a task without a container id yet" do
+      no_cid = task("running", "running", cid: nil)
+      assert ExecSession.pick_running_task([no_cid]) == :pending
+    end
+
+    test "is :pending for an empty task list" do
+      assert ExecSession.pick_running_task([]) == :pending
+    end
+  end
+end

--- a/test/camelot/runtime/runner/swarm/proxy_router_test.exs
+++ b/test/camelot/runtime/runner/swarm/proxy_router_test.exs
@@ -1,0 +1,44 @@
+defmodule Camelot.Runtime.Runner.Swarm.ProxyRouterTest do
+  use ExUnit.Case, async: true
+
+  alias Camelot.Runtime.Runner.Swarm.ProxyRouter
+
+  # docker-socket-proxy task shape, trimmed to the fields the
+  # resolver reads.
+  defp proxy_task(desired, status, node, ip) do
+    %{
+      "DesiredState" => desired,
+      "NodeID" => node,
+      "Status" => %{"State" => status},
+      "NetworksAttachments" => [%{"Addresses" => ["#{ip}/24"]}]
+    }
+  end
+
+  describe "proxy_ip_for_node/2" do
+    test "returns the overlay IP of the desired-running proxy on the node" do
+      tasks = [proxy_task("running", "running", "node-a", "10.0.1.79")]
+      assert ProxyRouter.proxy_ip_for_node(tasks, "node-a") == "10.0.1.79"
+    end
+
+    test "ignores an orphaned proxy task advertising a stale IP" do
+      # A rescheduled proxy leaves an old task that can still report
+      # Status.State == "running" with the previous overlay IP.
+      # Selecting it would route exec traffic to a dead endpoint.
+      orphan = proxy_task("shutdown", "running", "node-a", "10.0.1.91")
+      live = proxy_task("running", "running", "node-a", "10.0.1.79")
+
+      assert ProxyRouter.proxy_ip_for_node([orphan, live], "node-a") ==
+               "10.0.1.79"
+    end
+
+    test "returns nil when no proxy runs on the requested node" do
+      tasks = [proxy_task("running", "running", "node-a", "10.0.1.79")]
+      assert ProxyRouter.proxy_ip_for_node(tasks, "node-b") == nil
+    end
+
+    test "returns nil when the node's proxy is not yet running" do
+      tasks = [proxy_task("running", "pending", "node-a", "10.0.1.79")]
+      assert ProxyRouter.proxy_ip_for_node(tasks, "node-a") == nil
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Task `3c3561db` ("Update PostHog library") on `test.camelotai.tech` got stuck in `executing/error` with a misleading `"empty output"`. Investigation traced it to exec routing at a dead Swarm placement.

On `2026-07-01`, the worker node `instance-camelotai-02` (a 1 GB box) OOM-killed the task runner's `beam.smp` (swap was 99.98% full). After a force-redeploy moved the live replica to the leader, the old replica lingered in Docker's view as `Status.State == "running"` (the starved node couldn't report its shutdown). Both `ExecSession.pick_running_task/1` and `ProxyRouter`'s proxy resolution selected on `Status.State` alone, so they locked onto the **dead placement** and hammered its unreachable node proxy (`:ehostunreach`) for the full 60 s transport budget. The exec never started; `AgentProcess`'s `:DOWN` handler synthesized exit-1 with an empty buffer, and `OutputParser` reported `"empty output"` — hiding the real cause.

The reconciler's `list_runnable_swarm_tasks/1` already filters on `desired-state`; the exec path did not. This aligns them.

## Changes

- **Require `DesiredState == "running"` in both selectors** so only the current desired placement is ever chosen, never an orphaned replica.
  - `ExecSession.pick_running_task/1`
  - `ProxyRouter` (extracted pure `proxy_ip_for_node/2`)
- **Thread the runner death reason through `AgentProcess`** via a shared `finalize_runner_exit/3`, so the session records the real cause (e.g. `:ehostunreach`) instead of the parser's empty-buffer guess.
- **Tests** for the orphaned-replica regression (pure selectors) plus the error-message change.

## Verification

- `mix compile --warnings-as-errors` — clean
- `mix test test/camelot/runtime/` — 53 tests, 0 failures (10 new)
- `mix format --check-formatted` / `mix credo` (changed files) — clean
- `mix dialyzer` — not run (no PLT present; changes are small with matching specs)

## Not included / follow-ups

- Re-resolving the node when transport errors persist mid-session (a task that *moves* nodes). With this fix the orphan case is solved at the source; the move-mid-session case is rarer and a larger refactor.
- Infra: `instance-camelotai-02` is undersized (1 GB RAM). Swap was raised to 9 GB on both nodes as a stopgap; the durable fix is resizing and/or setting Swarm memory reservations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
