### PR TITLE
fix(board): react to PR comments from the PR author's own account

### DIFF
--- a/lib/camelot/board/changes/check_pr_status.ex
+++ b/lib/camelot/board/changes/check_pr_status.ex
@@ -63,14 +63,14 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
         transition(task, :cancel)
 
       task.state == :waiting_for_input ->
-        apply_waiting_for_input(task, pr, reviews, comments, commits)
+        apply_waiting_for_input(task, reviews, comments, commits)
 
       true ->
         :ok
     end
   end
 
-  defp apply_waiting_for_input(task, pr, reviews, comments, commits) do
+  defp apply_waiting_for_input(task, reviews, comments, commits) do
     cond do
       has_review_state?(reviews, "CHANGES_REQUESTED") ->
         transition_with_seen_at(task, comments)
@@ -78,7 +78,7 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
       has_review_state?(reviews, "APPROVED") ->
         transition(task, :complete)
 
-      has_new_comments?(task, pr, comments, commits) ->
+      has_new_comments?(task, comments, commits) ->
         transition_with_seen_at(task, comments)
 
       true ->
@@ -90,36 +90,36 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
     Enum.any?(reviews, &(&1["state"] == state))
   end
 
-  defp has_new_comments?(task, pr, comments, commits) do
-    pr_author = get_in(pr, ["user", "login"])
-    last_commit_date = last_commit_date(commits)
-    seen_at = task.pr_comments_seen_at
+  defp has_new_comments?(task, comments, commits) do
+    new_comments?(comments, last_commit_date(commits), task.pr_comments_seen_at)
+  end
 
-    comments
-    |> Enum.reject(&(get_in(&1, ["user", "login"]) == pr_author))
-    |> Enum.any?(fn comment ->
+  @doc """
+  True if any comment is newer than the last commit AND unseen.
+
+  Deliberately does NOT filter by author. Runners open PRs with the
+  user's own GitHub token, so the PR author and the human reviewer are
+  the same account — an author-based filter would silently drop the
+  reviewer's feedback (which is exactly the comment we must react to).
+  Nothing in the app posts PR comments, so there is no bot chatter to
+  exclude; re-trigger loops are prevented by `pr_comments_seen_at` and
+  the newer-than-last-commit guard.
+  """
+  @spec new_comments?([map()], String.t() | nil, DateTime.t() | nil) :: boolean()
+  def new_comments?(comments, last_commit_date, seen_at) do
+    Enum.any?(comments, fn comment ->
       created = comment["created_at"]
-
-      newer_than_commit? =
-        case {last_commit_date, created} do
-          {nil, _} -> true
-          {_, nil} -> false
-          {cd, cr} -> cr > cd
-        end
-
-      not_seen? =
-        case seen_at do
-          nil ->
-            true
-
-          dt ->
-            created >
-              DateTime.to_iso8601(dt)
-        end
-
-      newer_than_commit? and not_seen?
+      newer_than_commit?(created, last_commit_date) and unseen?(created, seen_at)
     end)
   end
+
+  defp newer_than_commit?(_created, nil), do: true
+  defp newer_than_commit?(nil, _commit_date), do: false
+  defp newer_than_commit?(created, commit_date), do: created > commit_date
+
+  defp unseen?(_created, nil), do: true
+  defp unseen?(nil, _seen_at), do: false
+  defp unseen?(created, seen_at), do: created > DateTime.to_iso8601(seen_at)
 
   defp last_commit_date(commits) do
     case List.last(commits) do

--- a/test/camelot/board/changes/check_pr_status_test.exs
+++ b/test/camelot/board/changes/check_pr_status_test.exs
@@ -1,0 +1,55 @@
+defmodule Camelot.Board.Changes.CheckPrStatusTest do
+  use ExUnit.Case, async: true
+
+  alias Camelot.Board.Changes.CheckPrStatus
+
+  @commit "2026-07-09T13:42:09Z"
+
+  defp comment(created, login \\ "T0ha") do
+    %{"created_at" => created, "user" => %{"login" => login}}
+  end
+
+  describe "new_comments?/3" do
+    test "a comment newer than the last commit and unseen triggers" do
+      comments = [comment("2026-07-10T05:19:45Z")]
+
+      assert CheckPrStatus.new_comments?(comments, @commit, nil)
+    end
+
+    test "reviewer sharing the PR author account still counts (no author filter)" do
+      # Regression: runner opens the PR with the user's token, so the
+      # reviewer's login equals the PR author's — must NOT be dropped.
+      comments = [comment("2026-07-10T05:19:45Z", "T0ha")]
+
+      assert CheckPrStatus.new_comments?(comments, @commit, nil)
+    end
+
+    test "a comment older than the last commit does not trigger" do
+      comments = [comment("2026-07-09T10:00:00Z")]
+
+      refute CheckPrStatus.new_comments?(comments, @commit, nil)
+    end
+
+    test "an already-seen comment does not trigger" do
+      created = "2026-07-10T05:19:45Z"
+      {:ok, seen_at, _} = DateTime.from_iso8601(created)
+
+      refute CheckPrStatus.new_comments?([comment(created)], @commit, seen_at)
+    end
+
+    test "a comment after the seen marker triggers again" do
+      {:ok, seen_at, _} = DateTime.from_iso8601("2026-07-10T05:19:45Z")
+      comments = [comment("2026-07-10T06:00:00Z")]
+
+      assert CheckPrStatus.new_comments?(comments, @commit, seen_at)
+    end
+
+    test "no commits treats any unseen comment as new" do
+      assert CheckPrStatus.new_comments?([comment("2026-07-10T05:19:45Z")], nil, nil)
+    end
+
+    test "no comments is never new" do
+      refute CheckPrStatus.new_comments?([], @commit, nil)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Commenting on a task's PR (e.g. task `cc72d763`, PR #40) did nothing — the task stayed in `pr / waiting_for_input` and the agent never picked up the feedback.

`CheckPrStatus.has_new_comments?` rejected every comment whose author equalled the **PR author**:

```elixir
comments
|> Enum.reject(&(get_in(&1, ["user", "login"]) == pr_author))
```

But runners open PRs with the **user's own GitHub token**, so the PR author and the human reviewer are the *same* account (`T0ha`). The reviewer's comment was filtered out, so `has_new_comments?` returned false and nothing was queued.

Verified on the test cluster: PR #40 author `T0ha`, only comment by `T0ha`, no reviews; the Oban `github` queue is running fine (40k+ completed jobs, every 2 min), and the comment (`07-10 05:19`) is newer than the last commit (`07-09 13:42`) — so only the author filter was blocking it.

## Fix

- Drop the author-based filter. Nothing in the app ever posts a PR comment (the GitHub client only reads), so there's no bot chatter to exclude. Re-trigger loops are already prevented by `pr_comments_seen_at` + the newer-than-last-commit guard.
- Extract pure, unit-tested `new_comments?/3`.

## Verification

- New test `check_pr_status_test.exs` (7 cases), incl. the regression: a reviewer sharing the PR-author account is now detected.
- `mix format`, `mix credo`, `mix dialyzer`, and full `mix test` (**232 tests, 0 failures**) all green.

## Post-merge / deploy note

Needs deploy to `test.camelotai.tech`. After deploy, the `check_pr_status` trigger (every 2 min) will pick up the existing comment on PR #40 and queue task `cc72d763` for changes — no manual retrigger needed (seen_at is still null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)