### PR TITLE
feat(runner): auto-discover runner overlay networks

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -51,7 +51,7 @@ config :camelot, :runner,
   docker_host: "unix:///var/run/docker.sock",
   global_max: 20,
   per_user_max: 2,
-  networks: []
+  networks: ["auto"]
 
 config :camelot, :token_signing_secret, "dev-only-signing-secret-change-in-prod"
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -23,7 +23,8 @@ if System.get_env("PHX_SERVER") do
 end
 
 # Overlay networks the task-runner services should join, comma-separated
-# (e.g. "captain-overlay-network"). Needed on Swarm so runners can reach
+# (e.g. "captain-overlay-network"), or "auto" to copy the networks the
+# Camelot service is itself on. Needed on Swarm so runners can reach
 # DB/service hostnames that only resolve on a shared overlay; empty (the
 # default) is correct for plain-Docker / non-Swarm self-hosting.
 runner_networks =

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -22,17 +22,26 @@ if System.get_env("PHX_SERVER") do
   config :camelot, CamelotWeb.Endpoint, server: true
 end
 
-# Overlay networks the task-runner services should join, comma-separated
-# (e.g. "captain-overlay-network"), or "auto" to copy the networks the
-# Camelot service is itself on. Needed on Swarm so runners can reach
-# DB/service hostnames that only resolve on a shared overlay; empty (the
-# default) is correct for plain-Docker / non-Swarm self-hosting.
+# Overlay networks the task-runner services should join, so runners can
+# reach DB/service hostnames that only resolve on a shared overlay.
+# Defaults to "auto": copy the networks the Camelot service is itself on
+# (a no-op that fails soft when there's nothing to discover, e.g.
+# plain-Docker / non-Swarm self-hosting). Override with a comma-separated
+# list of network names/IDs, or "none" to keep runners isolated.
 runner_networks =
-  "RUNNER_NETWORKS"
-  |> System.get_env("")
-  |> String.split(",", trim: true)
-  |> Enum.map(&String.trim/1)
-  |> Enum.reject(&(&1 == ""))
+  case System.get_env("RUNNER_NETWORKS") do
+    nil ->
+      ["auto"]
+
+    "" ->
+      ["auto"]
+
+    value ->
+      value
+      |> String.split(",", trim: true)
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+  end
 
 config :camelot, CamelotWeb.Endpoint, http: [port: String.to_integer(System.get_env("PORT", "4000"))]
 

--- a/docs/cluster-runners.md
+++ b/docs/cluster-runners.md
@@ -17,8 +17,8 @@ For a hosted CapRover deployment:
    - `ENCRYPTION_KEY=<32-byte base64>`
    - `RUNNER_GLOBAL_MAX=20` (or whatever your cluster can handle)
    - `RUNNER_PER_USER_MAX=2` (default tier)
-   - `RUNNER_NETWORKS=auto` if runners must reach a DB/service by its
-     overlay hostname (see *Runner networking*)
+   - `RUNNER_NETWORKS` — optional; defaults to `auto` (see *Runner
+     networking*). Set `none` to keep runners isolated.
 4. Build and push the runner images
    (`.github/workflows/runner-images.yml`). Reference them from
    `AgentTemplate.runner_image`.
@@ -107,34 +107,34 @@ a future paid tier will let users buy higher per-user caps.
 
 ## Runner networking
 
-By default a task-runner service joins only the Swarm bridge network,
-so it can reach the public internet but **cannot resolve other Swarm
-services by name**. Swarm's service-discovery DNS (e.g. a CapRover
-`srv-captain--db`) only works between containers attached to the same
-overlay. A runner that needs to run the project's test suite against a
-shared database — with `DATABASE_URL=ecto://…@srv-captain--db:5432/…` —
-will otherwise fail with *"Name or service not known"*.
+A task-runner container joins the Swarm bridge network for outbound
+internet, but Swarm's service-discovery DNS (e.g. a CapRover
+`srv-captain--db`) only resolves between containers on the same
+*overlay*. A runner that runs the project's test suite against a shared
+database — `DATABASE_URL=ecto://…@srv-captain--db:5432/…` — needs to be
+on that overlay, or it fails with *"Name or service not known"* /
+`nxdomain`.
 
-| Env var | Default | What it controls |
-|---|---|---|
-| `RUNNER_NETWORKS` | *(empty)* | Overlay networks each runner service joins. Comma-separated network names/IDs, or `auto`. |
+`RUNNER_NETWORKS` controls which overlays runners join.
 
-Empty is the correct default for plain-Docker and non-Swarm
-self-hosting, where there is no overlay to join.
+| Value | What happens |
+|---|---|
+| *(unset)* / `auto` | **Default.** Camelot copies the overlay network(s) its *own* service is on onto each runner. |
+| `net-a,net-b` | Explicit network names/IDs. Combine with `auto` (`auto,net-a`) to add to the discovered set. |
+| `none` | Keep runners isolated — bridge only, no overlay. |
 
-**`RUNNER_NETWORKS=auto` (recommended on Swarm)** — Camelot discovers the
-overlay network(s) its *own* service is attached to and places runners
-on the same ones, so a runner reaches exactly what Camelot reaches. No
-network name to hardcode. Discovery reads the app's own task and service
-via the Docker API (`TASKS` + `SERVICES`, already in the socket-proxy
-allow-list) and memoizes the result; if it can't complete, runners start
-with no extra network and a warning is logged rather than failing.
+**`auto` (the default)** — a runner reaches exactly what Camelot
+reaches, with nothing to hardcode. Discovery reads the app's own task and
+service via the Docker API (`TASKS` + `SERVICES`, already in the
+socket-proxy allow-list) and memoizes the result. If it can't complete
+(e.g. plain-Docker / non-Swarm self-hosting, where there is no overlay to
+discover), runners start with no extra network and a warning is logged —
+never a hard failure.
 
-**Explicit list** — set the names yourself, e.g.
-`RUNNER_NETWORKS=captain-overlay-network` (confirm the exact name with
-`docker network ls`). Comma-separate several, and combine with `auto`
-(e.g. `auto,some-extra-net`) to add networks on top of the discovered
-ones.
+**Security note:** `auto` places runners on the same overlay as Camelot,
+so they can reach the control-plane services on it (including Camelot's
+own DB). Set `RUNNER_NETWORKS=none` — or an explicit, dedicated overlay —
+if you need runners isolated from the control plane.
 
 ## Backups & disaster recovery
 

--- a/docs/cluster-runners.md
+++ b/docs/cluster-runners.md
@@ -17,8 +17,8 @@ For a hosted CapRover deployment:
    - `ENCRYPTION_KEY=<32-byte base64>`
    - `RUNNER_GLOBAL_MAX=20` (or whatever your cluster can handle)
    - `RUNNER_PER_USER_MAX=2` (default tier)
-   - `RUNNER_NETWORKS=captain-overlay-network` if runners must reach a
-     DB/service by its overlay hostname (see *Runner networking*)
+   - `RUNNER_NETWORKS=auto` if runners must reach a DB/service by its
+     overlay hostname (see *Runner networking*)
 4. Build and push the runner images
    (`.github/workflows/runner-images.yml`). Reference them from
    `AgentTemplate.runner_image`.
@@ -117,13 +117,24 @@ will otherwise fail with *"Name or service not known"*.
 
 | Env var | Default | What it controls |
 |---|---|---|
-| `RUNNER_NETWORKS` | *(empty)* | Comma-separated overlay networks each runner service joins, e.g. `captain-overlay-network`. |
+| `RUNNER_NETWORKS` | *(empty)* | Overlay networks each runner service joins. Comma-separated network names/IDs, or `auto`. |
 
 Empty is the correct default for plain-Docker and non-Swarm
-self-hosting, where there is no overlay to join. On CapRover, use
-`captain-overlay-network` (confirm the exact name with
-`docker network ls`). List several networks comma-separated to join
-more than one.
+self-hosting, where there is no overlay to join.
+
+**`RUNNER_NETWORKS=auto` (recommended on Swarm)** — Camelot discovers the
+overlay network(s) its *own* service is attached to and places runners
+on the same ones, so a runner reaches exactly what Camelot reaches. No
+network name to hardcode. Discovery reads the app's own task and service
+via the Docker API (`TASKS` + `SERVICES`, already in the socket-proxy
+allow-list) and memoizes the result; if it can't complete, runners start
+with no extra network and a warning is logged rather than failing.
+
+**Explicit list** — set the names yourself, e.g.
+`RUNNER_NETWORKS=captain-overlay-network` (confirm the exact name with
+`docker network ls`). Comma-separate several, and combine with `auto`
+(e.g. `auto,some-extra-net`) to add networks on top of the discovered
+ones.
 
 ## Backups & disaster recovery
 

--- a/lib/camelot/runtime/runner/swarm/self_networks.ex
+++ b/lib/camelot/runtime/runner/swarm/self_networks.ex
@@ -6,7 +6,7 @@ defmodule Camelot.Runtime.Runner.Swarm.SelfNetworks do
   e.g. reaching a CapRover `srv-captain--db` DB host that only resolves
   on a shared overlay.
 
-  Enabled with `RUNNER_NETWORKS=auto`. Discovery walks:
+  Used when `RUNNER_NETWORKS` is `auto` (the default). Discovery walks:
 
     1. own container id — the container hostname (Swarm sets it to the
        container's short id unless overridden);

--- a/lib/camelot/runtime/runner/swarm/self_networks.ex
+++ b/lib/camelot/runtime/runner/swarm/self_networks.ex
@@ -1,0 +1,155 @@
+defmodule Camelot.Runtime.Runner.Swarm.SelfNetworks do
+  @moduledoc """
+  Auto-discovers the overlay networks the Camelot service itself is
+  attached to, so task-runner services can be placed on the same
+  networks and inherit identical service-to-service reachability —
+  e.g. reaching a CapRover `srv-captain--db` DB host that only resolves
+  on a shared overlay.
+
+  Enabled with `RUNNER_NETWORKS=auto`. Discovery walks:
+
+    1. own container id — the container hostname (Swarm sets it to the
+       container's short id unless overridden);
+    2. `GET /tasks` — find the running task whose container id matches,
+       read its `ServiceID`;
+    3. `GET /services/<id>` — copy that service's own
+       `TaskTemplate.Networks` targets.
+
+  A successful (non-empty) result is memoized in `:persistent_term`,
+  since the app's own network attachments only change on a redeploy —
+  which restarts the app and clears the term. Failures and empty
+  results are not cached, so a transient Docker API hiccup at boot is
+  retried on the next runner launch.
+  """
+
+  alias Camelot.Runtime.Runner.DockerApi
+
+  require Logger
+
+  @cache_key {__MODULE__, :targets}
+
+  @doc """
+  Returns the network targets to attach runners to, discovering them on
+  the first call and serving the memoized result thereafter. Returns
+  `[]` (and logs) when discovery can't complete — runner creation then
+  proceeds with no extra network rather than failing.
+  """
+  @spec discover() :: [String.t()]
+  def discover do
+    case :persistent_term.get(@cache_key, :miss) do
+      :miss -> discover_and_maybe_cache()
+      targets -> targets
+    end
+  end
+
+  @doc """
+  Forget any memoized discovery result so the next `discover/0`
+  re-probes. Exposed for operators (force a re-scan) and tests.
+  """
+  @spec reset_cache() :: :ok
+  def reset_cache do
+    :persistent_term.erase(@cache_key)
+    :ok
+  end
+
+  @doc false
+  # Seed the memo directly. Used by tests to exercise the `auto` wiring
+  # without a live Docker daemon.
+  @spec put_cache([String.t()]) :: :ok
+  def put_cache(targets) when is_list(targets) do
+    :persistent_term.put(@cache_key, targets)
+    :ok
+  end
+
+  # --- Pure discovery logic (unit-tested) ---
+
+  @doc """
+  Finds the `ServiceID` of the task whose container id is prefixed by
+  `container_id` (the daemon stores the full id; the hostname is the
+  short form). Returns `nil` when no task matches.
+  """
+  @spec find_own_service_id([map()], String.t()) :: String.t() | nil
+  def find_own_service_id(tasks, container_id) do
+    Enum.find_value(tasks, &own_service_id(&1, container_id))
+  end
+
+  defp own_service_id(_task, ""), do: nil
+
+  defp own_service_id(task, container_id) do
+    cid = get_in(task, ["Status", "ContainerStatus", "ContainerID"]) || ""
+
+    if String.starts_with?(cid, container_id) do
+      task["ServiceID"]
+    end
+  end
+
+  @doc """
+  Extracts the network targets from a service object's own
+  `TaskTemplate.Networks`, dropping any entry without a `Target`.
+  """
+  @spec targets_from_service(map()) :: [String.t()]
+  def targets_from_service(service) do
+    service
+    |> get_in(["Spec", "TaskTemplate", "Networks"])
+    |> List.wrap()
+    |> Enum.map(& &1["Target"])
+    |> Enum.reject(&is_nil/1)
+  end
+
+  # --- HTTP glue (thin, matches the untested-HTTP convention) ---
+
+  defp discover_and_maybe_cache do
+    case do_discover() do
+      [] -> []
+      targets -> tap(targets, &put_cache/1)
+    end
+  end
+
+  defp do_discover do
+    with {:ok, id} <- own_container_id(),
+         {:ok, tasks} <- fetch_running_tasks(),
+         service_id when is_binary(service_id) <- find_own_service_id(tasks, id),
+         {:ok, service} <- fetch_service(service_id) do
+      targets_from_service(service)
+    else
+      other ->
+        Logger.warning(
+          "Swarm.SelfNetworks: could not auto-discover networks " <>
+            "(#{inspect(other)}); runners will start with no extra network"
+        )
+
+        []
+    end
+  end
+
+  defp own_container_id do
+    case :inet.gethostname() do
+      {:ok, name} -> {:ok, List.to_string(name)}
+      other -> {:error, {:hostname, other}}
+    end
+  end
+
+  defp fetch_running_tasks do
+    case Req.get(DockerApi.request(),
+           url: "/tasks",
+           params: [filters: ~s({"desired-state":["running"]})]
+         ) do
+      {:ok, %Req.Response{status: 200, body: tasks}} when is_list(tasks) ->
+        {:ok, tasks}
+
+      {:ok, resp} ->
+        {:error, {:tasks_bad_status, resp.status}}
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  defp fetch_service(id) do
+    case Req.get(DockerApi.request(), url: "/services/#{id}") do
+      {:ok, %Req.Response{status: 200, body: body}} -> {:ok, body}
+      {:ok, resp} -> {:error, {:service_bad_status, resp.status}}
+      {:error, _} = err -> err
+    end
+  end
+end

--- a/lib/camelot/runtime/runner/swarm/self_networks.ex
+++ b/lib/camelot/runtime/runner/swarm/self_networks.ex
@@ -122,11 +122,11 @@ defmodule Camelot.Runtime.Runner.Swarm.SelfNetworks do
     end
   end
 
+  # `:inet.gethostname/0` is typed to always succeed; in a container the
+  # hostname is the short container id (Swarm sets it unless overridden).
   defp own_container_id do
-    case :inet.gethostname() do
-      {:ok, name} -> {:ok, List.to_string(name)}
-      other -> {:error, {:hostname, other}}
-    end
+    {:ok, name} = :inet.gethostname()
+    {:ok, List.to_string(name)}
   end
 
   defp fetch_running_tasks do

--- a/lib/camelot/runtime/runner/swarm/task_service.ex
+++ b/lib/camelot/runtime/runner/swarm/task_service.ex
@@ -426,11 +426,10 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
   # Swarm resolves a service's DNS name (e.g. a CapRover
   # `srv-captain--db`) only for containers on the same overlay
   # network. Task runners land on the default bridge and so can't
-  # reach such hostnames; operators list the overlays to join via the
-  # `RUNNER_NETWORKS` env var (`:runner, :networks` config), or set it
-  # to `auto` to copy the networks the Camelot service is itself on.
-  # Empty is the default and correct for plain-Docker / non-Swarm
-  # self-hosting.
+  # reach such hostnames. The `RUNNER_NETWORKS` env var
+  # (`:runner, :networks` config) controls which overlays they join;
+  # it defaults to `auto` (copy the networks the Camelot service is
+  # itself on). `none` keeps runners isolated.
   defp task_networks do
     case configured_networks() do
       [] -> nil
@@ -441,20 +440,23 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
   defp configured_networks do
     :camelot
     |> Application.get_env(:runner, [])
-    |> Keyword.get(:networks, [])
+    |> Keyword.get(:networks, ["auto"])
     |> resolve_networks()
   end
 
-  # `auto` (from `RUNNER_NETWORKS=auto`) is replaced with the networks
-  # discovered from the Camelot service itself; any explicit entries
-  # alongside it are kept.
+  # `auto` is replaced with the networks discovered from the Camelot
+  # service itself (explicit entries alongside it are kept); `none`
+  # forces isolation regardless of other entries.
   defp resolve_networks(names) do
-    if "auto" in names do
-      Enum.uniq(SelfNetworks.discover() ++ List.delete(names, "auto"))
-    else
-      names
-    end
+    resolve_networks(names, "auto" in names, "none" in names)
   end
+
+  defp resolve_networks(names, true, _none) do
+    Enum.uniq(SelfNetworks.discover() ++ (names -- ["auto", "none"]))
+  end
+
+  defp resolve_networks(_names, false, true), do: []
+  defp resolve_networks(names, false, false), do: names
 
   defp container_spec(%Spec{} = spec) do
     reject_nil(%{

--- a/lib/camelot/runtime/runner/swarm/task_service.ex
+++ b/lib/camelot/runtime/runner/swarm/task_service.ex
@@ -22,6 +22,7 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
   alias Camelot.Board.Task
   alias Camelot.Runtime.Runner.DockerApi
   alias Camelot.Runtime.Runner.Spec
+  alias Camelot.Runtime.Runner.Swarm.SelfNetworks
   alias Camelot.Runtime.SecretSync
 
   require Logger
@@ -426,8 +427,10 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
   # `srv-captain--db`) only for containers on the same overlay
   # network. Task runners land on the default bridge and so can't
   # reach such hostnames; operators list the overlays to join via the
-  # `RUNNER_NETWORKS` env var (`:runner, :networks` config). Empty is
-  # the default and correct for plain-Docker / non-Swarm self-hosting.
+  # `RUNNER_NETWORKS` env var (`:runner, :networks` config), or set it
+  # to `auto` to copy the networks the Camelot service is itself on.
+  # Empty is the default and correct for plain-Docker / non-Swarm
+  # self-hosting.
   defp task_networks do
     case configured_networks() do
       [] -> nil
@@ -439,6 +442,18 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
     :camelot
     |> Application.get_env(:runner, [])
     |> Keyword.get(:networks, [])
+    |> resolve_networks()
+  end
+
+  # `auto` (from `RUNNER_NETWORKS=auto`) is replaced with the networks
+  # discovered from the Camelot service itself; any explicit entries
+  # alongside it are kept.
+  defp resolve_networks(names) do
+    if "auto" in names do
+      Enum.uniq(SelfNetworks.discover() ++ List.delete(names, "auto"))
+    else
+      names
+    end
   end
 
   defp container_spec(%Spec{} = spec) do

--- a/test/camelot/runtime/runner/swarm/self_networks_test.exs
+++ b/test/camelot/runtime/runner/swarm/self_networks_test.exs
@@ -1,0 +1,70 @@
+defmodule Camelot.Runtime.Runner.Swarm.SelfNetworksTest do
+  use ExUnit.Case, async: true
+
+  alias Camelot.Runtime.Runner.Swarm.SelfNetworks
+
+  describe "find_own_service_id/2" do
+    test "matches the task whose full container id is prefixed by the short id" do
+      tasks = [
+        %{"ServiceID" => "svc-other", "Status" => %{"ContainerStatus" => %{"ContainerID" => "aaaa1111zzzz"}}},
+        %{"ServiceID" => "svc-self", "Status" => %{"ContainerStatus" => %{"ContainerID" => "60910a6e58a7deadbeef"}}}
+      ]
+
+      assert SelfNetworks.find_own_service_id(tasks, "60910a6e58a7") == "svc-self"
+    end
+
+    test "returns nil when no container id matches" do
+      tasks = [
+        %{"ServiceID" => "svc-other", "Status" => %{"ContainerStatus" => %{"ContainerID" => "ffffffff"}}}
+      ]
+
+      assert SelfNetworks.find_own_service_id(tasks, "60910a6e58a7") == nil
+    end
+
+    test "returns nil for an empty container id (never matches everything)" do
+      tasks = [%{"ServiceID" => "svc", "Status" => %{"ContainerStatus" => %{"ContainerID" => "abc"}}}]
+
+      assert SelfNetworks.find_own_service_id(tasks, "") == nil
+    end
+
+    test "tolerates tasks missing container status" do
+      tasks = [%{"ServiceID" => "svc"}, %{"ServiceID" => "svc2", "Status" => %{}}]
+
+      assert SelfNetworks.find_own_service_id(tasks, "abc") == nil
+    end
+  end
+
+  describe "targets_from_service/1" do
+    test "extracts the service's own network targets" do
+      service = %{
+        "Spec" => %{
+          "TaskTemplate" => %{
+            "Networks" => [%{"Target" => "netid-1"}, %{"Target" => "netid-2"}]
+          }
+        }
+      }
+
+      assert SelfNetworks.targets_from_service(service) == ["netid-1", "netid-2"]
+    end
+
+    test "returns [] when the service has no networks" do
+      assert SelfNetworks.targets_from_service(%{"Spec" => %{"TaskTemplate" => %{}}}) == []
+      assert SelfNetworks.targets_from_service(%{}) == []
+    end
+
+    test "drops entries without a Target" do
+      service = %{"Spec" => %{"TaskTemplate" => %{"Networks" => [%{"Target" => "ok"}, %{}]}}}
+
+      assert SelfNetworks.targets_from_service(service) == ["ok"]
+    end
+  end
+
+  describe "discover/0 memoization" do
+    test "serves a seeded cache without hitting Docker" do
+      SelfNetworks.put_cache(["cached-net"])
+      on_exit(&SelfNetworks.reset_cache/0)
+
+      assert SelfNetworks.discover() == ["cached-net"]
+    end
+  end
+end

--- a/test/camelot/runtime/runner/swarm/task_service_test.exs
+++ b/test/camelot/runtime/runner/swarm/task_service_test.exs
@@ -3,6 +3,7 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskServiceTest do
   use ExUnit.Case, async: false
 
   alias Camelot.Runtime.Runner.Spec
+  alias Camelot.Runtime.Runner.Swarm.SelfNetworks
   alias Camelot.Runtime.Runner.Swarm.TaskService
 
   setup do
@@ -55,6 +56,29 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskServiceTest do
       assert payload["Name"] == "camelot-task-task-1"
       assert template["RestartPolicy"] == %{"Condition" => "none"}
       assert template["ContainerSpec"]["Image"] == "ghcr.io/example/runner"
+    end
+
+    test "auto resolves to the discovered networks" do
+      SelfNetworks.put_cache(["discovered-net"])
+      on_exit(&SelfNetworks.reset_cache/0)
+      put_networks(["auto"])
+
+      payload = TaskService.service_create_payload(spec(), "camelot-task-task-1")
+
+      assert payload["TaskTemplate"]["Networks"] == [%{"Target" => "discovered-net"}]
+    end
+
+    test "auto merges discovered networks with explicit extras" do
+      SelfNetworks.put_cache(["discovered-net"])
+      on_exit(&SelfNetworks.reset_cache/0)
+      put_networks(["auto", "extra-net"])
+
+      payload = TaskService.service_create_payload(spec(), "camelot-task-task-1")
+
+      assert payload["TaskTemplate"]["Networks"] == [
+               %{"Target" => "discovered-net"},
+               %{"Target" => "extra-net"}
+             ]
     end
   end
 end

--- a/test/camelot/runtime/runner/swarm/task_service_test.exs
+++ b/test/camelot/runtime/runner/swarm/task_service_test.exs
@@ -28,8 +28,16 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskServiceTest do
   end
 
   describe "service_create_payload/2 — networks" do
-    test "omits Networks when none are configured" do
+    test "omits Networks when the list is empty" do
       put_networks([])
+
+      payload = TaskService.service_create_payload(spec(), "camelot-task-task-1")
+
+      refute Map.has_key?(payload["TaskTemplate"], "Networks")
+    end
+
+    test "none keeps runners isolated (no Networks)" do
+      put_networks(["none"])
 
       payload = TaskService.service_create_payload(spec(), "camelot-task-task-1")
 


### PR DESCRIPTION
## Motivation

Follow-up to #37. That PR let operators attach runners to an overlay via `RUNNER_NETWORKS=<name>`, but the name had to be known and set by hand — and on the test cluster it was simply never configured, so runners stayed bridge-only and hit `nxdomain` reaching `srv-captain--db`.

A runner needs to reach exactly what **Camelot itself** reaches. So discover that automatically, and make it the **default**.

## Behavior

`RUNNER_NETWORKS` controls which overlays runner services join:

| Value | What happens |
|---|---|
| *(unset)* / `auto` | **Default.** Copy the overlay network(s) the Camelot service is itself on onto each runner. |
| `net-a,net-b` | Explicit names/IDs. Combine with `auto` (`auto,net-a`) to add to the discovered set. |
| `none` | Keep runners isolated — bridge only. |

## Discovery (`SelfNetworks.discover/0`)

1. own container id ← container hostname (Swarm sets it to the short id);
2. `GET /tasks` → the running task whose `ContainerID` is prefixed by that id → its `ServiceID`;
3. `GET /services/<id>` → copy that service's `TaskTemplate.Networks`.

Both endpoints are already in the socket-proxy allow-list (`TASKS`, `SERVICES`). Verified live: the app task resolves to `captain-overlay-network`, exactly what runners need.

**Robustness:**
- Non-empty results memoized in `:persistent_term` (own attachments only change on a redeploy, which restarts the app).
- Failures/empties are **not** cached and **fail soft** — runners start with no extra network + a warning, never blocking creation. So on plain-Docker / non-Swarm self-hosting, `auto` is a harmless no-op.

**Security note (in the docs):** `auto` places runners on the control-plane overlay, so they can reach Camelot's own DB and sibling services. `RUNNER_NETWORKS=none` (or a dedicated isolated overlay) opts out.

## Tests & docs

- `self_networks_test.exs` — pure discovery logic (container-id prefix match incl. empty-id/missing-status guards; target extraction; memoization via seeded cache).
- `task_service_test.exs` — `auto` → discovered networks; `auto,extra` merge; `none` and empty → isolated (no `Networks` key).
- `docs/cluster-runners.md` — value table, default, security note, checklist updated.
- `mix format`, `mix compile --warnings-as-errors`, `mix credo` (clean), full `mix test` (210, 0 failures).

## Deploying

No env change needed — new runners auto-join Camelot's overlay and resolve `srv-captain--db`. Existing runner services predate the change and need recreating. Set `RUNNER_NETWORKS=none` to restore the old isolated behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)