### PR TITLE
fix(runtime): recover executing stage when the agent opens no PR

### DIFF
--- a/.claude/rules/feature-workflow.md
+++ b/.claude/rules/feature-workflow.md
@@ -1,0 +1,15 @@
+# Feature Implementation Flow
+
+- Create a new branch from `main` for the feature
+- Implement tests first (TDD)
+- Implement the feature code
+- Make sure code is compilable by `mix compile` and has no warnings
+- Run all tests with `mix test` and ensure they pass
+- Make sure code runs in `iex -S mix` without errors
+- Check with `mix dialyzer` for type issues
+- Update documentation and AGENTS.md if needed
+- Run `mix format` to ensure code style compliance
+- Commit code
+- Push branch to remote
+- Create a pull request
+

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -1,0 +1,15 @@
+# PR Issues Fixing Flow
+
+**Never fix files in `.claude` directory! **
+
+- Checkout the branch related to the PR
+- Fix critical issues from the comments and review in the PR
+- Make sure code is compilable by `mix compile` and has no warnings
+- Run all tests with `mix test` and ensure they pass
+- Make sure code runs in `iex -S mix` without errors
+- Check with `mix dialyzer` for type issues
+- Run `mix format` to ensure code style compliance
+- Commit code
+- Push branch to remote
+- Create a pull request
+

--- a/lib/camelot/agents/changes/dispatch_tasks.ex
+++ b/lib/camelot/agents/changes/dispatch_tasks.ex
@@ -125,8 +125,21 @@ defmodule Camelot.Agents.Changes.DispatchTasks do
         {:error, :template_not_found} -> fallback_prompt(task)
       end
 
-    append_conversation(base, task.messages)
+    base
+    |> append_branch_directive(task, slug)
+    |> append_conversation(task.messages)
   end
+
+  # Pin the working branch to a deterministic, task-scoped name so a
+  # PR that the agent opens can be recovered from GitHub even when its
+  # URL is missing from the final output (see AgentProcess fallback).
+  defp append_branch_directive(prompt, task, "execution") do
+    prompt <>
+      "\n\nWork on a git branch named exactly `camelot/task-#{task.id}` " <>
+      "and open the pull request from that branch."
+  end
+
+  defp append_branch_directive(prompt, _task, _slug), do: prompt
 
   defp prompt_slug(%{stage: :pr}), do: "pr_review"
 

--- a/lib/camelot/agents/claude_code_defaults.ex
+++ b/lib/camelot/agents/claude_code_defaults.ex
@@ -21,6 +21,25 @@ defmodule Camelot.Agents.ClaudeCodeDefaults do
   @spec planning_system_prompt() :: String.t()
   def planning_system_prompt, do: @planning_system_prompt
 
+  @execution_system_prompt "You are running fully autonomously in a " <>
+                             "headless, single-turn session: there is no " <>
+                             "interactive user to answer you and no follow-up " <>
+                             "turn, so you must complete the whole task before " <>
+                             "your turn ends. Do NOT use background tasks or " <>
+                             "run any command in the background; run every " <>
+                             "command (tests, builds, git) synchronously and " <>
+                             "wait for it to finish inline. Do NOT stop to " <>
+                             "wait for a notification, approval, or " <>
+                             "confirmation — the plan is already approved. " <>
+                             "Finish the task by opening a pull request with " <>
+                             "`gh pr create`, and print the resulting PR URL " <>
+                             "as the last line of your final message so it is " <>
+                             "captured."
+
+  @doc "System prompt appended to the execution run."
+  @spec execution_system_prompt() :: String.t()
+  def execution_system_prompt, do: @execution_system_prompt
+
   @doc """
   JSON Schema (encoded string) passed as `--json-schema` for planning.
 
@@ -72,7 +91,12 @@ defmodule Camelot.Agents.ClaudeCodeDefaults do
         "--json-schema",
         planning_json_schema()
       ],
-      "executing" => ["--permission-mode", "acceptEdits"]
+      "executing" => [
+        "--permission-mode",
+        "acceptEdits",
+        "--append-system-prompt",
+        execution_system_prompt()
+      ]
     }
   end
 end

--- a/lib/camelot/github/client.ex
+++ b/lib/camelot/github/client.ex
@@ -62,6 +62,20 @@ defmodule Camelot.Github.Client do
     )
   end
 
+  @spec find_open_pr_by_head(String.t(), String.t(), String.t()) ::
+          {:ok, map()} | :none | {:error, term()}
+  def find_open_pr_by_head(owner, repo, branch) do
+    case request(
+           :get,
+           "/repos/#{owner}/#{repo}/pulls" <>
+             "?state=open&head=#{owner}:#{branch}"
+         ) do
+      {:ok, [pr | _]} -> {:ok, pr}
+      {:ok, _} -> :none
+      error -> error
+    end
+  end
+
   defp request(method, path) do
     url = @base_url <> path
 

--- a/lib/camelot/runtime/agent_process.ex
+++ b/lib/camelot/runtime/agent_process.ex
@@ -29,6 +29,7 @@ defmodule Camelot.Runtime.AgentProcess do
   alias Camelot.Agents.Session
   alias Camelot.Board.Task
   alias Camelot.Board.TaskMessage
+  alias Camelot.Github.Client
   alias Camelot.Runtime.AgentConfig
   alias Camelot.Runtime.AgentRegistry
   alias Camelot.Runtime.EnvVarResolver
@@ -935,26 +936,71 @@ defmodule Camelot.Runtime.AgentProcess do
   defp structured_questions(_), do: nil
 
   defp maybe_create_pr(state, task, text, task_id) do
-    {pr_url, pr_number} = extract_pr_info(state, text)
+    case execution_pr_outcome(state, task, text) do
+      {:pr, pr_url, pr_number} ->
+        record_pr(task, pr_url, pr_number, task_id)
 
-    if pr_url do
-      case Ash.update(task, %{pr_url: pr_url, pr_number: pr_number}, action: :pr_created) do
-        {:ok, updated} ->
-          broadcast_task_update(updated)
-
-        {:error, error} ->
-          Logger.warning("Failed to mark PR created for task #{task_id}: #{inspect(error)}")
-      end
-    else
-      Logger.warning("Execution completed without PR for task #{task_id}")
-
-      mark_error_with_reason(
-        state,
-        task,
-        "Agent finished executing without opening a PR. " <>
-          "No PR URL was found in the agent's final output."
-      )
+      :no_pr ->
+        Logger.warning("Execution completed without PR for task #{task_id}")
+        request_no_pr_input(state, task, task_id)
     end
+  end
+
+  @doc """
+  Decides whether an execution run produced a PR.
+
+  Prefers a URL scraped from the agent's final output; failing that,
+  falls back to querying GitHub for an open PR on the task's dedicated
+  `camelot/task-<id>` branch (guards a real PR whose URL never reached
+  stdout). Returns `:no_pr` when neither yields one.
+  """
+  @spec execution_pr_outcome(t(), Task.t(), String.t()) ::
+          {:pr, String.t(), pos_integer()} | :no_pr
+  def execution_pr_outcome(state, task, text) do
+    case extract_pr_info(state, text) do
+      {nil, _} -> github_pr_fallback(task)
+      {url, number} -> {:pr, url, number}
+    end
+  end
+
+  defp github_pr_fallback(task) do
+    task = Ash.load!(task, :project)
+    find_pr_on_github(task.project, task.id)
+  end
+
+  defp find_pr_on_github(%{github_owner: nil}, _task_id), do: :no_pr
+  defp find_pr_on_github(%{github_repo: nil}, _task_id), do: :no_pr
+
+  defp find_pr_on_github(%{github_owner: owner, github_repo: repo}, task_id) do
+    case Client.find_open_pr_by_head(owner, repo, "camelot/task-#{task_id}") do
+      {:ok, %{"html_url" => url, "number" => number}} ->
+        {:pr, url, number}
+
+      _ ->
+        :no_pr
+    end
+  end
+
+  defp record_pr(task, pr_url, pr_number, task_id) do
+    case Ash.update(task, %{pr_url: pr_url, pr_number: pr_number}, action: :pr_created) do
+      {:ok, updated} ->
+        broadcast_task_update(updated)
+
+      {:error, error} ->
+        Logger.warning("Failed to mark PR created for task #{task_id}: #{inspect(error)}")
+    end
+  end
+
+  # Clean exit but no PR: keep the task recoverable instead of dead
+  # (:error). Route it to waiting_for_input with an explanation; a reply
+  # re-queues the executing stage with the conversation appended.
+  defp request_no_pr_input(state, task, task_id) do
+    reason =
+      "Finished executing but no pull request was opened. Reply to have " <>
+        "me open the PR, or give further guidance."
+
+    annotate_session_error(state.current_session_id, reason)
+    request_user_input(task, reason, task_id)
   end
 
   defp has_questions?(denials) do
@@ -1043,38 +1089,54 @@ defmodule Camelot.Runtime.AgentProcess do
     Phoenix.PubSub.broadcast(Camelot.PubSub, "board", {:task_updated, task})
   end
 
-  defp finish_session(state, exit_code, parsed, denials) do
-    if state.current_session_id do
-      session = Ash.get!(Session, state.current_session_id)
-      action = if exit_code == 0, do: :complete, else: :fail
-
-      error_message =
-        case parsed do
-          {:error, msg} -> msg
-          _ -> nil
-        end
-
-      case Ash.update(
-             session,
-             %{
-               output_log: state.output_buffer,
-               exit_code: exit_code,
-               error_message: error_message,
-               permission_denials: denials
-             },
-             action: action
-           ) do
-        {:ok, _} ->
-          :ok
-
-        {:error, reason} ->
-          Logger.error(
-            "AgentProcess #{state.agent_id} failed to mark session " <>
-              "#{state.current_session_id} as #{action}: #{inspect(reason)}"
-          )
-      end
-    end
+  @doc false
+  # Finalise the current session row. Wrapped in a rescue so a transient
+  # DB error (or a session deleted out from under us) logs and returns
+  # instead of crashing AgentProcess mid-finalisation — which would
+  # strand the session as :running until the Reconciler swept it.
+  @spec finish_session(t(), integer(), term(), [map()]) :: :ok
+  def finish_session(%__MODULE__{current_session_id: nil}, _exit_code, _parsed, _denials) do
+    :ok
   end
+
+  def finish_session(state, exit_code, parsed, denials) do
+    session = Ash.get!(Session, state.current_session_id)
+    action = session_action(exit_code)
+
+    case Ash.update(
+           session,
+           %{
+             output_log: state.output_buffer,
+             exit_code: exit_code,
+             error_message: parsed_error(parsed),
+             permission_denials: denials
+           },
+           action: action
+         ) do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "AgentProcess #{state.agent_id} failed to mark session " <>
+            "#{state.current_session_id} as #{action}: #{inspect(reason)}"
+        )
+    end
+  rescue
+    error ->
+      Logger.error(
+        "AgentProcess #{state.agent_id} crashed finalising session " <>
+          "#{state.current_session_id}: #{Exception.message(error)}"
+      )
+
+      :ok
+  end
+
+  defp session_action(0), do: :complete
+  defp session_action(_exit_code), do: :fail
+
+  defp parsed_error({:error, msg}), do: msg
+  defp parsed_error(_parsed), do: nil
 
   defp extract_denials({:ok, %{permission_denials: d}}), do: d
   defp extract_denials(_), do: []

--- a/priv/repo/migrations/20260713120000_claude_execution_system_prompt.exs
+++ b/priv/repo/migrations/20260713120000_claude_execution_system_prompt.exs
@@ -1,0 +1,46 @@
+defmodule Camelot.Repo.Migrations.ClaudeExecutionSystemPrompt do
+  @moduledoc """
+  Append an execution-stage system prompt to the seeded `claude_code`
+  template. In a headless, single-turn `claude -p` run the agent used
+  to spawn background tasks and end its turn to "wait for a
+  notification", exiting cleanly without opening a PR. The appended
+  `--append-system-prompt` steers it to run synchronously, never pause
+  for approval, and always open the PR (printing its URL).
+
+  Only rewrites the `{executing}` key (via jsonb_set) so hand-customised
+  stages are preserved. Idempotent: guarded on whether the executing
+  args already carry `--append-system-prompt`.
+  """
+  use Ecto.Migration
+
+  alias Camelot.Agents.ClaudeCodeDefaults
+
+  def up do
+    new_executing =
+      Jason.encode!(ClaudeCodeDefaults.permission_args_by_stage()["executing"])
+
+    repo().query!(
+      """
+      UPDATE agent_templates
+      SET permission_args_by_stage =
+        jsonb_set(permission_args_by_stage, '{executing}', $1::text::jsonb)
+      WHERE slug = 'claude_code'
+        AND NOT (permission_args_by_stage -> 'executing' @> '["--append-system-prompt"]'::jsonb)
+      """,
+      [new_executing]
+    )
+  end
+
+  def down do
+    repo().query!(
+      """
+      UPDATE agent_templates
+      SET permission_args_by_stage =
+        jsonb_set(permission_args_by_stage, '{executing}', '["--permission-mode","acceptEdits"]'::jsonb)
+      WHERE slug = 'claude_code'
+        AND permission_args_by_stage -> 'executing' @> '["--append-system-prompt"]'::jsonb
+      """,
+      []
+    )
+  end
+end

--- a/test/camelot/github/client_test.exs
+++ b/test/camelot/github/client_test.exs
@@ -36,4 +36,15 @@ defmodule Camelot.Github.ClientTest do
                )
     end
   end
+
+  describe "find_open_pr_by_head/3" do
+    test "handles API errors gracefully" do
+      assert {:error, _} =
+               Client.find_open_pr_by_head(
+                 "nonexistent-owner",
+                 "nonexistent-repo",
+                 "camelot/task-abc"
+               )
+    end
+  end
 end

--- a/test/camelot/runtime/agent_config_test.exs
+++ b/test/camelot/runtime/agent_config_test.exs
@@ -41,7 +41,7 @@ defmodule Camelot.Runtime.AgentConfigTest do
       assert "--json-schema" in args
     end
 
-    test "executing stage emits --permission-mode acceptEdits", ctx do
+    test "executing stage emits acceptEdits + the execution system prompt", ctx do
       args =
         AgentConfig.build_cli_args(
           ctx.claude,
@@ -50,17 +50,17 @@ defmodule Camelot.Runtime.AgentConfigTest do
           :executing
         )
 
-      assert args == [
-               "--output-format",
-               "stream-json",
-               "--verbose",
-               "--permission-mode",
-               "acceptEdits",
-               "--allowedTools",
-               "Read",
-               "-p",
-               "do it"
-             ]
+      executing_args = ClaudeCodeDefaults.permission_args_by_stage()["executing"]
+
+      assert args ==
+               ["--output-format", "stream-json", "--verbose"] ++
+                 executing_args ++
+                 ["--allowedTools", "Read", "-p", "do it"]
+
+      # Guard the contract shape explicitly.
+      assert "--permission-mode" in args
+      assert "acceptEdits" in args
+      assert "--append-system-prompt" in args
     end
 
     test "filters EnterPlanMode / ExitPlanMode from allowed_tools", ctx do
@@ -137,6 +137,16 @@ defmodule Camelot.Runtime.AgentConfigTest do
                "/w",
                "img"
              ]
+    end
+  end
+
+  describe "ClaudeCodeDefaults.execution_system_prompt/0" do
+    test "forbids background tasks and mandates opening a PR" do
+      prompt = ClaudeCodeDefaults.execution_system_prompt()
+
+      assert prompt =~ "background task"
+      assert prompt =~ "gh pr create"
+      assert prompt =~ "PR URL"
     end
   end
 

--- a/test/camelot/runtime/agent_process_test.exs
+++ b/test/camelot/runtime/agent_process_test.exs
@@ -315,4 +315,54 @@ defmodule Camelot.Runtime.AgentProcessTest do
                AgentProcess.planning_action(planning_state(), res)
     end
   end
+
+  describe "execution_pr_outcome/3" do
+    defp exec_state do
+      %AgentProcess{
+        agent_id: "a",
+        config: %AgentConfig{
+          parser: :claude_code_json,
+          executable: "claude",
+          pr_url_pattern: "https://github\\.com/[^\\s]+/pull/(\\d+)"
+        }
+      }
+    end
+
+    test "extracts a PR URL from the final output", ctx do
+      text = "All done. Opened https://github.com/T0ha/camelot/pull/42 for review."
+
+      assert {:pr, "https://github.com/T0ha/camelot/pull/42", 42} =
+               AgentProcess.execution_pr_outcome(exec_state(), ctx.task, text)
+    end
+
+    test "returns :no_pr when no URL and the project has no GitHub repo", ctx do
+      # setup project is created without github_owner/repo, so the
+      # GitHub fallback short-circuits without a network call.
+      assert :no_pr =
+               AgentProcess.execution_pr_outcome(
+                 exec_state(),
+                 ctx.task,
+                 "Finished, but I did not open a PR."
+               )
+    end
+  end
+
+  describe "finish_session/4" do
+    test "is a no-op when there is no current session" do
+      state = %AgentProcess{agent_id: "a", current_session_id: nil, output_buffer: ""}
+      assert :ok = AgentProcess.finish_session(state, 0, nil, [])
+    end
+
+    test "does not crash when the session row is missing" do
+      state = %AgentProcess{
+        agent_id: "a",
+        current_session_id: Ecto.UUID.generate(),
+        output_buffer: "some output"
+      }
+
+      # Ash.get! raises for the missing row; the rescue must swallow it
+      # so AgentProcess survives instead of stranding the session.
+      assert :ok = AgentProcess.finish_session(state, 1, {:error, "boom"}, [])
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Fix #3 from the `test.camelotai.tech` investigation. Tasks `e007bbc3…` and `b2be763b…` dead-ended in `error` with *"Agent finished executing without opening a PR. No PR URL was found in the agent's final output."*

Root cause (evidence from the captured session logs): in a headless single-turn `claude -p` run the coding agent spawned **background bash tasks** (`mix test` via a poll loop) and ended its turn with *"I'll stop polling and wait for the automatic task-completion notification before proceeding."* Nothing re-invokes it in a one-shot exec, so the CLI exits 0 with the work unfinished — no PR. `maybe_create_pr/4` then hard-errored the task. A contributing factor: the `execution` prompt referenced `@.claude/rules/feature-workflow.md`, which didn't exist, so the agent never saw the "open a PR" step.

## Changes

1. **Execution-stage system prompt** (`ClaudeCodeDefaults`) appended via `--append-system-prompt` (mirrors the planning system prompt): run every command synchronously, never use background tasks or wait for notifications, always finish by opening a PR with `gh pr create` and printing its URL. A data migration updates the seeded `claude_code` template row (same pattern as `20260709120000_claude_planning_json_schema`). `DispatchTasks` pins a deterministic `camelot/task-<id>` branch.
2. **Missing rule files** `feature-workflow.md` / `pr-workflow.md` added (cherry-picked from the author's local commit) so the `@`-mention in the execution/pr-review prompts resolves in the runner's clone.
3. **GitHub PR fallback** — `Github.Client.find_open_pr_by_head/3`; before erroring, `maybe_create_pr/4` checks GitHub for an open PR on the task's head branch, catching a real PR whose URL never reached stdout.
4. **User-actionable recovery** — on clean-exit-no-PR the task now routes to `waiting_for_input` (via `request_user_input/3`) instead of terminal `:error`; a reply re-queues the executing stage with conversation history appended. No new UI/resume machinery.
5. **Harden `finish_session/4`** (Error A) — wrap in `try/rescue` so a transient `Ash.get!`/`Ash.update` failure logs instead of crashing AgentProcess and stranding a session as `:running` (the July-10 "unregistered without finalising" crash).

## Tests

- `execution_pr_outcome/3`: extracts a URL from output; returns `:no_pr` (fallback short-circuits with no GitHub repo).
- `finish_session/4`: no-op with no session; survives a missing session row without crashing.
- `agent_config`: executing args now carry `--append-system-prompt`; execution system prompt forbids background tasks and mandates a PR.
- `Github.Client.find_open_pr_by_head/3`: handles API errors gracefully.
- Full gate: `mix test` **281/0**, compile `--warnings-as-errors`, `mix format`, `mix credo`, `mix dialyzer` all clean.

## Deploy note

The data migration updates the running system's `claude_code` template; the new rule files ship in this PR so the runner (which clones the repo) picks them up once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)