### PR TITLE
feat(runner): reliable output capture + live output UI

### DIFF
--- a/lib/camelot/runtime/agent_process.ex
+++ b/lib/camelot/runtime/agent_process.ex
@@ -251,6 +251,14 @@ defmodule Camelot.Runtime.AgentProcess do
     {:noreply, %{state | output_buffer: state.output_buffer <> output}}
   end
 
+  # Authoritative output fetched from the runner's tee'd file after
+  # the process exited. Replaces (not appends to) the streamed buffer,
+  # which may be incomplete if the live exec stream was severed on a
+  # long, quiet run. Arrives just before `{:runner_exit, ...}`.
+  def handle_info({:runner_output, handle, bytes}, %{runner: handle} = state) do
+    {:noreply, %{state | output_buffer: to_string(bytes)}}
+  end
+
   def handle_info({:runner_exit, handle, exit_code}, %{runner: handle} = state) do
     Logger.info("Agent #{state.agent_id} runner exited with code #{exit_code}")
     finalize_runner_exit(state, exit_code, nil)

--- a/lib/camelot/runtime/output_parser.ex
+++ b/lib/camelot/runtime/output_parser.ex
@@ -52,7 +52,7 @@ defmodule Camelot.Runtime.OutputParser do
         {:ok,
          %{
            result_text: result_text,
-           cost_usd: data["cost_usd"],
+           cost_usd: data["cost_usd"] || data["total_cost_usd"],
            duration_ms: data["duration_ms"],
            permission_denials: denials
          }}
@@ -65,21 +65,45 @@ defmodule Camelot.Runtime.OutputParser do
     end
   end
 
-  # Tries the whole buffer first (fast path for clean output), then
-  # falls back to scanning lines from the end. Container runners emit
-  # entrypoint log lines before the CLI output and terminal escape
-  # codes after, so a whole-buffer decode often fails even though a
-  # valid JSON line is in there.
+  # Tries the whole buffer first (fast path for a single-object
+  # `--output-format json` result), then falls back to scanning the
+  # per-line objects. Container runners emit entrypoint log lines
+  # before the CLI output and terminal escape codes after, so a
+  # whole-buffer decode often fails even though valid JSON lines are
+  # in there.
   defp extract_json(buffer) do
     case Jason.decode(String.trim(buffer)) do
-      {:ok, data} ->
-        {:ok, data}
+      {:ok, data} -> {:ok, data}
+      {:error, _} -> extract_json_from_lines(buffer)
+    end
+  end
 
-      {:error, _} ->
-        buffer
-        |> String.split(~r/\r?\n/)
-        |> Enum.reverse()
-        |> Enum.find_value(:error, &decode_line/1)
+  # `--output-format stream-json` emits one JSON object per line:
+  # a system/init event, assistant/tool events, then a final
+  # `type: "result"` event carrying the same fields the single-object
+  # format uses. Prefer that result event; fall back to the last
+  # decodable object so a single-object buffer wrapped in log/terminal
+  # noise still parses.
+  defp extract_json_from_lines(buffer) do
+    objects =
+      buffer
+      |> String.split(~r/\r?\n/)
+      |> Enum.flat_map(&decode_line_to_list/1)
+
+    pick_object(Enum.find(objects, &result_event?/1), objects)
+  end
+
+  defp pick_object(nil, []), do: :error
+  defp pick_object(nil, objects), do: {:ok, List.last(objects)}
+  defp pick_object(result, _objects), do: {:ok, result}
+
+  defp result_event?(%{"type" => "result"}), do: true
+  defp result_event?(_), do: false
+
+  defp decode_line_to_list(line) do
+    case decode_line(line) do
+      {:ok, data} -> [data]
+      _ -> []
     end
   end
 

--- a/lib/camelot/runtime/runner/docker_engine/exec_session.ex
+++ b/lib/camelot/runtime/runner/docker_engine/exec_session.ex
@@ -85,6 +85,17 @@ defmodule Camelot.Runtime.Runner.DockerEngine.ExecSession do
   def handle_info({:stream_done, _}, state), do: {:noreply, state}
 
   def handle_info({:exit_code, code}, %__MODULE__{} = state) do
+    # Prefer the exec-wrapper's tee'd file (complete even if the live
+    # stream was cut) as the authoritative result; fall back to the
+    # streamed buffer on any failure.
+    case fetch_output_file(state) do
+      {:ok, bytes} when bytes != "" ->
+        send(state.owner, {:runner_output, self(), bytes})
+
+      _ ->
+        :ok
+    end
+
     send(state.owner, {:runner_exit, self(), code})
     {:stop, :normal, state}
   end
@@ -172,8 +183,12 @@ defmodule Camelot.Runtime.Runner.DockerEngine.ExecSession do
   # The exec-wrapper treats /tmp/camelot.env as a fallback only;
   # these values override anything baked in at container start.
   defp session_env(%Spec{} = spec) do
-    secret_env(spec) ++ mcp_env(spec)
+    session_id_env(spec) ++ secret_env(spec) ++ mcp_env(spec)
   end
+
+  # The exec-wrapper tees output to /tmp/camelot-output-<id>.log so we
+  # can fetch it after exit; it needs the session id to name the file.
+  defp session_id_env(%Spec{session_id: id}), do: ["CAMELOT_SESSION_ID=#{id}"]
 
   defp secret_env(%Spec{secrets: secrets}) do
     Enum.flat_map(secrets, &secret_to_env/1)
@@ -262,6 +277,34 @@ defmodule Camelot.Runtime.Runner.DockerEngine.ExecSession do
         poll_exec_exit(exec_id, parent)
     end
   end
+
+  # Fetch the exec-wrapper's tee'd output file with a short `cat`
+  # exec — complete even if the long-lived agent stream was severed.
+  # Returns `:error` (caller falls back to the streamed buffer) on any
+  # missing field or Docker error.
+  defp fetch_output_file(%__MODULE__{session_id: sid, container_id: cid}) when is_binary(sid) and is_binary(cid) do
+    payload = %{
+      "AttachStdout" => true,
+      "AttachStderr" => false,
+      "Tty" => false,
+      "Cmd" => ["cat", "/tmp/camelot-output-#{sid}.log"]
+    }
+
+    with {:ok, %Req.Response{status: 201, body: %{"Id" => exec_id}}} <-
+           Req.post(DockerApi.request(), url: "/containers/#{cid}/exec", json: payload),
+         {:ok, %Req.Response{status: 200, body: body}} when is_binary(body) <-
+           Req.post(DockerApi.request(),
+             url: "/exec/#{exec_id}/start",
+             json: %{"Detach" => false, "Tty" => false}
+           ) do
+      {payloads, _rest} = DockerStreamDemux.drain(<<>>, body)
+      {:ok, IO.iodata_to_binary(payloads)}
+    else
+      _ -> :error
+    end
+  end
+
+  defp fetch_output_file(_), do: :error
 
   defp reject_nil(map) when is_map(map) do
     map

--- a/lib/camelot/runtime/runner/swarm/exec_session.ex
+++ b/lib/camelot/runtime/runner/swarm/exec_session.ex
@@ -111,6 +111,19 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
   def handle_info({:stream_done, _}, state), do: {:noreply, state}
 
   def handle_info({:exit_code, code}, %__MODULE__{} = state) do
+    # The live stream can be severed on long, quiet runs, so the
+    # accumulated buffer may be incomplete. Fetch the durable copy the
+    # exec-wrapper tee'd to a file and hand it to the owner as the
+    # authoritative result; on any failure we fall back to whatever
+    # the stream delivered.
+    case fetch_output_file(state) do
+      {:ok, bytes} when bytes != "" ->
+        send(state.owner, {:runner_output, self(), bytes})
+
+      _ ->
+        :ok
+    end
+
     send(state.owner, {:runner_exit, self(), code})
     {:stop, :normal, state}
   end
@@ -345,8 +358,12 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
   # fallback only; these values override anything mounted from
   # /run/secrets/ at container-start time.
   defp session_env(%Spec{} = spec) do
-    secret_env(spec) ++ mcp_env(spec)
+    session_id_env(spec) ++ secret_env(spec) ++ mcp_env(spec)
   end
+
+  # The exec-wrapper tees output to /tmp/camelot-output-<id>.log so we
+  # can fetch it after exit; it needs the session id to name the file.
+  defp session_id_env(%Spec{session_id: id}), do: ["CAMELOT_SESSION_ID=#{id}"]
 
   defp secret_env(%Spec{secrets: secrets}) do
     Enum.flat_map(secrets, &secret_to_env/1)
@@ -455,6 +472,32 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
     Process.sleep(@exit_poll_ms)
     poll_exec_exit(node_id, exec_id, parent)
   end
+
+  # Fetch the exec-wrapper's tee'd output file with a short `cat`
+  # exec. Short and chatty, so it can't hit the idle timeout that
+  # loses the long-lived agent stream. Returns `:error` (caller falls
+  # back to the streamed buffer) on any missing field or Docker error.
+  defp fetch_output_file(%__MODULE__{session_id: sid, container_id: cid, node_req: req})
+       when is_binary(sid) and is_binary(cid) and not is_nil(req) do
+    payload = %{
+      "AttachStdout" => true,
+      "AttachStderr" => false,
+      "Tty" => false,
+      "Cmd" => ["cat", "/tmp/camelot-output-#{sid}.log"]
+    }
+
+    with {:ok, %Req.Response{status: 201, body: %{"Id" => exec_id}}} <-
+           Req.post(req, url: "/containers/#{cid}/exec", json: payload),
+         {:ok, %Req.Response{status: 200, body: body}} when is_binary(body) <-
+           Req.post(req, url: "/exec/#{exec_id}/start", json: %{"Detach" => false, "Tty" => false}) do
+      {payloads, _rest} = DockerStreamDemux.drain(<<>>, body)
+      {:ok, IO.iodata_to_binary(payloads)}
+    else
+      _ -> :error
+    end
+  end
+
+  defp fetch_output_file(_), do: :error
 
   # Cancel path: no first-party /exec/<id>/kill endpoint exists.
   # Docker only kills exec processes by signalling the whole

--- a/lib/camelot_web/live/task_live.ex
+++ b/lib/camelot_web/live/task_live.ex
@@ -25,12 +25,18 @@ defmodule CamelotWeb.TaskLive do
           Phoenix.PubSub.subscribe(Camelot.PubSub, "task:#{id}")
         end
 
-        {:ok,
-         assign(socket,
-           page_title: task.title,
-           task: task,
-           message_input: ""
-         )}
+        socket =
+          socket
+          |> assign(
+            page_title: task.title,
+            task: task,
+            message_input: "",
+            live_output: "",
+            subscribed_agent_id: nil
+          )
+          |> maybe_subscribe_agent(task)
+
+        {:ok, socket}
 
       :forbidden ->
         {:ok,
@@ -63,7 +69,18 @@ defmodule CamelotWeb.TaskLive do
         :messages
       ])
 
-    {:noreply, assign(socket, task: task)}
+    {:noreply,
+     socket
+     |> assign(task: task)
+     |> maybe_subscribe_agent(task)
+     |> reset_live_output_unless_running(task)}
+  end
+
+  # Live agent output (one NDJSON chunk per broadcast). Accumulate,
+  # bounded, for the running-session panel.
+  def handle_info({:agent_output, _agent_id, chunk}, socket) do
+    combined = socket.assigns.live_output <> to_string(chunk)
+    {:noreply, assign(socket, live_output: cap_tail(combined, 20_000))}
   end
 
   @impl true
@@ -439,6 +456,16 @@ defmodule CamelotWeb.TaskLive do
           </form>
         </div>
 
+        <div
+          :if={@task.state == :in_progress && @live_output != ""}
+          class="space-y-2"
+        >
+          <h3 class="font-semibold flex items-center gap-2">
+            Live output <span class="loading loading-dots loading-xs"></span>
+          </h3>
+          <pre class="text-xs overflow-auto max-h-96 bg-base-300 p-2 rounded whitespace-pre-wrap">{humanize_stream(@live_output)}</pre>
+        </div>
+
         <div class="space-y-4">
           <h3 class="font-semibold">Sessions</h3>
           <div
@@ -600,6 +627,80 @@ defmodule CamelotWeb.TaskLive do
       []
     end
   end
+
+  # Subscribe to the running agent's live-output topic once the task
+  # has an agent. Idempotent per agent id so a re-render/reassign
+  # doesn't double-subscribe (which would duplicate every chunk).
+  defp maybe_subscribe_agent(socket, %Task{agent_id: nil}), do: socket
+
+  defp maybe_subscribe_agent(%{assigns: %{subscribed_agent_id: id}} = socket, %Task{agent_id: id}) do
+    socket
+  end
+
+  defp maybe_subscribe_agent(socket, %Task{agent_id: agent_id}) do
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Camelot.PubSub, "agent:#{agent_id}")
+    end
+
+    assign(socket, subscribed_agent_id: agent_id)
+  end
+
+  # The live buffer is only meaningful while a session is actively
+  # running; once the task leaves :in_progress the persisted
+  # output_log takes over, so drop the buffer.
+  defp reset_live_output_unless_running(socket, %Task{state: :in_progress}), do: socket
+  defp reset_live_output_unless_running(socket, _task), do: assign(socket, live_output: "")
+
+  defp cap_tail(str, max) do
+    if String.length(str) > max do
+      String.slice(str, -max, max)
+    else
+      str
+    end
+  end
+
+  # Best-effort render of the NDJSON stream-json feed: surface
+  # assistant text and tool calls, collapse other events to a marker,
+  # and pass a trailing partial line through untouched.
+  defp humanize_stream(text) do
+    text
+    |> String.split(~r/\r?\n/)
+    |> Enum.map(&humanize_line/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n")
+  end
+
+  defp humanize_line(line) do
+    case Jason.decode(line) do
+      {:ok, %{"type" => "assistant", "message" => %{"content" => content}}} ->
+        humanize_content(content)
+
+      {:ok, %{"type" => "result", "result" => result}} when is_binary(result) ->
+        result
+
+      {:ok, %{"type" => type}} ->
+        "· #{type}"
+
+      {:ok, _} ->
+        ""
+
+      {:error, _} ->
+        line
+    end
+  end
+
+  defp humanize_content(content) when is_list(content) do
+    content
+    |> Enum.map(&humanize_block/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n")
+  end
+
+  defp humanize_content(_), do: ""
+
+  defp humanize_block(%{"type" => "text", "text" => text}) when is_binary(text), do: text
+  defp humanize_block(%{"type" => "tool_use", "name" => name}), do: "→ #{name}"
+  defp humanize_block(_), do: ""
 
   defp mark_session_clarified(nil), do: :ok
 

--- a/priv/repo/migrations/20260706120000_claude_stream_json_base_args.exs
+++ b/priv/repo/migrations/20260706120000_claude_stream_json_base_args.exs
@@ -1,0 +1,33 @@
+defmodule Camelot.Repo.Migrations.ClaudeStreamJsonBaseArgs do
+  @moduledoc """
+  Switch the seeded `claude_code` template from
+  `--output-format json` (a single JSON blob emitted only at
+  process end) to `--output-format stream-json --verbose`
+  (incremental NDJSON events). This keeps the exec stream warm
+  on long runs and enables live output; the parser reads the
+  final `type: "result"` event either way.
+
+  Only rewrites rows still carrying the exact old value so a
+  hand-customised template is left untouched.
+  """
+  use Ecto.Migration
+
+  @new_args "ARRAY['--output-format','stream-json','--verbose']::text[]"
+  @old_args "ARRAY['--output-format','json']::text[]"
+
+  def up do
+    execute("""
+    UPDATE agent_templates
+    SET base_args = #{@new_args}
+    WHERE slug = 'claude_code' AND base_args = #{@old_args}
+    """)
+  end
+
+  def down do
+    execute("""
+    UPDATE agent_templates
+    SET base_args = #{@old_args}
+    WHERE slug = 'claude_code' AND base_args = #{@new_args}
+    """)
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -37,7 +37,7 @@ if !Enum.any?(existing_templates, &(&1.slug == "claude_code")) do
     slug: "claude_code",
     name: "Claude Code",
     executable: "claude",
-    base_args: ["--output-format", "json"],
+    base_args: ["--output-format", "stream-json", "--verbose"],
     prompt_flag: "-p",
     tools_flag: "--allowedTools",
     tools_separator: ",",

--- a/runner-images/base/exec-wrapper.sh
+++ b/runner-images/base/exec-wrapper.sh
@@ -33,4 +33,15 @@ fi
 
 cd /workspace 2>/dev/null || true
 
-exec "$@"
+# Tee the agent's output to a per-session file so the BEAM can fetch
+# the complete result with a short `docker exec cat` after the process
+# exits, instead of depending on the long-lived, mostly-idle exec
+# stream (which an intermediary can sever on long runs, losing the
+# single final JSON blob). stdout still flows to the exec stream for
+# live output. `set -e` must not abort before we read PIPESTATUS.
+out="/tmp/camelot-output-${CAMELOT_SESSION_ID:-session}.log"
+set +e
+"$@" 2>&1 | tee "$out"
+code=${PIPESTATUS[0]}
+set -e
+exit "$code"

--- a/test/camelot/agents/agent_template_test.exs
+++ b/test/camelot/agents/agent_template_test.exs
@@ -9,7 +9,7 @@ defmodule Camelot.Agents.AgentTemplateTest do
 
       assert template.name == "Claude Code"
       assert template.executable == "claude"
-      assert template.base_args == ["--output-format", "json"]
+      assert template.base_args == ["--output-format", "stream-json", "--verbose"]
       assert template.prompt_flag == "-p"
       assert template.tools_flag == "--allowedTools"
       assert template.parser == :claude_code_json

--- a/test/camelot/runtime/agent_config_test.exs
+++ b/test/camelot/runtime/agent_config_test.exs
@@ -29,7 +29,8 @@ defmodule Camelot.Runtime.AgentConfigTest do
 
       assert args == [
                "--output-format",
-               "json",
+               "stream-json",
+               "--verbose",
                "--permission-mode",
                "plan",
                "--allowedTools",
@@ -50,7 +51,8 @@ defmodule Camelot.Runtime.AgentConfigTest do
 
       assert args == [
                "--output-format",
-               "json",
+               "stream-json",
+               "--verbose",
                "--permission-mode",
                "acceptEdits",
                "--allowedTools",
@@ -194,7 +196,7 @@ defmodule Camelot.Runtime.AgentConfigTest do
     %Camelot.Agents.AgentTemplate{
       command_prefix: nil,
       executable: "claude",
-      base_args: ["--output-format", "json"],
+      base_args: ["--output-format", "stream-json", "--verbose"],
       prompt_flag: "-p",
       tools_flag: "--allowedTools",
       tools_separator: ",",

--- a/test/camelot/runtime/output_parser_test.exs
+++ b/test/camelot/runtime/output_parser_test.exs
@@ -68,6 +68,62 @@ defmodule Camelot.Runtime.OutputParserTest do
     end
   end
 
+  describe "parse/2 with :claude_code_json — stream-json (NDJSON)" do
+    test "picks the type:result event out of a multi-line stream" do
+      buffer =
+        Enum.map_join(
+          [
+            %{"type" => "system", "subtype" => "init", "session_id" => "abc"},
+            %{"type" => "assistant", "message" => %{"content" => [%{"type" => "text", "text" => "working"}]}},
+            %{
+              "type" => "result",
+              "subtype" => "success",
+              "is_error" => false,
+              "result" => "All done.",
+              "total_cost_usd" => 0.12,
+              "duration_ms" => 4567,
+              "permission_denials" => []
+            }
+          ],
+          "\n",
+          &Jason.encode!/1
+        )
+
+      assert {:ok, parsed} = OutputParser.parse(:claude_code_json, buffer)
+      assert parsed.result_text == "All done."
+      assert parsed.cost_usd == 0.12
+      assert parsed.duration_ms == 4567
+      assert parsed.permission_denials == []
+    end
+
+    test "prefers type:result even when a later line also decodes" do
+      buffer =
+        Enum.map_join(
+          [
+            %{"type" => "result", "result" => "the answer", "is_error" => false},
+            %{"type" => "trailing", "note" => "should be ignored"}
+          ],
+          "\n",
+          &Jason.encode!/1
+        )
+
+      assert {:ok, %{result_text: "the answer"}} =
+               OutputParser.parse(:claude_code_json, buffer)
+    end
+
+    test "surfaces is_error from a stream-json result event" do
+      buffer =
+        Enum.map_join(
+          [%{"type" => "system", "subtype" => "init"}, %{"type" => "result", "is_error" => true, "result" => "boom"}],
+          "\n",
+          &Jason.encode!/1
+        )
+
+      assert {:error, "claude error: boom"} =
+               OutputParser.parse(:claude_code_json, buffer)
+    end
+  end
+
   describe "parse/2 with :raw_text" do
     test "returns raw text as-is" do
       buffer = "some raw output\nwith newlines"


### PR DESCRIPTION
## Context

Task `9004803c` on test.camelotai.tech got stuck in `executing`/`error`. Root cause: the executing session ran ~35 min, claude exited **0**, but the session recorded `error_message="empty output"` and the task was flagged errored.

With `--output-format json`, claude emits **nothing until a single JSON blob at process end**. Both `Swarm.ExecSession` and `DockerEngine.ExecSession` read that blob over one long-lived, mostly-idle streaming `POST /exec/<id>/start` connection through the tecnativa docker-socket-proxy (HAProxy). On long runs that idle stream is severed before the final blob arrives (no crash — the stream just ends with zero bytes), while the independent `poll_exec_exit` loop still sees exit 0. `AgentProcess.finalize_runner_exit` then parses an empty `output_buffer` → `{:error,"empty output"}` → `mark_task_error`. The ~3-min planning session on the same container worked; only duration differed. There is also a secondary poll/stream race: finalize reads `output_buffer` on exit with no guarantee the stream flushed.

## Changes

**A. File capture (source of truth — the load-bearing fix)**
- `exec-wrapper.sh` tees output to `/tmp/camelot-output-$CAMELOT_SESSION_ID.log` (stdout still flows to the live stream).
- Both ExecSession backends inject `CAMELOT_SESSION_ID` and, after exit, `cat` the file and send `{:runner_output, handle, bytes}` to the owner.
- `AgentProcess` overrides (not appends) `output_buffer` with that value; falls back to the streamed buffer if the fetch is empty/fails. Removes both the idle-drop and the poll/stream race.

**B. stream-json + parser hardening**
- Template `base_args` → `--output-format stream-json --verbose` (`priv/repo/seeds.exs` + data migration `20260706120000`). Output now arrives incrementally, keeping the stream warm.
- `OutputParser` picks the `type:"result"` NDJSON event (falling back to last-decodable-object for the old single-blob format) and reads `total_cost_usd`.
- Verified: runner claude 2.1.186 accepts these flags.

**C. Live output UI**
- `TaskLive` subscribes to `agent:<id>` and renders a live-output panel for the running session (nothing consumed this broadcast before).

## Rollout notes
- Runner image ships via `.github/workflows/runner-images.yml` on merge (touching `runner-images/**`). Long-lived task services pin `:latest` and won't re-pull until recreated; the wrapper's `${CAMELOT_SESSION_ID:-session}` default and the backend's fetch-fallback make version skew safe.
- After deploy, stuck task `9004803c` can be reset to `:queued` to retry.

## Verification
- `mix test` (194 tests, 0 failures), incl. new stream-json NDJSON parser cases and updated arg/template expectations.
- `mix credo` (no new issues), `mix dialyzer` (passed), `mix format`.
- Confirmed `claude --output-format stream-json --verbose` in the runner image.
- Not yet run: full local e2e (needs app + docker + creds) and remote post-deploy check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)