### PR TITLE
fix(runner): capture last result event in resumed sessions

### DIFF
--- a/lib/camelot/runtime/output_parser.ex
+++ b/lib/camelot/runtime/output_parser.ex
@@ -90,7 +90,21 @@ defmodule Camelot.Runtime.OutputParser do
       |> String.split(~r/\r?\n/)
       |> Enum.flat_map(&decode_line_to_list/1)
 
-    pick_object(Enum.find(objects, &result_event?/1), objects)
+    pick_object(last_result_event(objects), objects)
+  end
+
+  # A resumed session — the agent yields to a background sub-agent, then
+  # wakes on a task-notification — runs as several `claude` invocations
+  # concatenated into one log, each emitting its own `type: "result"`
+  # event. Every result event is a cumulative snapshot of the session, so
+  # the last top-level one is the terminal state (its cost and turn count
+  # already include the earlier invocations). Sub-agent streams are inlined
+  # with a non-nil `parent_tool_use_id`; skip them so a sub-agent result can
+  # never masquerade as the session result.
+  defp last_result_event(objects) do
+    objects
+    |> Enum.filter(&(result_event?(&1) and top_level?(&1)))
+    |> List.last()
   end
 
   defp pick_object(nil, []), do: :error
@@ -99,6 +113,10 @@ defmodule Camelot.Runtime.OutputParser do
 
   defp result_event?(%{"type" => "result"}), do: true
   defp result_event?(_), do: false
+
+  defp top_level?(%{"parent_tool_use_id" => nil}), do: true
+  defp top_level?(%{"parent_tool_use_id" => _id}), do: false
+  defp top_level?(_), do: true
 
   defp decode_line_to_list(line) do
     case decode_line(line) do

--- a/test/camelot/runtime/output_parser_test.exs
+++ b/test/camelot/runtime/output_parser_test.exs
@@ -122,6 +122,68 @@ defmodule Camelot.Runtime.OutputParserTest do
       assert {:error, "claude error: boom"} =
                OutputParser.parse(:claude_code_json, buffer)
     end
+
+    test "picks the last result event of a resumed (multi-invocation) session" do
+      buffer =
+        Enum.map_join(
+          [
+            %{"type" => "system", "subtype" => "init", "session_id" => "s1"},
+            %{
+              "type" => "result",
+              "subtype" => "success",
+              "is_error" => false,
+              "result" => "I'll wait for the exploration agent's findings.",
+              "total_cost_usd" => 0.18,
+              "num_turns" => 4,
+              "permission_denials" => []
+            },
+            %{"type" => "system", "subtype" => "init", "session_id" => "s1"},
+            %{"type" => "assistant", "message" => %{"content" => [%{"type" => "text", "text" => "writing plan"}]}},
+            %{
+              "type" => "result",
+              "subtype" => "success",
+              "is_error" => false,
+              "result" => "I've completed the plan.",
+              "total_cost_usd" => 0.74,
+              "num_turns" => 8,
+              "permission_denials" => []
+            }
+          ],
+          "\n",
+          &Jason.encode!/1
+        )
+
+      assert {:ok, parsed} = OutputParser.parse(:claude_code_json, buffer)
+      assert parsed.result_text == "I've completed the plan."
+      # The last event is a cumulative snapshot: take its cost, don't sum.
+      assert parsed.cost_usd == 0.74
+    end
+
+    test "ignores sub-agent result events (non-nil parent_tool_use_id)" do
+      buffer =
+        Enum.map_join(
+          [
+            %{"type" => "system", "subtype" => "init"},
+            %{
+              "type" => "result",
+              "is_error" => false,
+              "result" => "session result",
+              "parent_tool_use_id" => nil
+            },
+            %{
+              "type" => "result",
+              "is_error" => false,
+              "result" => "sub-agent result",
+              "parent_tool_use_id" => "toolu_123"
+            }
+          ],
+          "\n",
+          &Jason.encode!/1
+        )
+
+      assert {:ok, %{result_text: "session result"}} =
+               OutputParser.parse(:claude_code_json, buffer)
+    end
   end
 
   describe "parse/2 with :raw_text" do


### PR DESCRIPTION
## Problem

A planning task's card showed an **"approve plan" prompt with no real plan** — e.g. task `e3cc00b3` stored `"I'll wait for the exploration agent's findings — I'll be notified automatically when it completes, no need to poll."` as its plan.

### Root cause

When the agent yields to a background sub-agent and later wakes on a `task-notification`, the session runs as **several `claude` invocations concatenated into one stream-json log**, each emitting its own `type:"result"` event. `OutputParser.extract_json_from_lines/1` used `Enum.find`, which returned the **first** result event — an early intermediate turn ("I'll wait…") — and discarded the real final plan produced after the resume.

Verified on the live `e3cc00b3` log: 2 result events, cumulative (`num_turns` 4 → 8, cost 0.186 → 0.741). The parser grabbed #0; the real plan was #1.

## Fix

Select the **last top-level** `type:"result"` event:

- **Last, not merged** — each result event is a cumulative snapshot, so the final one is the terminal state (its cost/turn count already include earlier invocations). Summing would double-count; unioning denials would re-raise denials an earlier invocation already resolved.
- **Top-level only** — the stream inlines sub-agent events; skip results with a non-nil `parent_tool_use_id` so a sub-agent result can never masquerade as the session result.

## Verification

- Against `e3cc00b3`'s real 144 KB log: parser now returns the actual plan text + cumulative cost `0.74113615`.
- Two regression tests added (resumed multi-invocation session; sub-agent result exclusion).
- `mix format`, `mix compile --warnings-as-errors`, `mix credo` (no issues), full `mix test` (196, 0 failures).

## Not included

Does **not** address the separate `ExitPlanMode` note-leak (agent narrating "ExitPlanMode tool isn't available"); that's a distinct fix in the plan-capture path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)