### PR TITLE
fix(runner): let task runners join configurable overlay networks

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -50,7 +50,8 @@ config :camelot, :runner,
   backend: Camelot.Runtime.Runner.LocalPort,
   docker_host: "unix:///var/run/docker.sock",
   global_max: 20,
-  per_user_max: 2
+  per_user_max: 2,
+  networks: []
 
 config :camelot, :token_signing_secret, "dev-only-signing-secret-change-in-prod"
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -22,6 +22,17 @@ if System.get_env("PHX_SERVER") do
   config :camelot, CamelotWeb.Endpoint, server: true
 end
 
+# Overlay networks the task-runner services should join, comma-separated
+# (e.g. "captain-overlay-network"). Needed on Swarm so runners can reach
+# DB/service hostnames that only resolve on a shared overlay; empty (the
+# default) is correct for plain-Docker / non-Swarm self-hosting.
+runner_networks =
+  "RUNNER_NETWORKS"
+  |> System.get_env("")
+  |> String.split(",", trim: true)
+  |> Enum.map(&String.trim/1)
+  |> Enum.reject(&(&1 == ""))
+
 config :camelot, CamelotWeb.Endpoint, http: [port: String.to_integer(System.get_env("PORT", "4000"))]
 
 # Invite-only mode. When false, /sign-in rejects unknown emails; existing
@@ -45,7 +56,8 @@ if backend_env = System.get_env("RUNNER_BACKEND") do
     backend: runner_backend,
     docker_host: System.get_env("DOCKER_HOST", "unix:///var/run/docker.sock"),
     global_max: String.to_integer(System.get_env("RUNNER_GLOBAL_MAX", "20")),
-    per_user_max: String.to_integer(System.get_env("RUNNER_PER_USER_MAX", "2"))
+    per_user_max: String.to_integer(System.get_env("RUNNER_PER_USER_MAX", "2")),
+    networks: runner_networks
 end
 
 if config_env() == :prod do
@@ -69,7 +81,8 @@ if config_env() == :prod do
       backend: Swarm,
       docker_host: System.get_env("DOCKER_HOST", "unix:///var/run/docker.sock"),
       global_max: String.to_integer(System.get_env("RUNNER_GLOBAL_MAX", "20")),
-      per_user_max: String.to_integer(System.get_env("RUNNER_PER_USER_MAX", "2"))
+      per_user_max: String.to_integer(System.get_env("RUNNER_PER_USER_MAX", "2")),
+      networks: runner_networks
   end
 
   maybe_ipv6 = if System.get_env("ECTO_IPV6") in ~w(true 1), do: [:inet6], else: []

--- a/docs/cluster-runners.md
+++ b/docs/cluster-runners.md
@@ -17,6 +17,8 @@ For a hosted CapRover deployment:
    - `ENCRYPTION_KEY=<32-byte base64>`
    - `RUNNER_GLOBAL_MAX=20` (or whatever your cluster can handle)
    - `RUNNER_PER_USER_MAX=2` (default tier)
+   - `RUNNER_NETWORKS=captain-overlay-network` if runners must reach a
+     DB/service by its overlay hostname (see *Runner networking*)
 4. Build and push the runner images
    (`.github/workflows/runner-images.yml`). Reference them from
    `AgentTemplate.runner_image`.
@@ -102,6 +104,26 @@ through Camelot's admin UI.
 
 Sessions never get refused — they queue. Wait time surfaces in the UI;
 a future paid tier will let users buy higher per-user caps.
+
+## Runner networking
+
+By default a task-runner service joins only the Swarm bridge network,
+so it can reach the public internet but **cannot resolve other Swarm
+services by name**. Swarm's service-discovery DNS (e.g. a CapRover
+`srv-captain--db`) only works between containers attached to the same
+overlay. A runner that needs to run the project's test suite against a
+shared database — with `DATABASE_URL=ecto://…@srv-captain--db:5432/…` —
+will otherwise fail with *"Name or service not known"*.
+
+| Env var | Default | What it controls |
+|---|---|---|
+| `RUNNER_NETWORKS` | *(empty)* | Comma-separated overlay networks each runner service joins, e.g. `captain-overlay-network`. |
+
+Empty is the correct default for plain-Docker and non-Swarm
+self-hosting, where there is no overlay to join. On CapRover, use
+`captain-overlay-network` (confirm the exact name with
+`docker network ls`). List several networks comma-separated to join
+more than one.
 
 ## Backups & disaster recovery
 

--- a/lib/camelot/runtime/runner/swarm/task_service.ex
+++ b/lib/camelot/runtime/runner/swarm/task_service.ex
@@ -404,17 +404,41 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
 
   # --- Service spec construction ---
 
-  defp service_create_payload(%Spec{} = spec, name) do
+  @doc false
+  # Public only so the payload can be asserted on in tests.
+  @spec service_create_payload(Spec.t(), String.t()) :: map()
+  def service_create_payload(%Spec{} = spec, name) do
     reject_nil(%{
       "Name" => name,
-      "TaskTemplate" => %{
-        "ContainerSpec" => container_spec(spec),
-        "Placement" => placement(spec),
-        "Resources" => resources(spec),
-        "RestartPolicy" => %{"Condition" => "none"}
-      },
+      "TaskTemplate" =>
+        reject_nil(%{
+          "ContainerSpec" => container_spec(spec),
+          "Networks" => task_networks(),
+          "Placement" => placement(spec),
+          "Resources" => resources(spec),
+          "RestartPolicy" => %{"Condition" => "none"}
+        }),
       "Mode" => %{"Replicated" => %{"Replicas" => 1}}
     })
+  end
+
+  # Swarm resolves a service's DNS name (e.g. a CapRover
+  # `srv-captain--db`) only for containers on the same overlay
+  # network. Task runners land on the default bridge and so can't
+  # reach such hostnames; operators list the overlays to join via the
+  # `RUNNER_NETWORKS` env var (`:runner, :networks` config). Empty is
+  # the default and correct for plain-Docker / non-Swarm self-hosting.
+  defp task_networks do
+    case configured_networks() do
+      [] -> nil
+      names -> Enum.map(names, &%{"Target" => &1})
+    end
+  end
+
+  defp configured_networks do
+    :camelot
+    |> Application.get_env(:runner, [])
+    |> Keyword.get(:networks, [])
   end
 
   defp container_spec(%Spec{} = spec) do

--- a/test/camelot/runtime/runner/swarm/task_service_test.exs
+++ b/test/camelot/runtime/runner/swarm/task_service_test.exs
@@ -1,0 +1,60 @@
+defmodule Camelot.Runtime.Runner.Swarm.TaskServiceTest do
+  # Mutates the global :runner app env, so it can't run async.
+  use ExUnit.Case, async: false
+
+  alias Camelot.Runtime.Runner.Spec
+  alias Camelot.Runtime.Runner.Swarm.TaskService
+
+  setup do
+    original = Application.get_env(:camelot, :runner)
+    on_exit(fn -> Application.put_env(:camelot, :runner, original) end)
+    :ok
+  end
+
+  defp put_networks(networks) do
+    runner = Application.get_env(:camelot, :runner, [])
+    Application.put_env(:camelot, :runner, Keyword.put(runner, :networks, networks))
+  end
+
+  defp spec do
+    %Spec{
+      session_id: "sess-1",
+      owner_pid: self(),
+      argv: [],
+      task_id: "task-1",
+      image: "ghcr.io/example/runner"
+    }
+  end
+
+  describe "service_create_payload/2 — networks" do
+    test "omits Networks when none are configured" do
+      put_networks([])
+
+      payload = TaskService.service_create_payload(spec(), "camelot-task-task-1")
+
+      refute Map.has_key?(payload["TaskTemplate"], "Networks")
+    end
+
+    test "attaches each configured overlay network as a Target" do
+      put_networks(["captain-overlay-network", "extra-net"])
+
+      payload = TaskService.service_create_payload(spec(), "camelot-task-task-1")
+
+      assert payload["TaskTemplate"]["Networks"] == [
+               %{"Target" => "captain-overlay-network"},
+               %{"Target" => "extra-net"}
+             ]
+    end
+
+    test "keeps the rest of the task template intact" do
+      put_networks(["captain-overlay-network"])
+
+      payload = TaskService.service_create_payload(spec(), "camelot-task-task-1")
+      template = payload["TaskTemplate"]
+
+      assert payload["Name"] == "camelot-task-task-1"
+      assert template["RestartPolicy"] == %{"Condition" => "none"}
+      assert template["ContainerSpec"]["Image"] == "ghcr.io/example/runner"
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Task-runner Swarm services are created attached **only to the default bridge network**. Swarm service-discovery DNS (e.g. a CapRover `srv-captain--db`) only resolves between containers on a shared overlay, so a runner can't reach shared services by name.

Diagnosed on the live test cluster (task `e3cc00b3`, repo LamaBot): the runner had `DATABASE_URL=ecto://…@srv-captain--db:5432/lamabot_dev`, but from inside the container:

- `getent hosts srv-captain--db` → **"Name or service not known"**
- TCP connect to `srv-captain--db:5432` → **fail**
- outbound internet → OK; container networks → **`bridge` only**

`srv-captain--db` lives on `captain-overlay-network`; the runner shared no network with it. So any task that needs to run its project's test suite against a shared DB fails regardless of how `DATABASE_URL` is wired.

## Fix

Make the overlay attachment **configurable, defaulting to none**:

- `RUNNER_NETWORKS` env var (comma-separated) → `:runner, :networks` config, parsed in `runtime.exs` for both the `RUNNER_BACKEND`-override and prod-default paths.
- `TaskService.service_create_payload/2` adds `TaskTemplate.Networks` (`[%{"Target" => name}]`) from that config. When empty, the key is **omitted entirely** — no behavior change for plain-Docker / non-Swarm self-hosting, which has no overlay to join.

Operators on Swarm/CapRover set e.g. `RUNNER_NETWORKS=captain-overlay-network`.

## Tests & docs

- `test/camelot/runtime/runner/swarm/task_service_test.exs` — omitted when unconfigured; attached per configured network; rest of the task template intact.
- `docs/cluster-runners.md` — new *Runner networking* section + setup-checklist entry explaining the requirement and the empty default.
- `mix format`, `mix compile --warnings-as-errors`, `mix credo` (clean), full `mix test` (199, 0 failures).

## Note

Separate concern from #36 (output-parser last-result-event fix); branched off `main` independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)