### PR TITLE
fix(web): stop TaskLive crashing on {:agent_updated} broadcasts

### DIFF
--- a/lib/camelot_web/live/board_live.ex
+++ b/lib/camelot_web/live/board_live.ex
@@ -35,6 +35,9 @@ defmodule CamelotWeb.BoardLive do
     {:noreply, socket}
   end
 
+  # Never crash the board on an unexpected PubSub message.
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
   @impl true
   @task_fields ~w(title description priority project_id)
 

--- a/lib/camelot_web/live/task_live.ex
+++ b/lib/camelot_web/live/task_live.ex
@@ -83,6 +83,16 @@ defmodule CamelotWeb.TaskLive do
     {:noreply, assign(socket, live_output: cap_tail(combined, 20_000))}
   end
 
+  # The assigned agent changed status (e.g. :idle <-> :busy). We
+  # subscribe to its topic, so refresh the copy embedded in the task
+  # to keep the card in sync (input controls key off agent.status).
+  def handle_info({:agent_updated, agent}, socket) do
+    {:noreply, assign(socket, task: %{socket.assigns.task | agent: agent})}
+  end
+
+  # Never crash the card on an unexpected PubSub message.
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
   @impl true
   def handle_event("transition", %{"action" => action}, socket) do
     task = socket.assigns.task

--- a/lib/camelot_web/live/user_profile_live.ex
+++ b/lib/camelot_web/live/user_profile_live.ex
@@ -50,6 +50,9 @@ defmodule CamelotWeb.UserProfileLive do
     {:noreply, assign(socket, :pool, pool_for(socket.assigns.current_user))}
   end
 
+  # Never crash the profile page on an unexpected PubSub message.
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
   @impl true
   def handle_event("create_credential", %{"credential" => params}, socket) do
     attrs = %{

--- a/test/camelot_web/live/board_live_test.exs
+++ b/test/camelot_web/live/board_live_test.exs
@@ -17,6 +17,14 @@ defmodule CamelotWeb.BoardLiveTest do
     assert html =~ "Done"
   end
 
+  test "ignores unrelated PubSub messages without crashing", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    send(view.pid, {:some_unexpected_message, :payload})
+
+    assert render(view) =~ "Board"
+  end
+
   describe "scoping" do
     test "non-admin sees only tasks from member projects", %{conn: conn, user: user} do
       {:ok, mine} =

--- a/test/camelot_web/live/task_live_test.exs
+++ b/test/camelot_web/live/task_live_test.exs
@@ -92,6 +92,68 @@ defmodule CamelotWeb.TaskLiveTest do
     end
   end
 
+  describe "agent updates" do
+    test "survives an {:agent_updated, agent} broadcast and reflects new status",
+         %{conn: conn, project: project, user: user} do
+      {:ok, agent} =
+        Ash.create(Agent, %{
+          name: "live-agent",
+          template_id: agent_template!("claude_code").id,
+          project_id: project.id,
+          user_id: user.id
+        })
+
+      {:ok, task} =
+        Ash.create(Task, %{
+          title: "Agent-bound task",
+          project_id: project.id,
+          creator_id: user.id
+        })
+
+      {:ok, _task} = Ash.update(task, %{agent_id: agent.id}, action: :begin_work)
+
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.id}")
+
+      {:ok, busy_agent} = Ash.update(agent, %{}, action: :mark_busy)
+
+      Phoenix.PubSub.broadcast(
+        Camelot.PubSub,
+        "agent:#{agent.id}",
+        {:agent_updated, busy_agent}
+      )
+
+      # Before the fix this crashed the LiveView with a FunctionClauseError;
+      # render/1 forces a round-trip so a dead process would raise here.
+      assert render(view) =~ "Agent-bound task"
+    end
+
+    test "ignores unrelated PubSub messages without crashing",
+         %{conn: conn, project: project, user: user} do
+      {:ok, agent} =
+        Ash.create(Agent, %{
+          name: "live-agent-2",
+          template_id: agent_template!("claude_code").id,
+          project_id: project.id,
+          user_id: user.id
+        })
+
+      {:ok, task} =
+        Ash.create(Task, %{
+          title: "Catch-all task",
+          project_id: project.id,
+          creator_id: user.id
+        })
+
+      {:ok, _task} = Ash.update(task, %{agent_id: agent.id}, action: :begin_work)
+
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.id}")
+
+      send(view.pid, {:some_unexpected_message, :payload})
+
+      assert render(view) =~ "Catch-all task"
+    end
+  end
+
   describe "scoping" do
     test "redirects non-member from another user's task", %{conn: conn} do
       other = Ash.Seed.seed!(Camelot.Accounts.User, %{email: "to-#{System.unique_integer()}@x.com"})

--- a/test/camelot_web/live/user_profile_live_test.exs
+++ b/test/camelot_web/live/user_profile_live_test.exs
@@ -15,6 +15,14 @@ defmodule CamelotWeb.UserProfileLiveTest do
       assert html =~ "SSH key"
     end
 
+    test "ignores unrelated PubSub messages without crashing", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/profile")
+
+      send(view.pid, {:some_unexpected_message, :payload})
+
+      assert render(view) =~ "SSH key"
+    end
+
     test "auto-backfills a default key for a legacy user on first mount",
          %{conn: conn, user: user} do
       # `register_and_log_in_user` uses `Ash.Seed.seed!`, which skips


### PR DESCRIPTION
## Problem

Reported as *\"the same error in cards\"* on three task pages on `test.camelotai.tech`:
`/tasks/e007bbc3…`, `/tasks/b2be763b…`, `/tasks/e163e3a3…`.

All three tasks are assigned to the **same agent** (`1245ddd1…` "Claude CamelotAI"). Each task card subscribes to `agent:#{agent_id}` (to stream live output), but `TaskLive` had **no `handle_info/2` clause for `{:agent_updated, agent}`** — the message `AgentProcess` broadcasts to that same topic whenever the agent's status changes (e.g. `:idle` ⇆ `:busy`).

Result: every open card whose agent changed status crashed with:

```
** (FunctionClauseError) no function clause matching in CamelotWeb.TaskLive.handle_info/2
    lib/camelot_web/live/task_live.ex:62
    handle_info({:agent_updated, %Agent{status: :busy}}, ...)
```

Prod logs showed 18 identical crashes in 6h, no other error types. Cards sharing one agent crash in lockstep — hence "the same error" across all three (including the `queued` one, whose task state is fine — confirming this is a page-level LiveView crash, not the task's `error` state).

`AgentLive.Show` / `AgentLive.Index` subscribe to the same topic but already handle `{:agent_updated, …}` **and** have a catch-all; `TaskLive` had neither.

## Fix

1. Add `handle_info({:agent_updated, agent}, socket)` to `TaskLive` that refreshes the agent embedded in the task, so the card also reflects busy/idle live.
2. Add a defensive catch-all `handle_info(_msg, socket)` to `TaskLive`, `BoardLive`, and `UserProfileLive` (the three subscribing LiveViews that lacked one) so an unexpected PubSub message can never crash a page.

## Tests

- Reproduced the crash first (TDD): new tests broadcast `{:agent_updated, …}` and an unexpected message and assert the LiveView survives (`render/1` round-trip). Red before the fix, green after.
- `mix test`: 245 tests, 0 failures. Compile (`--warnings-as-errors`), `mix format`, `mix credo`, `mix dialyzer` all clean.

## Not included

The two tasks in `error` state failed execution for an unrelated reason ("Agent finished executing without opening a PR"). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)