### PR TITLE
fix(runner): capture plan/question via --json-schema, not ExitPlanMode

### DIFF
--- a/docs/planning-output-contract.md
+++ b/docs/planning-output-contract.md
@@ -1,0 +1,70 @@
+# Planning output contract
+
+How Camelot captures a **plan** or a **clarifying question** from a
+headless Claude Code planning run.
+
+## Why a contract is needed
+
+The runner's Claude Code is a ToolSearch/deferred-tools build. In headless
+mode (`-p --output-format stream-json --permission-mode plan`) the
+`system/init` event's tool registry does **not** contain `ExitPlanMode`
+or `EnterPlanMode`. The original design — "the agent calls `ExitPlanMode`,
+headless denies it, and we recover the plan from the denial's
+`tool_input.plan`" — therefore never fires. Worse, the final
+`type:"result"` event's `result` field is only the agent's **last
+assistant turn** (often a throwaway sentence such as *"I'll wait for your
+decision…"*), so a plan or question raised in an earlier turn is lost.
+
+The symptom: a task sits in `planning / waiting_for_input` with a
+meaningless `plan` and **no `TaskMessage`**, so the UI shows a plan-approval
+card with nothing useful and no question.
+
+## The contract
+
+Planning runs pass `--json-schema` (see `priv/repo/seeds.exs`,
+`claude_code` template, `permission_args_by_stage["planning"]`). This
+injects a `StructuredOutput` tool that **coexists with the normal
+read-only investigation tools** (Bash, Read, Edit, WebFetch, Task,
+ToolSearch, …). The agent explores the repo, then delivers its result by
+calling `StructuredOutput` with:
+
+```json
+{
+  "decision": "plan" | "question",
+  "plan": "…full Markdown plan…",        // when decision = "plan"
+  "questions": ["…", "…"]                 // when decision = "question"
+}
+```
+
+An `--append-system-prompt` reinforces the rule: *never ask questions as
+plain assistant text; always use `StructuredOutput`.*
+
+## How it is parsed
+
+For a `--json-schema` run, the final `type:"result"` event carries the
+validated object under **`structured_output`** (and the same payload as a
+JSON string under `result`). `Camelot.Runtime.OutputParser` surfaces it as
+`parsed.structured`, and also exposes `parsed.assistant_texts` — every
+top-level assistant turn — as a fallback source of truth.
+
+`Camelot.Runtime.AgentProcess.planning_action/2` routes, in precedence:
+
+1. `structured.decision == "plan"` → `submit_plan/3` with the full plan.
+2. `structured.decision == "question"` → `request_user_input/3`, which
+   always writes a `TaskMessage` so the UI can show the question.
+3. Legacy `ExitPlanMode` denial (kept as a fallback).
+4. Tool-permission denials → request input.
+5. A free-text question detected across the **full** transcript.
+6. Empty output → task error.
+7. Otherwise → treat the full transcript as the plan.
+
+## Invariants
+
+- A question path always persists a `TaskMessage` with the real text.
+- A plan path always stores the full plan, never a trailing sentence.
+
+## Scope
+
+Only the `planning` stage uses `--json-schema`. The `executing` and `pr`
+stages produce free text (a PR URL) and must not be forced into structured
+output; they still detect `AskUserQuestion` denials to route questions.

--- a/lib/camelot/agents/claude_code_defaults.ex
+++ b/lib/camelot/agents/claude_code_defaults.ex
@@ -1,0 +1,78 @@
+defmodule Camelot.Agents.ClaudeCodeDefaults do
+  @moduledoc """
+  Canonical CLI defaults for the built-in `claude_code` agent template.
+
+  Single source of truth for the planning-stage structured-output
+  contract so the seed script, the data migration, and the regression
+  tests never drift. See `docs/planning-output-contract.md`.
+  """
+
+  @planning_system_prompt "You are in planning mode: investigate the " <>
+                            "repository read-only, then deliver your result " <>
+                            "by calling the StructuredOutput tool. Set " <>
+                            ~s(decision="plan" with a complete Markdown plan ) <>
+                            "when you are ready for approval, or " <>
+                            ~s(decision="question" with specific questions ) <>
+                            "when you need input or a decision before " <>
+                            "planning can complete. Never ask questions as " <>
+                            "plain assistant text; always use StructuredOutput."
+
+  @doc "System prompt appended to the planning run."
+  @spec planning_system_prompt() :: String.t()
+  def planning_system_prompt, do: @planning_system_prompt
+
+  @doc """
+  JSON Schema (encoded string) passed as `--json-schema` for planning.
+
+  The runner's Claude Code omits `ExitPlanMode` from the headless tool
+  registry, so the plan/question is delivered via the injected
+  `StructuredOutput` tool instead.
+  """
+  @spec planning_json_schema() :: String.t()
+  def planning_json_schema do
+    Jason.encode!(%{
+      "type" => "object",
+      "properties" => %{
+        "decision" => %{
+          "type" => "string",
+          "enum" => ["plan", "question"],
+          "description" =>
+            ~s(Use "plan" when you have a complete implementation plan ) <>
+              ~s(ready for approval. Use "question" when you need input, a ) <>
+              ~s(decision, or clarification from the user before the plan ) <>
+              ~s(can be finalized.)
+        },
+        "plan" => %{
+          "type" => "string",
+          "description" =>
+            ~s(The full implementation plan in Markdown. Required when ) <>
+              ~s(decision is "plan".)
+        },
+        "questions" => %{
+          "type" => "array",
+          "items" => %{"type" => "string"},
+          "description" =>
+            ~s(One clarifying question per item. Required when decision ) <>
+              ~s(is "question".)
+        }
+      },
+      "required" => ["decision"]
+    })
+  end
+
+  @doc "Per-stage permission/CLI args for the `claude_code` template."
+  @spec permission_args_by_stage() :: %{optional(String.t()) => [String.t()]}
+  def permission_args_by_stage do
+    %{
+      "planning" => [
+        "--permission-mode",
+        "plan",
+        "--append-system-prompt",
+        planning_system_prompt(),
+        "--json-schema",
+        planning_json_schema()
+      ],
+      "executing" => ["--permission-mode", "acceptEdits"]
+    }
+  end
+end

--- a/lib/camelot/runtime/agent_process.ex
+++ b/lib/camelot/runtime/agent_process.ex
@@ -687,37 +687,46 @@ defmodule Camelot.Runtime.AgentProcess do
          true <- exit_code == 0 and state.output_buffer != "",
          task = Ash.get!(Task, task_id),
          :in_progress <- task.state do
-      denials = extract_denials(parsed)
-
-      result_text =
-        case parsed do
-          {:ok, %{result_text: text}} -> text
-          {:error, _} -> state.output_buffer
-        end
-
-      handle_task_result(state, task, result_text, denials, task.id)
+      handle_task_result(state, task, build_result(state, parsed), task.id)
     else
       _ -> :ok
     end
   end
 
-  defp handle_task_result(state, %{stage: :planning} = task, text, denials, task_id) do
-    plan_from_exit = extract_exit_plan(denials)
-    real_denials = reject_internal_denials(state, denials)
-    trimmed = String.trim(text || "")
+  # Normalises the parser output into the shape the stage handlers
+  # consume. `text` is the final result field (used for PR-URL scraping);
+  # `assistant_texts` is every top-level assistant turn (used when the
+  # plan/question lives in an earlier turn); `structured` is the
+  # `--json-schema` payload; `denials` the permission denials.
+  defp build_result(_state, {:ok, parsed}) do
+    %{
+      text: parsed.result_text,
+      structured: parsed.structured,
+      assistant_texts: parsed.assistant_texts,
+      denials: parsed.permission_denials
+    }
+  end
 
-    cond do
-      plan_from_exit != nil ->
-        submit_plan(task, plan_from_exit, task_id)
+  defp build_result(state, {:error, _}) do
+    %{text: state.output_buffer, structured: nil, assistant_texts: [], denials: []}
+  end
 
-      has_questions?(real_denials) or real_denials != [] ->
-        input = if trimmed == "", do: "Agent needs tool permissions", else: trimmed
-        request_user_input(task, input, task_id)
+  # Planning routes on the `--json-schema` decision first (the reliable
+  # path: the agent emits `StructuredOutput` with {decision, plan,
+  # questions}). Everything below is a fallback for runs without a
+  # structured payload — legacy ExitPlanMode, tool-permission denials, or
+  # free text — and reads the FULL assistant transcript so a plan or
+  # question raised in an earlier turn is never lost to the trailing
+  # result sentence.
+  defp handle_task_result(state, %{stage: :planning} = task, result, task_id) do
+    case planning_action(state, result) do
+      {:submit_plan, plan} ->
+        submit_plan(task, plan, task_id)
 
-      question?(state, trimmed) ->
-        request_user_input(task, trimmed, task_id)
+      {:request_input, text} ->
+        request_user_input(task, text, task_id)
 
-      trimmed == "" ->
+      :empty ->
         Logger.warning("Empty plan for task #{task_id}, marking error")
 
         mark_error_with_reason(
@@ -725,33 +734,120 @@ defmodule Camelot.Runtime.AgentProcess do
           task,
           "Agent finished planning without producing a plan."
         )
+    end
+  end
+
+  defp handle_task_result(state, %{stage: :executing} = task, result, task_id) do
+    real_denials = reject_internal_denials(state, result.denials)
+
+    cond do
+      questions = structured_questions(result.structured) ->
+        request_user_input(task, questions, task_id)
+
+      has_questions?(real_denials) or real_denials != [] ->
+        request_user_input(task, result.text, task_id)
 
       true ->
-        submit_plan(task, text, task_id)
+        maybe_create_pr(state, task, result.text, task_id)
     end
   end
 
-  defp handle_task_result(state, %{stage: :executing} = task, text, denials, task_id) do
-    real_denials = reject_internal_denials(state, denials)
+  defp handle_task_result(state, %{stage: :pr} = task, result, task_id) do
+    real_denials = reject_internal_denials(state, result.denials)
 
-    if has_questions?(real_denials) or real_denials != [] do
-      request_user_input(task, text, task_id)
-    else
-      maybe_create_pr(state, task, text, task_id)
+    cond do
+      questions = structured_questions(result.structured) ->
+        request_user_input(task, questions, task_id)
+
+      has_questions?(real_denials) or real_denials != [] ->
+        request_user_input(task, result.text, task_id)
+
+      true ->
+        transition(task, :request_input)
     end
   end
 
-  defp handle_task_result(state, %{stage: :pr} = task, text, denials, task_id) do
-    real_denials = reject_internal_denials(state, denials)
+  defp handle_task_result(_state, _task, _result, _task_id), do: :ok
 
-    if has_questions?(real_denials) or real_denials != [] do
-      request_user_input(task, text, task_id)
-    else
-      transition(task, :request_input)
+  @doc """
+  Decides the planning-stage outcome from a parsed runner result.
+
+  Pure (no DB writes) so the routing can be unit-tested. Precedence:
+  the `--json-schema` structured decision, then legacy ExitPlanMode,
+  then tool-permission denials, then a free-text question, then a
+  plain plan; an empty result yields `:empty`.
+  """
+  @spec planning_action(t(), map()) ::
+          {:submit_plan, String.t()}
+          | {:request_input, String.t()}
+          | :empty
+  def planning_action(state, result) do
+    structured_action(result.structured) ||
+      fallback_action(state, result)
+  end
+
+  # The reliable path: a `--json-schema` decision.
+  defp structured_action(structured) do
+    cond do
+      plan = structured_plan(structured) -> {:submit_plan, plan}
+      questions = structured_questions(structured) -> {:request_input, questions}
+      true -> nil
     end
   end
 
-  defp handle_task_result(_state, _task, _text, _denials, _task_id), do: :ok
+  # No structured payload: recover from a legacy ExitPlanMode denial,
+  # tool-permission denials, or the free-text transcript.
+  defp fallback_action(state, result) do
+    real_denials = reject_internal_denials(state, result.denials)
+    full_text = planning_text(result)
+    plan_from_exit = extract_exit_plan(result.denials)
+
+    cond do
+      plan_from_exit != nil ->
+        {:submit_plan, plan_from_exit}
+
+      has_questions?(real_denials) or real_denials != [] ->
+        {:request_input, if(full_text == "", do: "Agent needs tool permissions", else: full_text)}
+
+      question?(state, full_text) ->
+        {:request_input, full_text}
+
+      full_text == "" ->
+        :empty
+
+      true ->
+        {:submit_plan, full_text}
+    end
+  end
+
+  # Prefer the full assistant transcript (all top-level turns) over the
+  # trailing result field, which is only the last turn.
+  defp planning_text(%{assistant_texts: [_ | _] = texts}) do
+    texts |> Enum.join("\n\n") |> String.trim()
+  end
+
+  defp planning_text(%{text: text}), do: String.trim(text || "")
+
+  # A structured "plan" decision carries the full plan text; return it
+  # only when non-empty so the caller can fall through otherwise.
+  defp structured_plan(%{"decision" => "plan", "plan" => plan}) when is_binary(plan) do
+    case String.trim(plan) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp structured_plan(_), do: nil
+
+  # A structured "question" decision carries a list of questions; render
+  # them as a single message for the TaskMessage / UI.
+  defp structured_questions(%{"decision" => "question", "questions" => qs}) when is_list(qs) and qs != [] do
+    qs
+    |> Enum.map(&to_string/1)
+    |> Enum.map_join("\n", &("- " <> &1))
+  end
+
+  defp structured_questions(_), do: nil
 
   defp maybe_create_pr(state, task, text, task_id) do
     {pr_url, pr_number} = extract_pr_info(state, text)

--- a/lib/camelot/runtime/output_parser.ex
+++ b/lib/camelot/runtime/output_parser.ex
@@ -21,7 +21,9 @@ defmodule Camelot.Runtime.OutputParser do
           result_text: String.t(),
           cost_usd: float() | nil,
           duration_ms: integer() | nil,
-          permission_denials: [permission_denial()]
+          permission_denials: [permission_denial()],
+          structured: map() | nil,
+          assistant_texts: [String.t()]
         }
 
   @spec parse(parser(), String.t()) ::
@@ -32,7 +34,9 @@ defmodule Camelot.Runtime.OutputParser do
        result_text: buffer,
        cost_usd: nil,
        duration_ms: nil,
-       permission_denials: []
+       permission_denials: [],
+       structured: nil,
+       assistant_texts: []
      }}
   end
 
@@ -42,28 +46,59 @@ defmodule Camelot.Runtime.OutputParser do
 
   def parse(:claude_code_json, buffer) do
     case extract_json(buffer) do
-      {:ok, %{"is_error" => true, "result" => message}} when is_binary(message) ->
-        {:error, "claude error: " <> message}
-
-      {:ok, %{"result" => result} = data} ->
-        denials = parse_denials(data["permission_denials"])
-        {result_text, denials} = maybe_extract_plan(result, denials)
-
-        {:ok,
-         %{
-           result_text: result_text,
-           cost_usd: data["cost_usd"] || data["total_cost_usd"],
-           duration_ms: data["duration_ms"],
-           permission_denials: denials
-         }}
-
-      {:ok, _} ->
-        {:error, "unexpected JSON structure"}
-
-      :error ->
-        {:error, "no JSON object found in output"}
+      {result, objects} -> from_result(result, objects)
+      :error -> {:error, "no JSON object found in output"}
     end
   end
+
+  defp from_result(%{"is_error" => true, "result" => message}, _objects) when is_binary(message) do
+    {:error, "claude error: " <> message}
+  end
+
+  defp from_result(%{"result" => result} = data, objects) do
+    denials = parse_denials(data["permission_denials"])
+    {result_text, denials} = maybe_extract_plan(result, denials)
+
+    {:ok,
+     %{
+       result_text: result_text,
+       cost_usd: data["cost_usd"] || data["total_cost_usd"],
+       duration_ms: data["duration_ms"],
+       permission_denials: denials,
+       structured: structured_output(data),
+       assistant_texts: assistant_texts(objects)
+     }}
+  end
+
+  defp from_result(_data, _objects), do: {:error, "unexpected JSON structure"}
+
+  # `--json-schema` runs force a `StructuredOutput` tool call; the result
+  # event then carries the validated object under `structured_output`
+  # (the `result` field holds the same payload as a JSON string).
+  defp structured_output(%{"structured_output" => %{} = s}), do: s
+  defp structured_output(_), do: nil
+
+  # Every top-level assistant text block, in stream order. The final
+  # `result` field is only the LAST assistant turn — often a trailing
+  # meta-sentence — so callers that need the full picture (e.g. a plan or
+  # a question emitted in an earlier turn) read these instead. Sub-agent
+  # turns (non-nil `parent_tool_use_id`) are skipped.
+  defp assistant_texts(objects) do
+    objects
+    |> Enum.filter(&(assistant_event?(&1) and top_level?(&1)))
+    |> Enum.flat_map(&text_blocks/1)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp assistant_event?(%{"type" => "assistant"}), do: true
+  defp assistant_event?(_), do: false
+
+  defp text_blocks(%{"message" => %{"content" => content}}) when is_list(content) do
+    for %{"type" => "text", "text" => text} <- content, is_binary(text), do: text
+  end
+
+  defp text_blocks(_), do: []
 
   # Tries the whole buffer first (fast path for a single-object
   # `--output-format json` result), then falls back to scanning the
@@ -71,9 +106,12 @@ defmodule Camelot.Runtime.OutputParser do
   # before the CLI output and terminal escape codes after, so a
   # whole-buffer decode often fails even though valid JSON lines are
   # in there.
+  #
+  # Returns `{result_object, all_objects}` so callers can read both the
+  # chosen result event and every decoded event (for `assistant_texts`).
   defp extract_json(buffer) do
     case Jason.decode(String.trim(buffer)) do
-      {:ok, data} -> {:ok, data}
+      {:ok, data} -> {data, [data]}
       {:error, _} -> extract_json_from_lines(buffer)
     end
   end
@@ -93,6 +131,12 @@ defmodule Camelot.Runtime.OutputParser do
     pick_object(last_result_event(objects), objects)
   end
 
+  # Pair the chosen result object with the full object list; `:error`
+  # (no decodable object at all) propagates unchanged.
+  defp pick_object(nil, []), do: :error
+  defp pick_object(nil, objects), do: {List.last(objects), objects}
+  defp pick_object(result, objects), do: {result, objects}
+
   # A resumed session — the agent yields to a background sub-agent, then
   # wakes on a task-notification — runs as several `claude` invocations
   # concatenated into one log, each emitting its own `type: "result"`
@@ -106,10 +150,6 @@ defmodule Camelot.Runtime.OutputParser do
     |> Enum.filter(&(result_event?(&1) and top_level?(&1)))
     |> List.last()
   end
-
-  defp pick_object(nil, []), do: :error
-  defp pick_object(nil, objects), do: {:ok, List.last(objects)}
-  defp pick_object(result, _objects), do: {:ok, result}
 
   defp result_event?(%{"type" => "result"}), do: true
   defp result_event?(_), do: false

--- a/priv/repo/migrations/20260709120000_claude_planning_json_schema.exs
+++ b/priv/repo/migrations/20260709120000_claude_planning_json_schema.exs
@@ -1,0 +1,47 @@
+defmodule Camelot.Repo.Migrations.ClaudePlanningJsonSchema do
+  @moduledoc """
+  Move the seeded `claude_code` template's planning stage onto the
+  `--json-schema` structured-output contract. The runner's Claude Code
+  (ToolSearch build) omits `ExitPlanMode` from the headless tool
+  registry, so the plan/question is delivered via the injected
+  `StructuredOutput` tool instead. See docs/planning-output-contract.md.
+
+  Only rewrites rows still carrying the exact old value so a
+  hand-customised template is left untouched.
+  """
+  use Ecto.Migration
+
+  alias Camelot.Agents.ClaudeCodeDefaults
+
+  # Only the planning key is rewritten (via jsonb_set), so `executing`
+  # and any hand-customised stages are preserved. Idempotent: guarded on
+  # whether the planning args already carry the `--json-schema` flag,
+  # rather than an exact-value match.
+  def up do
+    new_planning = Jason.encode!(ClaudeCodeDefaults.permission_args_by_stage()["planning"])
+
+    repo().query!(
+      """
+      UPDATE agent_templates
+      SET permission_args_by_stage =
+        jsonb_set(permission_args_by_stage, '{planning}', $1::text::jsonb)
+      WHERE slug = 'claude_code'
+        AND NOT (permission_args_by_stage -> 'planning' @> '["--json-schema"]'::jsonb)
+      """,
+      [new_planning]
+    )
+  end
+
+  def down do
+    repo().query!(
+      """
+      UPDATE agent_templates
+      SET permission_args_by_stage =
+        jsonb_set(permission_args_by_stage, '{planning}', '["--permission-mode","plan"]'::jsonb)
+      WHERE slug = 'claude_code'
+        AND permission_args_by_stage -> 'planning' @> '["--json-schema"]'::jsonb
+      """,
+      []
+    )
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -32,26 +32,85 @@ question_phrases = [
 
 existing_templates = Ash.read!(AgentTemplate)
 
-if !Enum.any?(existing_templates, &(&1.slug == "claude_code")) do
-  Ash.create!(AgentTemplate, %{
-    slug: "claude_code",
-    name: "Claude Code",
-    executable: "claude",
-    base_args: ["--output-format", "stream-json", "--verbose"],
-    prompt_flag: "-p",
-    tools_flag: "--allowedTools",
-    tools_separator: ",",
-    permission_args_by_stage: %{
-      "planning" => ["--permission-mode", "plan"],
-      "executing" => ["--permission-mode", "acceptEdits"]
+# Planning delivers a machine-readable decision via the CLI's
+# `--json-schema` structured-output contract. The runner's Claude Code
+# (ToolSearch build) does NOT expose ExitPlanMode in the headless tool
+# registry, so the plan/question can't be recovered from a tool denial;
+# instead the agent must emit this object via the injected
+# `StructuredOutput` tool, which the parser reads from the result event's
+# `structured_output` field. See docs/planning-output-contract.md.
+planning_schema =
+  Jason.encode!(%{
+    "type" => "object",
+    "properties" => %{
+      "decision" => %{
+        "type" => "string",
+        "enum" => ["plan", "question"],
+        "description" =>
+          ~s(Use "plan" when you have a complete implementation plan ) <>
+            ~s(ready for approval. Use "question" when you need input, a ) <>
+            ~s(decision, or clarification from the user before the plan ) <>
+            ~s(can be finalized.)
+      },
+      "plan" => %{
+        "type" => "string",
+        "description" =>
+          ~s(The full implementation plan in Markdown. Required when ) <>
+            ~s(decision is "plan".)
+      },
+      "questions" => %{
+        "type" => "array",
+        "items" => %{"type" => "string"},
+        "description" =>
+          ~s(One clarifying question per item. Required when decision ) <>
+            ~s(is "question".)
+      }
     },
-    internal_tools: ["EnterPlanMode", "ExitPlanMode"],
-    env_vars: %{"CLAUDECODE" => "false"},
-    parser: :claude_code_json,
-    pr_url_pattern: pr_url_pattern,
-    question_phrases: question_phrases,
-    base_retry_delay_ms: 5_000
+    "required" => ["decision"]
   })
+
+planning_system_prompt =
+  ~s(You are in planning mode: investigate the repository read-only, ) <>
+    ~s(then deliver your result by calling the StructuredOutput tool. ) <>
+    ~s(Set decision="plan" with a complete Markdown plan when you are ) <>
+    ~s(ready for approval, or decision="question" with specific ) <>
+    ~s(questions when you need input or a decision before planning can ) <>
+    ~s(complete. Never ask questions as plain assistant text; always ) <>
+    ~s(use StructuredOutput.)
+
+claude_code_attrs = %{
+  name: "Claude Code",
+  executable: "claude",
+  base_args: ["--output-format", "stream-json", "--verbose"],
+  prompt_flag: "-p",
+  tools_flag: "--allowedTools",
+  tools_separator: ",",
+  permission_args_by_stage: %{
+    "planning" => [
+      "--permission-mode",
+      "plan",
+      "--append-system-prompt",
+      planning_system_prompt,
+      "--json-schema",
+      planning_schema
+    ],
+    "executing" => ["--permission-mode", "acceptEdits"]
+  },
+  internal_tools: ["EnterPlanMode", "ExitPlanMode"],
+  env_vars: %{"CLAUDECODE" => "false"},
+  parser: :claude_code_json,
+  pr_url_pattern: pr_url_pattern,
+  question_phrases: question_phrases,
+  base_retry_delay_ms: 5_000
+}
+
+case Enum.find(existing_templates, &(&1.slug == "claude_code")) do
+  nil ->
+    Ash.create!(AgentTemplate, Map.put(claude_code_attrs, :slug, "claude_code"))
+
+  template ->
+    # Reconcile existing installs onto the structured-output contract.
+    Ash.update!(template, claude_code_attrs)
 end
 
 if !Enum.any?(existing_templates, &(&1.slug == "codex")) do

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -11,6 +11,7 @@
 # and so on) as they will fail if something goes wrong.
 
 alias Camelot.Agents.AgentTemplate
+alias Camelot.Agents.ClaudeCodeDefaults
 alias Camelot.Prompts.PromptTemplate
 
 pr_url_pattern = "https://github\\.com/[^\\s]+/pull/(\\d+)"
@@ -33,51 +34,12 @@ question_phrases = [
 existing_templates = Ash.read!(AgentTemplate)
 
 # Planning delivers a machine-readable decision via the CLI's
-# `--json-schema` structured-output contract. The runner's Claude Code
+# `--json-schema` structured-output contract (see
+# `Camelot.Agents.ClaudeCodeDefaults` and
+# docs/planning-output-contract.md). The runner's Claude Code
 # (ToolSearch build) does NOT expose ExitPlanMode in the headless tool
 # registry, so the plan/question can't be recovered from a tool denial;
-# instead the agent must emit this object via the injected
-# `StructuredOutput` tool, which the parser reads from the result event's
-# `structured_output` field. See docs/planning-output-contract.md.
-planning_schema =
-  Jason.encode!(%{
-    "type" => "object",
-    "properties" => %{
-      "decision" => %{
-        "type" => "string",
-        "enum" => ["plan", "question"],
-        "description" =>
-          ~s(Use "plan" when you have a complete implementation plan ) <>
-            ~s(ready for approval. Use "question" when you need input, a ) <>
-            ~s(decision, or clarification from the user before the plan ) <>
-            ~s(can be finalized.)
-      },
-      "plan" => %{
-        "type" => "string",
-        "description" =>
-          ~s(The full implementation plan in Markdown. Required when ) <>
-            ~s(decision is "plan".)
-      },
-      "questions" => %{
-        "type" => "array",
-        "items" => %{"type" => "string"},
-        "description" =>
-          ~s(One clarifying question per item. Required when decision ) <>
-            ~s(is "question".)
-      }
-    },
-    "required" => ["decision"]
-  })
-
-planning_system_prompt =
-  ~s(You are in planning mode: investigate the repository read-only, ) <>
-    ~s(then deliver your result by calling the StructuredOutput tool. ) <>
-    ~s(Set decision="plan" with a complete Markdown plan when you are ) <>
-    ~s(ready for approval, or decision="question" with specific ) <>
-    ~s(questions when you need input or a decision before planning can ) <>
-    ~s(complete. Never ask questions as plain assistant text; always ) <>
-    ~s(use StructuredOutput.)
-
+# instead the agent emits it via the injected `StructuredOutput` tool.
 claude_code_attrs = %{
   name: "Claude Code",
   executable: "claude",
@@ -85,17 +47,7 @@ claude_code_attrs = %{
   prompt_flag: "-p",
   tools_flag: "--allowedTools",
   tools_separator: ",",
-  permission_args_by_stage: %{
-    "planning" => [
-      "--permission-mode",
-      "plan",
-      "--append-system-prompt",
-      planning_system_prompt,
-      "--json-schema",
-      planning_schema
-    ],
-    "executing" => ["--permission-mode", "acceptEdits"]
-  },
+  permission_args_by_stage: ClaudeCodeDefaults.permission_args_by_stage(),
   internal_tools: ["EnterPlanMode", "ExitPlanMode"],
   env_vars: %{"CLAUDECODE" => "false"},
   parser: :claude_code_json,

--- a/test/camelot/runtime/agent_config_test.exs
+++ b/test/camelot/runtime/agent_config_test.exs
@@ -7,6 +7,7 @@ defmodule Camelot.Runtime.AgentConfigTest do
   """
   use Camelot.DataCase, async: true
 
+  alias Camelot.Agents.ClaudeCodeDefaults
   alias Camelot.Projects.Project
   alias Camelot.Runtime.AgentConfig
 
@@ -18,7 +19,7 @@ defmodule Camelot.Runtime.AgentConfigTest do
   end
 
   describe "build_cli_args/4 — claude_code parity with hardcoded logic" do
-    test "planning stage emits --permission-mode plan", ctx do
+    test "planning stage emits the structured-output contract", ctx do
       args =
         AgentConfig.build_cli_args(
           ctx.claude,
@@ -27,17 +28,17 @@ defmodule Camelot.Runtime.AgentConfigTest do
           :planning
         )
 
-      assert args == [
-               "--output-format",
-               "stream-json",
-               "--verbose",
-               "--permission-mode",
-               "plan",
-               "--allowedTools",
-               "Read,Write",
-               "-p",
-               "do the thing"
-             ]
+      planning_args = ClaudeCodeDefaults.permission_args_by_stage()["planning"]
+
+      assert args ==
+               ["--output-format", "stream-json", "--verbose"] ++
+                 planning_args ++
+                 ["--allowedTools", "Read,Write", "-p", "do the thing"]
+
+      # Guard the contract shape explicitly.
+      assert "--permission-mode" in args
+      assert "plan" in args
+      assert "--json-schema" in args
     end
 
     test "executing stage emits --permission-mode acceptEdits", ctx do

--- a/test/camelot/runtime/agent_process_test.exs
+++ b/test/camelot/runtime/agent_process_test.exs
@@ -182,4 +182,101 @@ defmodule Camelot.Runtime.AgentProcessTest do
       assert msg =~ "ehostunreach"
     end
   end
+
+  describe "planning_action/2" do
+    defp planning_state do
+      %AgentProcess{
+        agent_id: "a",
+        config: %AgentConfig{
+          parser: :claude_code_json,
+          executable: "claude",
+          internal_tools: ["ExitPlanMode", "EnterPlanMode"],
+          question_phrases: ["waiting for", "could you"]
+        }
+      }
+    end
+
+    defp result(overrides) do
+      Map.merge(
+        %{text: "", structured: nil, assistant_texts: [], denials: []},
+        Map.new(overrides)
+      )
+    end
+
+    test "structured decision=plan submits the plan text" do
+      structured = %{"decision" => "plan", "plan" => "Step 1\nStep 2"}
+
+      assert {:submit_plan, "Step 1\nStep 2"} =
+               AgentProcess.planning_action(
+                 planning_state(),
+                 result(structured: structured)
+               )
+    end
+
+    test "structured decision=question routes to input with rendered questions" do
+      structured = %{
+        "decision" => "question",
+        "questions" => ["Which DB?", "Which env?"]
+      }
+
+      assert {:request_input, text} =
+               AgentProcess.planning_action(
+                 planning_state(),
+                 result(structured: structured)
+               )
+
+      assert text == "- Which DB?\n- Which env?"
+    end
+
+    test "structured takes precedence over a trailing result sentence" do
+      # Reproduces the original bug: the trailing turn is a throwaway
+      # sentence, but the structured payload carries the real question.
+      structured = %{"decision" => "question", "questions" => ["Which DB?"]}
+
+      res =
+        result(
+          structured: structured,
+          text: "I'll wait for your decision before finalizing.",
+          assistant_texts: ["...long question...", "I'll wait for your decision."]
+        )
+
+      assert {:request_input, "- Which DB?"} =
+               AgentProcess.planning_action(planning_state(), res)
+    end
+
+    test "without structured output, a free-text question routes to input" do
+      res =
+        result(
+          text: "Short trailing note.",
+          assistant_texts: [
+            "I need input: could you confirm the database name?",
+            "Short trailing note."
+          ]
+        )
+
+      assert {:request_input, text} =
+               AgentProcess.planning_action(planning_state(), res)
+
+      # Uses the FULL transcript, not just the trailing sentence.
+      assert text =~ "could you confirm the database name"
+    end
+
+    test "without structured output, plain text becomes the plan" do
+      res = result(assistant_texts: ["Here is the concrete implementation plan."])
+
+      assert {:submit_plan, "Here is the concrete implementation plan."} =
+               AgentProcess.planning_action(planning_state(), res)
+    end
+
+    test "empty output yields :empty" do
+      assert :empty = AgentProcess.planning_action(planning_state(), result([]))
+    end
+
+    test "a non-internal permission denial routes to input" do
+      res = result(denials: [%{"tool_name" => "Bash", "tool_input" => %{}}])
+
+      assert {:request_input, _} =
+               AgentProcess.planning_action(planning_state(), res)
+    end
+  end
 end

--- a/test/camelot/runtime/output_parser_test.exs
+++ b/test/camelot/runtime/output_parser_test.exs
@@ -66,6 +66,28 @@ defmodule Camelot.Runtime.OutputParserTest do
       assert {:error, "unexpected JSON structure"} =
                OutputParser.parse(:claude_code_json, buffer)
     end
+
+    test "surfaces structured_output from a --json-schema result" do
+      buffer =
+        Jason.encode!(%{
+          "result" => ~s({"decision":"plan","plan":"Do the thing"}),
+          "structured_output" => %{
+            "decision" => "plan",
+            "plan" => "Do the thing"
+          },
+          "is_error" => false
+        })
+
+      assert {:ok, parsed} = OutputParser.parse(:claude_code_json, buffer)
+      assert parsed.structured == %{"decision" => "plan", "plan" => "Do the thing"}
+    end
+
+    test "structured is nil when absent" do
+      buffer = Jason.encode!(%{"result" => "plain text"})
+
+      assert {:ok, %{structured: nil}} =
+               OutputParser.parse(:claude_code_json, buffer)
+    end
   end
 
   describe "parse/2 with :claude_code_json — stream-json (NDJSON)" do
@@ -184,6 +206,70 @@ defmodule Camelot.Runtime.OutputParserTest do
       assert {:ok, %{result_text: "session result"}} =
                OutputParser.parse(:claude_code_json, buffer)
     end
+
+    test "collects all top-level assistant text blocks" do
+      buffer =
+        Enum.map_join(
+          [
+            %{"type" => "system", "subtype" => "init"},
+            %{
+              "type" => "assistant",
+              "parent_tool_use_id" => nil,
+              "message" => %{"content" => [%{"type" => "text", "text" => "Here is my question with options."}]}
+            },
+            %{
+              "type" => "assistant",
+              "parent_tool_use_id" => "toolu_sub",
+              "message" => %{"content" => [%{"type" => "text", "text" => "sub-agent chatter"}]}
+            },
+            %{
+              "type" => "assistant",
+              "parent_tool_use_id" => nil,
+              "message" => %{"content" => [%{"type" => "text", "text" => "I'll wait for your decision."}]}
+            },
+            %{"type" => "result", "is_error" => false, "result" => "I'll wait for your decision."}
+          ],
+          "\n",
+          &Jason.encode!/1
+        )
+
+      assert {:ok, parsed} = OutputParser.parse(:claude_code_json, buffer)
+      # Sub-agent text (non-nil parent_tool_use_id) is excluded; order preserved.
+      assert parsed.assistant_texts == [
+               "Here is my question with options.",
+               "I'll wait for your decision."
+             ]
+    end
+
+    test "surfaces structured_output from a stream-json result event" do
+      buffer =
+        Enum.map_join(
+          [
+            %{"type" => "system", "subtype" => "init", "tools" => ["StructuredOutput"]},
+            %{
+              "type" => "assistant",
+              "parent_tool_use_id" => nil,
+              "message" => %{
+                "content" => [
+                  %{"type" => "tool_use", "name" => "StructuredOutput", "input" => %{"decision" => "question"}}
+                ]
+              }
+            },
+            %{
+              "type" => "result",
+              "subtype" => "success",
+              "is_error" => false,
+              "result" => ~s({"decision":"question","questions":["Which DB?"]}),
+              "structured_output" => %{"decision" => "question", "questions" => ["Which DB?"]}
+            }
+          ],
+          "\n",
+          &Jason.encode!/1
+        )
+
+      assert {:ok, parsed} = OutputParser.parse(:claude_code_json, buffer)
+      assert parsed.structured == %{"decision" => "question", "questions" => ["Which DB?"]}
+    end
   end
 
   describe "parse/2 with :raw_text" do
@@ -194,6 +280,8 @@ defmodule Camelot.Runtime.OutputParserTest do
       assert parsed.result_text == buffer
       assert is_nil(parsed.cost_usd)
       assert is_nil(parsed.duration_ms)
+      assert is_nil(parsed.structured)
+      assert parsed.assistant_texts == []
     end
   end
 end


### PR DESCRIPTION
## Problem

A task on the test cluster sat in `planning / waiting_for_input` with **no visible question**. Root cause is systematic and affects many plan cards.

The runner's Claude Code is a **ToolSearch / deferred-tools build** (`claude-sonnet-5`, 2.1.x). In headless plan mode the `system/init` tool registry **does not contain `ExitPlanMode`/`EnterPlanMode`**. So:

1. The plan-capture design — agent calls `ExitPlanMode` → headless denies it → recover `tool_input.plan` — **never fires** (`plan_from_exit` always nil). Agents instead say *"I wasn't able to find an ExitPlanMode tool… I'll present the plan directly"* / write a plan file.
2. `OutputParser` read only the final `result` field, which is empirically just the agent's **last assistant turn** (a trailing meta-sentence like *"I'll wait for your decision…"*). The real plan/question, raised in an earlier turn, was discarded.
3. `handle_task_result(:planning)` then fell through to `submit_plan(trailing_sentence)` → junk `plan`, **no `TaskMessage`**, UI shows nothing.

## Fix

Deliver planning results via the CLI's native **`--json-schema`** structured-output contract instead of `ExitPlanMode`.

- **OutputParser** — expose `structured` (from the result event's `structured_output`) and `assistant_texts` (every top-level assistant turn) as a fallback source of truth.
- **AgentProcess** — `planning_action/2` (pure, unit-tested) routes on the `{decision, plan, questions}` contract first, then legacy ExitPlanMode, denials, and the **full transcript**. Invariants: a question always writes a `TaskMessage`; a plan stores the full text.
- **claude_code template** — planning passes `--permission-mode plan --json-schema <schema>` (+ an `--append-system-prompt`); the injected `StructuredOutput` tool coexists with the read-only investigation tools. Seeds reconcile existing rows idempotently.
- **docs/planning-output-contract.md** documents the contract.

## Verification

- Probed the runner image directly: `--json-schema` exists; `StructuredOutput` coexists with Bash/Read/Edit/WebFetch/Task/ToolSearch under default tools; the result event carries both `result` (JSON string) and `structured_output` (parsed object).
- `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo`, `mix dialyzer` — all clean.
- `mix test` — **221 tests, 0 failures**, including new parser tests and `planning_action/2` tests that reproduce the exact bug scenario.

## Follow-ups (not in this PR)

- **Deploy** the app to the test cluster and re-run seeds (or update the `claude_code` `agent_templates` row) so the `--json-schema` args take effect. Note the remote `executing` permission-mode drifted to `auto` vs seed `acceptEdits`.
- **Unblock task `d02c2766`** after deploy (re-running before deploy would just re-stick).
- The target repo `T0ha/LamaBot` contains a **prompt-injection** block disguised as a plan-mode system reminder — worth investigating separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)