### PR TITLE
feat: send invitation email when admin creates a user

### DIFF
--- a/lib/camelot/accounts/user.ex
+++ b/lib/camelot/accounts/user.ex
@@ -135,6 +135,7 @@ defmodule Camelot.Accounts.User do
     create :create_user do
       accept([:email, :role])
       change(set_attribute(:confirmed_at, &DateTime.utc_now/0))
+      change(Camelot.Accounts.User.Changes.SendInvitationEmail)
     end
 
     update :set_swarm_node_label do

--- a/lib/camelot/accounts/user/changes/send_invitation_email.ex
+++ b/lib/camelot/accounts/user/changes/send_invitation_email.ex
@@ -1,0 +1,37 @@
+defmodule Camelot.Accounts.User.Changes.SendInvitationEmail do
+  @moduledoc """
+  Sends a marketing-style invitation email after an admin creates a
+  new user via `User.:create_user`.
+
+  Not wired into the magic-link auto-upsert — self-registering users
+  already know the platform exists, so they only get the token-bearing
+  `SendMagicLink`/`SendConfirmationEmail` mail, not this one.
+
+  Delivery failure is non-fatal: the user is created either way.
+  """
+  use Ash.Resource.Change
+
+  alias Camelot.Accounts.User.Senders.SendInvitationEmail
+
+  require Logger
+
+  @impl Ash.Resource.Change
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.after_action(changeset, fn _changeset, user ->
+      _ = safely_deliver(user)
+      {:ok, user}
+    end)
+  end
+
+  defp safely_deliver(user) do
+    SendInvitationEmail.deliver(user)
+  rescue
+    error ->
+      Logger.warning(
+        "SendInvitationEmail: delivery failed for user #{user.id} — " <>
+          Exception.format(:error, error, __STACKTRACE__)
+      )
+
+      {:error, error}
+  end
+end

--- a/lib/camelot/accounts/user/senders/send_invitation_email.ex
+++ b/lib/camelot/accounts/user/senders/send_invitation_email.ex
@@ -1,0 +1,97 @@
+defmodule Camelot.Accounts.User.Senders.SendInvitationEmail do
+  @moduledoc """
+  Sends a marketing-style invitation email to a newly admin-created
+  user via Swoosh. In dev mode, viewable at /dev/mailbox.
+
+  Unlike `Camelot.Accounts.User.Senders.SendMagicLink`, this carries
+  no token: it just points the user at the sign-in page so they can
+  request their own magic link whenever they're ready to start.
+  """
+
+  import Swoosh.Email
+
+  @spec deliver(Ash.Resource.record()) :: :ok
+  def deliver(user) do
+    email = to_string(user.email)
+
+    email
+    |> build_email(sign_in_url())
+    |> Camelot.Mailer.deliver!()
+
+    :ok
+  end
+
+  defp sign_in_url do
+    query =
+      URI.encode_query(
+        utm_source: "email",
+        utm_medium: "invitation",
+        utm_campaign: "admin_invite"
+      )
+
+    CamelotWeb.Endpoint.url() <> "/sign-in?" <> query
+  end
+
+  defp build_email(to, url) do
+    new()
+    |> from(Camelot.Mailer.from())
+    |> to(to)
+    |> subject("You're invited to Camelot")
+    |> html_body(html_body(url))
+    |> text_body(text_body(url))
+  end
+
+  defp html_body(url) do
+    """
+    <div style="font-family: -apple-system, Helvetica, Arial, sans-serif; \
+    max-width: 560px; margin: 0 auto; color: #1a1a2e;">
+      <div style="background: #1a1a2e; padding: 32px 24px; text-align: center;">
+        <h1 style="color: #ffffff; font-size: 20px; margin: 0;">Camelot</h1>
+      </div>
+      <div style="padding: 32px 24px; background: #ffffff;">
+        <h2 style="margin-top: 0;">Your Camelot account is ready</h2>
+        <p>
+          Delegate coding tasks to AI agents and manage them from a kanban
+          board. Create tasks, let agents plan and implement them, then
+          review and approve before anything ships.
+        </p>
+        <ul style="padding-left: 20px; line-height: 1.6;">
+          <li><strong>Kanban board</strong> — track every task from todo to done.</li>
+          <li><strong>Multi-agent coordination</strong> — run agents in parallel across projects.</li>
+          <li><strong>Human-in-the-loop</strong> — approve plans before anything is written.</li>
+          <li><strong>GitHub-native</strong> — syncs issues, tracks PRs, auto-completes on merge.</li>
+        </ul>
+        <p style="text-align: center; margin: 32px 0;">
+          <a href="#{url}" style="background: #7c3aed; color: #ffffff; \
+    padding: 12px 24px; border-radius: 6px; text-decoration: none; \
+    font-weight: bold; display: inline-block;">
+            Sign in to Camelot
+          </a>
+        </p>
+        <p style="color: #666666; font-size: 14px;">
+          If the button doesn't work, copy and paste this link into your browser:<br>
+          <a href="#{url}" style="color: #7c3aed;">#{url}</a>
+        </p>
+      </div>
+    </div>
+    """
+  end
+
+  defp text_body(url) do
+    """
+    Your Camelot account is ready
+
+    Delegate coding tasks to AI agents and manage them from a kanban
+    board. Create tasks, let agents plan and implement them, then
+    review and approve before anything ships.
+
+    - Kanban board — track every task from todo to done.
+    - Multi-agent coordination — run agents in parallel across projects.
+    - Human-in-the-loop — approve plans before anything is written.
+    - GitHub-native — syncs issues, tracks PRs, auto-completes on merge.
+
+    Sign in to Camelot:
+    #{url}
+    """
+  end
+end

--- a/lib/camelot_web/live/admin_live/users.ex
+++ b/lib/camelot_web/live/admin_live/users.ex
@@ -130,8 +130,8 @@ defmodule CamelotWeb.AdminLive.Users do
         <h2 class="text-lg font-semibold">Add user</h2>
 
         <p class="text-sm text-base-content/60">
-          The new user can sign in immediately with a magic link sent to this
-          email address.
+          The new user gets an invitation email at this address and can
+          sign in themselves with a magic link whenever they're ready.
         </p>
 
         <.form

--- a/lib/mix/tasks/camelot.create_user.ex
+++ b/lib/mix/tasks/camelot.create_user.ex
@@ -2,14 +2,14 @@ defmodule Mix.Tasks.Camelot.CreateUser do
   @shortdoc "Create a confirmed user account by email"
 
   @moduledoc """
-  Creates a confirmed user account so they can sign in immediately via
-  magic link.
+  Creates a confirmed user account and sends them an invitation email
+  so they can sign in themselves via magic link.
 
       mix camelot.create_user EMAIL [--role admin|user]
 
   Defaults to `--role admin` so the first invocation on a fresh install
-  bootstraps an operator account. Subsequent users can be added from
-  `/admin/users` once an admin is signed in.
+  bootstraps an operator account. Subsequent users can also be added
+  from `/admin/users` once an admin is signed in.
 
   Works in a release as:
 

--- a/test/camelot/accounts/user/changes/send_invitation_email_test.exs
+++ b/test/camelot/accounts/user/changes/send_invitation_email_test.exs
@@ -1,0 +1,53 @@
+defmodule Camelot.Accounts.User.Changes.SendInvitationEmailTest do
+  use Camelot.DataCase, async: false
+
+  import Swoosh.TestAssertions
+
+  alias Ash.Resource.Info
+  alias Camelot.Accounts.User
+  alias Camelot.Accounts.User.Changes.SendInvitationEmail
+
+  describe ":create_user action" do
+    test "sends an invitation email after user creation" do
+      admin = Ash.Seed.seed!(User, %{email: "admin@e.com", role: :admin})
+
+      {:ok, user} =
+        User
+        |> Ash.Changeset.for_create(
+          :create_user,
+          %{email: "new@e.com", role: :user},
+          actor: admin
+        )
+        |> Ash.create()
+
+      assert_email_sent(to: [{"", to_string(user.email)}])
+    end
+  end
+
+  describe "resource-level wiring" do
+    test "the change is scoped to :create_user, not the resource-wide :create changes" do
+      create_user_action = Info.action(User, :create_user)
+
+      assert Enum.any?(create_user_action.changes, fn change ->
+               match?(
+                 %{change: {SendInvitationEmail, []}},
+                 change
+               )
+             end),
+             """
+             SendInvitationEmail should be wired into :create_user only, \
+             not on: [:create], so self-registering magic-link users \
+             don't get this email. Configured changes: \
+             #{inspect(create_user_action.changes)}
+             """
+
+      resource_changes = Info.changes(User)
+
+      refute Enum.any?(resource_changes, fn change ->
+               change.change ==
+                 {SendInvitationEmail, []}
+             end),
+             "SendInvitationEmail should not be a resource-wide change"
+    end
+  end
+end

--- a/test/camelot/accounts/user/senders/send_invitation_email_test.exs
+++ b/test/camelot/accounts/user/senders/send_invitation_email_test.exs
@@ -1,0 +1,24 @@
+defmodule Camelot.Accounts.User.Senders.SendInvitationEmailTest do
+  use Camelot.DataCase, async: false
+
+  import Swoosh.TestAssertions
+
+  alias Camelot.Accounts.User
+  alias Camelot.Accounts.User.Senders.SendInvitationEmail
+
+  test "delivers an invitation email with a sign-in link carrying UTM tags" do
+    user = Ash.Seed.seed!(User, %{email: "invited@example.com"})
+
+    :ok = SendInvitationEmail.deliver(user)
+
+    assert_email_sent(fn email ->
+      assert email.to == [{"", "invited@example.com"}]
+      assert email.subject =~ "invited"
+      assert email.html_body =~ "/sign-in?"
+      assert email.html_body =~ "utm_source=email"
+      assert email.html_body =~ "utm_medium=invitation"
+      assert email.html_body =~ "utm_campaign=admin_invite"
+      assert email.text_body =~ "/sign-in?"
+    end)
+  end
+end


### PR DESCRIPTION
## Summary
- Admin-created users had no way to learn their account existed — this adds a marketing-style invitation email sent right after `create :create_user`, with a sign-in link carrying UTM tags (no token, no magic-link expiry pressure).
- New `Camelot.Accounts.User.Senders.SendInvitationEmail` (Swoosh sender, brand-styled HTML/text, viewable at `/dev/mailbox` in dev) and `Camelot.Accounts.User.Changes.SendInvitationEmail` (`Ash.Resource.Change`, `after_action`, non-fatal on delivery failure — mirrors `EnsureDefaultSshKey`).
- Wired only into `create :create_user` (not the resource-wide `:create` changes), so self-registering magic-link users are unaffected.
- Updated `/admin/users` copy and `mix camelot.create_user` moduledoc to match the new behavior.

## Test plan
- [x] `mix test` — 300 tests, 0 failures (including new sender/change tests using `Swoosh.TestAssertions`)
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix credo --strict` — no new issues
- [x] `mix format --check-formatted` — clean
- [ ] `mix dialyzer` — running; will report separately if it surfaces anything

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>