### PR TITLE
feat(runner): adopt in-flight sessions after restart instead of failing

### DIFF
--- a/docs/session-adoption.md
+++ b/docs/session-adoption.md
@@ -1,0 +1,60 @@
+# Session adoption (reconnect after restart)
+
+When Camelot is redeployed, Swarm/Docker sends the app SIGTERM and the
+`AgentProcess` GenServers driving in-flight runs die. The **runner
+containers are separate services that keep running** (the agent process
+inside them is a `docker exec`, not tied to the app's connection), so the
+work isn't actually lost — only the app's live view of it.
+
+Previously the Reconciler marked every such `:running` session **failed**
+on boot, discarding in-flight work and leaving the task stuck
+`in_progress` with an orphaned runner. Adoption reconnects instead.
+
+## How it works
+
+1. **Durable output + completion marker.** The in-container
+   `exec-wrapper.sh` already tees the agent's full output to
+   `/tmp/camelot-output-<session_id>.log`. It now also writes the exit
+   code to `/tmp/camelot-exit-<session_id>` **after** the tee — so the
+   marker's presence implies the output file is complete. The marker is
+   needed because the original `docker exec` id is lost across a restart,
+   so the app can't poll the exec for its status.
+
+2. **Reconciler decides adopt vs. fail** (`recovery_action/4`, pure):
+   for a `:running` session whose owning `AgentProcess` is gone, if it's
+   a **task** session (not bootstrap), on a container backend (not
+   LocalPort), with a runner handle whose container probe is `:present`
+   → **adopt**. Otherwise → **fail** (retryable).
+
+3. **AgentProcess adopts** (`AgentProcess.adopt/2`): rebuilds the minimal
+   state finalisation needs (config, task, output-so-far) and starts the
+   runner in **adopt mode** (`Spec.adopt? = true`) — bypassing the
+   `RunnerPool` (no new slot) and creating **no new exec**. The session is
+   flagged `was_adopted`.
+
+4. **Adopt-mode runner** (`ExecSession`, both backends): resolves the
+   existing container and polls for the completion marker
+   (`AdoptMarker`). When it appears, it reuses the normal `{:exit_code,
+   _}` path — fetch the tee'd output, emit `{:runner_output, …}` then
+   `{:runner_exit, code}` — so the run finalises exactly as a live one
+   would (plan/PR/question routing all unchanged).
+
+## Caveats
+
+- **Requires the runner image rebuilt** with the marker-writing
+  `exec-wrapper.sh`. A session started under an older image never
+  produces a marker; adopt it only once images are updated, otherwise
+  retry the task.
+- **Live incremental output** streamed *before* the restart is not
+  replayed, but the final result is complete (read whole-file). This is
+  what the `Session.was_adopted` UI hint flags.
+- If the container is genuinely gone (node lost, service removed), there
+  is nothing to adopt → the session is failed and the existing
+  task-runner-lost sweep applies.
+- LocalPort (single-node/dev/test) has no container to re-attach to;
+  adoption is a no-op there.
+
+## Not covered here
+
+Graceful drain on SIGTERM (checkpoint/finish in-flight runs before exit)
+and the app-image multi-arch / placement issue are tracked separately.

--- a/lib/camelot/runtime/agent_process.ex
+++ b/lib/camelot/runtime/agent_process.ex
@@ -95,6 +95,20 @@ defmodule Camelot.Runtime.AgentProcess do
     end
   end
 
+  @doc """
+  Re-attach to a `:running` session whose runner container survived a
+  Camelot restart, instead of failing it. Reads the durable tee'd
+  output on completion and finalises normally. The caller must have
+  ensured the AgentProcess is started (see `Reconciler`).
+  """
+  @spec adopt(String.t(), String.t()) :: :ok | {:error, :busy | :not_found}
+  def adopt(agent_id, session_id) do
+    case AgentRegistry.lookup(agent_id) do
+      nil -> {:error, :not_found}
+      pid -> GenServer.call(pid, {:adopt, session_id})
+    end
+  end
+
   @spec retry(String.t()) :: :ok | {:error, :not_found | :no_task}
   def retry(agent_id) do
     case AgentRegistry.lookup(agent_id) do
@@ -146,6 +160,21 @@ defmodule Camelot.Runtime.AgentProcess do
           {:error, reason} ->
             {:reply, {:error, reason}, state}
         end
+    end
+  end
+
+  def handle_call({:adopt, session_id}, _from, state) do
+    if state.runner || state.current_session_id do
+      {:reply, {:error, :busy}, state}
+    else
+      case start_adoption(state, session_id) do
+        {:ok, new_state} ->
+          mark_agent_busy(state.agent_id)
+          {:reply, :ok, new_state}
+
+        {:error, reason} ->
+          {:reply, {:error, reason}, state}
+      end
     end
   end
 
@@ -442,6 +471,53 @@ defmodule Camelot.Runtime.AgentProcess do
 
   defp agent_user_id(%Agent{user_id: nil}), do: @unscoped_user
   defp agent_user_id(%Agent{user_id: id}), do: id
+
+  # Re-attach to an already-running session after a restart. Rebuilds
+  # the minimal state finalisation needs (config, task, output so far)
+  # and starts the runner in adopt mode — no pool slot, no new exec.
+  defp start_adoption(state, session_id) do
+    session = Ash.get!(Session, session_id)
+    agent = Ash.get!(Agent, session.agent_id, load: [:project, :template, :user])
+    task = session.task_id && Ash.get!(Task, session.task_id)
+    config = AgentConfig.resolve(agent)
+
+    state = %{
+      state
+      | current_task_id: session.task_id,
+        current_session_id: session.id,
+        current_prompt: "",
+        allowed_tools: (task && task.allowed_tools) || [],
+        config: config,
+        user_id: agent_user_id(agent),
+        max_retries: agent.max_retries,
+        retry_count: session.retry_number,
+        output_buffer: session.output_log || ""
+    }
+
+    spec = %{build_spec(state, agent, task, config, []) | adopt?: true}
+
+    case Runner.start(spec) do
+      {:ok, runner_pid} ->
+        mark_session_adopted(session_id, runner_pid)
+        SessionRegistry.register(session_id)
+        Process.monitor(runner_pid)
+        broadcast_agent_update(state.agent_id)
+        state = subscribe_task(state, session.task_id)
+        {:ok, %{state | runner: runner_pid, config: config}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  rescue
+    e ->
+      Logger.error("AgentProcess adopt failed: #{inspect(e)}")
+      {:error, e}
+  end
+
+  defp mark_session_adopted(session_id, runner_pid) do
+    session = Ash.get!(Session, session_id)
+    Ash.update(session, %{service_id: inspect(runner_pid)}, action: :mark_adopted)
+  end
 
   defp start_runner(state) do
     agent = Ash.get!(Agent, state.agent_id, load: [:project, :template, :user])

--- a/lib/camelot/runtime/reconciler.ex
+++ b/lib/camelot/runtime/reconciler.ex
@@ -6,12 +6,15 @@ defmodule Camelot.Runtime.Reconciler do
 
   On boot:
 
-    1. Marks any `Session{status: :running}` rows as
-       failed — the AgentProcess that owned the
-       container is gone, and re-attaching a log stream
-       safely is left for a follow-up. The session can
-       be retried by the user. The `was_adopted` flag on
-       Session is reserved for that future watcher.
+    1. Recovers any `Session{status: :running}` rows whose
+       owning AgentProcess is gone (e.g. after a redeploy).
+       If the session's task runner container is still
+       alive, it is **adopted** — a fresh AgentProcess
+       re-attaches and finalises from the durable tee'd
+       output (`was_adopted` is set). Only when there is no
+       live container to re-attach to (bootstrap sessions,
+       the LocalPort backend, or a truly gone runner) is the
+       session marked failed for the user to retry.
     2. Queued sessions are *not* touched — their DB rows
        survive untouched, and the next call to
        `RunnerPool.tick/0` (after AgentProcess
@@ -42,8 +45,12 @@ defmodule Camelot.Runtime.Reconciler do
 
   alias Camelot.Agents.Session
   alias Camelot.Board.Task
+  alias Camelot.Runtime.AgentProcess
+  alias Camelot.Runtime.AgentRegistry
+  alias Camelot.Runtime.AgentSupervisor
   alias Camelot.Runtime.Runner
   alias Camelot.Runtime.Runner.DockerApi
+  alias Camelot.Runtime.Runner.LocalPort
   alias Camelot.Runtime.Runner.Swarm
   alias Camelot.Runtime.RunnerPool
   alias Camelot.Runtime.SessionRegistry
@@ -134,29 +141,100 @@ defmodule Camelot.Runtime.Reconciler do
     Session
     |> Ash.Query.filter(status == :running)
     |> Ash.read!()
-    |> Enum.each(fn session ->
-      if alive_owner?(session) do
-        :ok
-      else
-        Logger.info(
-          "Reconciler: failing stale running session #{session.id} " <>
-            "(owning AgentProcess not registered)"
+    |> Enum.each(&recover_stale_session/1)
+  end
+
+  # A `:running` session whose owning AgentProcess is gone (typically
+  # after a redeploy). If its task runner container is still alive we
+  # adopt it — re-attach and finalise from the durable tee'd output —
+  # instead of discarding in-flight work. Only when the container is
+  # truly gone (or this is a bootstrap/LocalPort session with nothing
+  # to re-attach to) do we fail it so the user can retry.
+  defp recover_stale_session(session) do
+    if alive_owner?(session) do
+      :ok
+    else
+      handle = session.task_id && task_runner_handle(session.task_id)
+      presence = if handle, do: probe_runner(handle), else: :gone
+
+      case recovery_action(Runner.backend(), session.kind, handle, presence) do
+        :adopt -> adopt_stale_session(session)
+        :fail -> fail_stale_session(session)
+      end
+    end
+  end
+
+  @doc """
+  Pure decision for a stale `:running` session: `:adopt` only when a
+  task session's runner container is actually running; otherwise
+  `:fail`. Bootstrap sessions and the LocalPort backend have no
+  re-attachable container.
+  """
+  @spec recovery_action(module(), atom(), String.t() | nil, atom()) :: :adopt | :fail
+  def recovery_action(LocalPort, _kind, _handle, _presence), do: :fail
+  def recovery_action(_backend, :bootstrap, _handle, _presence), do: :fail
+  def recovery_action(_backend, _kind, nil, _presence), do: :fail
+  def recovery_action(_backend, _kind, _handle, :present), do: :adopt
+  def recovery_action(_backend, _kind, _handle, _presence), do: :fail
+
+  defp adopt_stale_session(%Session{} = session) do
+    Logger.info(
+      "Reconciler: adopting running session #{session.id} " <>
+        "(runner container still alive)"
+    )
+
+    with :ok <- ensure_agent_process(session.agent_id),
+         :ok <- AgentProcess.adopt(session.agent_id, session.id) do
+      :ok
+    else
+      other ->
+        Logger.warning(
+          "Reconciler: adopt failed for session #{session.id} " <>
+            "(#{inspect(other)}); failing it instead"
         )
 
-        Ash.update!(
-          session,
-          %{
-            error_message:
-              "AgentProcess unregistered without finalising this session " <>
-                "(likely a crash in finish_session/4). Inspect the runner " <>
-                "service `camelot-runner-#{session.id}` for container logs " <>
-                "within the retention window.",
-            exit_code: 1
-          },
-          action: :fail
-        )
-      end
-    end)
+        fail_stale_session(session)
+    end
+  end
+
+  defp ensure_agent_process(agent_id) do
+    case AgentRegistry.lookup(agent_id) do
+      nil ->
+        case AgentSupervisor.start_agent(agent_id) do
+          {:ok, _pid} -> :ok
+          {:error, {:already_started, _pid}} -> :ok
+          {:error, _} = err -> err
+        end
+
+      _pid ->
+        :ok
+    end
+  end
+
+  defp fail_stale_session(%Session{} = session) do
+    Logger.info(
+      "Reconciler: failing stale running session #{session.id} " <>
+        "(owning AgentProcess not registered, no adoptable runner)"
+    )
+
+    Ash.update!(
+      session,
+      %{
+        error_message:
+          "AgentProcess unregistered without finalising this session " <>
+            "and no live runner container was available to adopt. " <>
+            "The session can be retried.",
+        exit_code: 1
+      },
+      action: :fail
+    )
+  end
+
+  defp task_runner_handle(task_id) do
+    case Ash.get(Task, task_id) do
+      {:ok, %Task{runner_handle: handle}} -> handle
+      _ -> nil
+    end
   end
 
   defp alive_owner?(%Session{id: id}) do
@@ -169,7 +247,7 @@ defmodule Camelot.Runtime.Reconciler do
   defp backend_available? do
     backend = Runner.backend()
 
-    if backend == Camelot.Runtime.Runner.LocalPort do
+    if backend == LocalPort do
       true
     else
       case DockerApi.ping() do

--- a/lib/camelot/runtime/runner/adopt_marker.ex
+++ b/lib/camelot/runtime/runner/adopt_marker.ex
@@ -1,0 +1,32 @@
+defmodule Camelot.Runtime.Runner.AdoptMarker do
+  @moduledoc """
+  The exec-wrapper writes the agent's exit code to a per-session
+  marker file (`/tmp/camelot-exit-<session_id>`) once the run
+  finishes. After a Camelot restart the original `docker exec` id is
+  gone, so an adopting session can't poll the exec for its status — it
+  polls for this marker instead, then reads the tee'd output file.
+
+  Written last by the wrapper, so the marker's presence strictly implies
+  the output file (`/tmp/camelot-output-<session_id>.log`) is complete.
+  """
+
+  @doc "Absolute path of the completion marker for a session."
+  @spec path(String.t()) :: String.t()
+  def path(session_id), do: "/tmp/camelot-exit-#{session_id}"
+
+  @doc """
+  Parses marker file contents into an exit code.
+
+  Returns `:none` for empty/absent (a `cat` of a missing file yields
+  empty stdout) or non-numeric content, so the poller keeps waiting.
+  """
+  @spec parse(binary() | term()) :: {:ok, integer()} | :none
+  def parse(body) when is_binary(body) do
+    case body |> String.trim() |> Integer.parse() do
+      {code, _rest} -> {:ok, code}
+      :error -> :none
+    end
+  end
+
+  def parse(_), do: :none
+end

--- a/lib/camelot/runtime/runner/docker_engine/exec_session.ex
+++ b/lib/camelot/runtime/runner/docker_engine/exec_session.ex
@@ -11,6 +11,7 @@ defmodule Camelot.Runtime.Runner.DockerEngine.ExecSession do
   """
   use GenServer, restart: :temporary
 
+  alias Camelot.Runtime.Runner.AdoptMarker
   alias Camelot.Runtime.Runner.DockerApi
   alias Camelot.Runtime.Runner.DockerEngine.TaskContainer
   alias Camelot.Runtime.Runner.DockerStreamDemux
@@ -25,6 +26,7 @@ defmodule Camelot.Runtime.Runner.DockerEngine.ExecSession do
   # failure. Real upstream failures break the loop via {:error, _}.
   @ready_poll_ms 500
   @exit_poll_ms 1_000
+  @adopt_poll_ms 2_000
 
   defstruct [
     :owner,
@@ -61,6 +63,13 @@ defmodule Camelot.Runtime.Runner.DockerEngine.ExecSession do
   end
 
   @impl GenServer
+  def handle_continue(:start_exec, %__MODULE__{spec: %Spec{adopt?: true}} = state) do
+    case start_adopt(state) do
+      {:ok, state} -> {:noreply, state}
+      {:error, reason} -> {:stop, reason, state}
+    end
+  end
+
   def handle_continue(:start_exec, state) do
     case start_exec(state) do
       {:ok, state} -> {:noreply, state}
@@ -113,6 +122,58 @@ defmodule Camelot.Runtime.Runner.DockerEngine.ExecSession do
       {:ok, kick_off_streams(state)}
     end
   end
+
+  # Adoption: reconnect to an already-running task container after a
+  # Camelot restart. Resolve the container and poll for the wrapper's
+  # completion marker, then reuse the {:exit_code, _} path to read the
+  # tee'd output and finalise as a live run would.
+  defp start_adopt(%__MODULE__{spec: spec} = state) do
+    with {:ok, tc_pid} <- TaskContainer.ensure_started(spec),
+         {:ok, container_id} <- TaskContainer.get_container_id(tc_pid) do
+      state = %{state | container_id: container_id}
+      parent = self()
+      poll_task = Task.async(fn -> poll_adopt_exit(state, parent) end)
+      {:ok, %{state | poll_task: poll_task}}
+    end
+  end
+
+  defp poll_adopt_exit(%__MODULE__{} = state, parent) do
+    case read_marker(state) do
+      {:ok, code} ->
+        send(parent, {:exit_code, code})
+
+      :none ->
+        Process.sleep(@adopt_poll_ms)
+        poll_adopt_exit(state, parent)
+    end
+  end
+
+  defp read_marker(%__MODULE__{session_id: sid, container_id: cid}) when is_binary(sid) and is_binary(cid) do
+    payload = %{
+      "AttachStdout" => true,
+      "AttachStderr" => false,
+      "Tty" => false,
+      "Cmd" => ["cat", AdoptMarker.path(sid)]
+    }
+
+    with {:ok, %Req.Response{status: 201, body: %{"Id" => exec_id}}} <-
+           Req.post(DockerApi.request(), url: "/containers/#{cid}/exec", json: payload),
+         {:ok, %Req.Response{status: 200, body: body}} when is_binary(body) <-
+           Req.post(DockerApi.request(),
+             url: "/exec/#{exec_id}/start",
+             json: %{"Detach" => false, "Tty" => false}
+           ) do
+      {payloads, _rest} = DockerStreamDemux.drain(<<>>, body)
+
+      payloads
+      |> IO.iodata_to_binary()
+      |> AdoptMarker.parse()
+    else
+      _ -> :none
+    end
+  end
+
+  defp read_marker(_), do: :none
 
   defp wait_for_ready(container_id) do
     case ready_check(container_id) do

--- a/lib/camelot/runtime/runner/spec.ex
+++ b/lib/camelot/runtime/runner/spec.ex
@@ -30,7 +30,8 @@ defmodule Camelot.Runtime.Runner.Spec do
             node_label: nil,
             resources: %{},
             service_name: nil,
-            task_id: nil
+            task_id: nil,
+            adopt?: false
 
   @type secret :: %{kind: atom(), name: String.t(), value: String.t()}
 
@@ -50,7 +51,8 @@ defmodule Camelot.Runtime.Runner.Spec do
           node_label: String.t() | nil,
           resources: %{optional(String.t()) => String.t()},
           service_name: String.t() | nil,
-          task_id: String.t() | nil
+          task_id: String.t() | nil,
+          adopt?: boolean()
         }
 
   @doc """

--- a/lib/camelot/runtime/runner/swarm/exec_session.ex
+++ b/lib/camelot/runtime/runner/swarm/exec_session.ex
@@ -16,6 +16,7 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
   """
   use GenServer, restart: :temporary
 
+  alias Camelot.Runtime.Runner.AdoptMarker
   alias Camelot.Runtime.Runner.DockerApi
   alias Camelot.Runtime.Runner.DockerStreamDemux
   alias Camelot.Runtime.Runner.Spec
@@ -38,6 +39,7 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
   # the budget expires we give up and surface the transport error.
   @ready_poll_ms 500
   @exit_poll_ms 1_000
+  @adopt_poll_ms 2_000
   @transport_budget_ms 60_000
 
   defstruct [
@@ -84,6 +86,13 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
   end
 
   @impl GenServer
+  def handle_continue(:start_exec, %__MODULE__{spec: %Spec{adopt?: true}} = state) do
+    case start_adopt(state) do
+      {:ok, state} -> {:noreply, state}
+      {:error, reason} -> {:stop, reason, state}
+    end
+  end
+
   def handle_continue(:start_exec, state) do
     case start_exec(state) do
       {:ok, state} -> {:noreply, state}
@@ -154,6 +163,67 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
       {:ok, kick_off_streams(state)}
     end
   end
+
+  # Adoption: the runner container/service is already up and the agent
+  # is (or was) running inside it. Don't create a new exec — resolve the
+  # existing container and poll for the wrapper's completion marker,
+  # then reuse the {:exit_code, _} path to read the tee'd output and
+  # finalise exactly as a live run would.
+  defp start_adopt(%__MODULE__{spec: spec} = state) do
+    with {:ok, ts_pid} <- TaskService.ensure_started(spec),
+         {:ok, service_id} <- TaskService.get_service_id(ts_pid),
+         {:ok, container_id, node_id} <-
+           resolve_container(service_id, @transport_budget_ms),
+         {:ok, node_req} <- ProxyRouter.request_for_node(node_id) do
+      state = %{
+        state
+        | service_id: service_id,
+          container_id: container_id,
+          node_id: node_id,
+          node_req: node_req
+      }
+
+      parent = self()
+      poll_task = Task.async(fn -> poll_adopt_exit(state, parent) end)
+      {:ok, %{state | poll_task: poll_task}}
+    end
+  end
+
+  defp poll_adopt_exit(%__MODULE__{} = state, parent) do
+    case read_marker(state) do
+      {:ok, code} ->
+        send(parent, {:exit_code, code})
+
+      :none ->
+        Process.sleep(@adopt_poll_ms)
+        poll_adopt_exit(state, parent)
+    end
+  end
+
+  defp read_marker(%__MODULE__{session_id: sid, container_id: cid, node_req: req})
+       when is_binary(sid) and is_binary(cid) and not is_nil(req) do
+    payload = %{
+      "AttachStdout" => true,
+      "AttachStderr" => false,
+      "Tty" => false,
+      "Cmd" => ["cat", AdoptMarker.path(sid)]
+    }
+
+    with {:ok, %Req.Response{status: 201, body: %{"Id" => exec_id}}} <-
+           Req.post(req, url: "/containers/#{cid}/exec", json: payload),
+         {:ok, %Req.Response{status: 200, body: body}} when is_binary(body) <-
+           Req.post(req, url: "/exec/#{exec_id}/start", json: %{"Detach" => false, "Tty" => false}) do
+      {payloads, _rest} = DockerStreamDemux.drain(<<>>, body)
+
+      payloads
+      |> IO.iodata_to_binary()
+      |> AdoptMarker.parse()
+    else
+      _ -> :none
+    end
+  end
+
+  defp read_marker(_), do: :none
 
   defp resolve_container(service_id, transport_budget_ms) do
     case list_service_tasks(service_id) do

--- a/runner-images/base/exec-wrapper.sh
+++ b/runner-images/base/exec-wrapper.sh
@@ -44,4 +44,12 @@ set +e
 "$@" 2>&1 | tee "$out"
 code=${PIPESTATUS[0]}
 set -e
+
+# Completion marker: the exit code in its own file. After a Camelot
+# restart the original `docker exec` id is lost, so the BEAM can't poll
+# the exec for its exit status. An adopting session instead polls for
+# this marker to learn the run finished (and with what code), then reads
+# the tee'd output file above. Written last so its presence strictly
+# implies the output file is complete.
+echo "$code" > "/tmp/camelot-exit-${CAMELOT_SESSION_ID:-session}"
 exit "$code"

--- a/test/camelot/runtime/reconciler_test.exs
+++ b/test/camelot/runtime/reconciler_test.exs
@@ -1,0 +1,37 @@
+defmodule Camelot.Runtime.ReconcilerTest do
+  use ExUnit.Case, async: true
+
+  alias Camelot.Runtime.Reconciler
+  alias Camelot.Runtime.Runner.LocalPort
+  alias Camelot.Runtime.Runner.Swarm
+
+  describe "recovery_action/4" do
+    test "adopts a running task session when its runner is present" do
+      assert :adopt = Reconciler.recovery_action(Swarm, :task, "svc123", :present)
+    end
+
+    test "fails when the runner container is gone" do
+      assert :fail = Reconciler.recovery_action(Swarm, :task, "svc123", :gone)
+    end
+
+    test "fails when the service exists but has no running tasks" do
+      assert :fail = Reconciler.recovery_action(Swarm, :task, "svc123", :no_tasks)
+    end
+
+    test "fails when the runner state is unknown" do
+      assert :fail = Reconciler.recovery_action(Swarm, :task, "svc123", :unknown)
+    end
+
+    test "never adopts a bootstrap session (nothing to finalise)" do
+      assert :fail = Reconciler.recovery_action(Swarm, :bootstrap, "svc123", :present)
+    end
+
+    test "fails when there is no runner handle to probe" do
+      assert :fail = Reconciler.recovery_action(Swarm, :task, nil, :present)
+    end
+
+    test "never adopts on the LocalPort backend (no container)" do
+      assert :fail = Reconciler.recovery_action(LocalPort, :task, "svc123", :present)
+    end
+  end
+end

--- a/test/camelot/runtime/runner/adopt_marker_test.exs
+++ b/test/camelot/runtime/runner/adopt_marker_test.exs
@@ -1,0 +1,36 @@
+defmodule Camelot.Runtime.Runner.AdoptMarkerTest do
+  use ExUnit.Case, async: true
+
+  alias Camelot.Runtime.Runner.AdoptMarker
+
+  test "path/1 names the per-session marker file" do
+    assert AdoptMarker.path("abc-123") == "/tmp/camelot-exit-abc-123"
+  end
+
+  describe "parse/1" do
+    test "parses a plain exit code" do
+      assert {:ok, 0} = AdoptMarker.parse("0")
+      assert {:ok, 1} = AdoptMarker.parse("1")
+      assert {:ok, 137} = AdoptMarker.parse("137")
+    end
+
+    test "tolerates a trailing newline and surrounding whitespace" do
+      assert {:ok, 0} = AdoptMarker.parse("0\n")
+      assert {:ok, 2} = AdoptMarker.parse("  2  \n")
+    end
+
+    test "empty output (absent marker via `cat` of a missing file) is :none" do
+      assert :none = AdoptMarker.parse("")
+      assert :none = AdoptMarker.parse("   \n")
+    end
+
+    test "non-numeric content is :none" do
+      assert :none = AdoptMarker.parse("cat: /tmp/camelot-exit-x: No such file")
+    end
+
+    test "non-binary input is :none" do
+      assert :none = AdoptMarker.parse(nil)
+      assert :none = AdoptMarker.parse(:error)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

On redeploy, Camelot's `AgentProcess` GenServers die, so in-flight runs were lost: the Reconciler marked every `:running` session **failed** on boot, leaving the task stuck `in_progress` with an **orphaned runner** still running (exactly what happened to task `e007bbc3`).

But the runner container is a *separate* service and the agent runs as a `docker exec` (not tied to the app connection), so the work keeps going — only the app's live view is lost. We should **reconnect, not restart**.

## How

The foundation was already there (the exec-wrapper tees full output to a file; `Session.was_adopted` exists). This wires up adoption:

1. **Completion marker** — `exec-wrapper.sh` writes the exit code to `/tmp/camelot-exit-<sid>` *after* the tee. Needed because the original `docker exec` id is gone after a restart, so we can't poll the exec for status.
2. **`Reconciler.recovery_action/4`** (pure, unit-tested) — for a `:running` session with a dead owner: **adopt** only a task session, on a container backend, whose runner container probes `:present`; otherwise **fail** (retryable). Bootstrap/LocalPort/gone → fail.
3. **`AgentProcess.adopt/2`** — rebuilds the minimal finalisation state (config, task, output-so-far) and starts the runner in **adopt mode** — no pool slot, no new exec; sets `was_adopted`.
4. **Adopt-mode `ExecSession`** (DockerEngine + Swarm) — resolves the existing container, polls the marker (`AdoptMarker`), then reuses the normal `{:exit_code, _}` path to read the tee'd output and finalise exactly as a live run (plan/PR/question routing unchanged).

See `docs/session-adoption.md`.

## Verification

- Unit tests: `recovery_action/4` (adopt vs fail matrix) and `AdoptMarker.parse/1`.
- `mix format`, `mix credo`, `mix dialyzer`, full `mix test` — all green (**241 tests, 0 failures**).
- The container-I/O adopt paths (exec/cat/poll) can only be fully exercised against real Docker/Swarm — needs a cluster smoke test after deploy.

## Deploy / caveats

- **Requires the runner image rebuilt** with the marker-writing wrapper. Sessions started under an older image never produce a marker — retry those.
- Live output streamed *before* the restart isn't replayed (final result is complete via whole-file read); that's what the `was_adopted` UI hint flags.
- **Out of scope (separate):** graceful SIGTERM drain, and the app-image multi-arch / ARM-node placement issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)