### PR TITLE
fix(runtime): recover stuck executing tasks — no-PR recovery + bounded session adoption

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - develop
 
 defaults:
   run:
@@ -17,7 +18,7 @@ jobs:
   build_docker_image:
     name: Build Image
     runs-on: ubuntu-24.04
-    environment: test
+    environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'test' }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/push-checks.yml
+++ b/.github/workflows/push-checks.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches-ignore:
       - main
+      - develop
 
 defaults:
   run:

--- a/lib/camelot/runtime/agent_process.ex
+++ b/lib/camelot/runtime/agent_process.ex
@@ -495,7 +495,11 @@ defmodule Camelot.Runtime.AgentProcess do
         output_buffer: session.output_log || ""
     }
 
-    spec = %{build_spec(state, agent, task, config, []) | adopt?: true}
+    spec = %{
+      build_spec(state, agent, task, config, [])
+      | adopt?: true,
+        adopt_since: session.started_at
+    }
 
     case Runner.start(spec) do
       {:ok, runner_pid} ->

--- a/lib/camelot/runtime/reconciler.ex
+++ b/lib/camelot/runtime/reconciler.ex
@@ -11,10 +11,16 @@ defmodule Camelot.Runtime.Reconciler do
        If the session's task runner container is still
        alive, it is **adopted** — a fresh AgentProcess
        re-attaches and finalises from the durable tee'd
-       output (`was_adopted` is set). Only when there is no
-       live container to re-attach to (bootstrap sessions,
-       the LocalPort backend, or a truly gone runner) is the
-       session marked failed for the user to retry.
+       output (`was_adopted` is set). Adoption is refused
+       when the live container was *replaced* after the
+       session's exec began (Swarm reschedule / OOM): the
+       tee'd output and completion marker lived in the prior
+       container's `/tmp` and can never reappear, so polling
+       for them would hang forever — such a session is
+       failed instead. When there is no live container to
+       re-attach to (bootstrap sessions, the LocalPort
+       backend, or a truly gone runner) the session is
+       likewise marked failed for the user to retry.
     2. Queued sessions are *not* touched — their DB rows
        survive untouched, and the next call to
        `RunnerPool.tick/0` (after AgentProcess
@@ -52,6 +58,7 @@ defmodule Camelot.Runtime.Reconciler do
   alias Camelot.Runtime.Runner.DockerApi
   alias Camelot.Runtime.Runner.LocalPort
   alias Camelot.Runtime.Runner.Swarm
+  alias Camelot.Runtime.Runner.Swarm.ExecSession
   alias Camelot.Runtime.RunnerPool
   alias Camelot.Runtime.SessionRegistry
 
@@ -158,11 +165,76 @@ defmodule Camelot.Runtime.Reconciler do
       presence = if handle, do: probe_runner(handle), else: :gone
 
       case recovery_action(Runner.backend(), session.kind, handle, presence) do
-        :adopt -> adopt_stale_session(session)
+        :adopt -> adopt_or_fail(session, handle)
         :fail -> fail_stale_session(session)
       end
     end
   end
+
+  # Even when the runner container is still alive, adopting is pointless
+  # if that container was *replaced* since the session's exec began: the
+  # completion marker the adoption would poll for lived in the prior
+  # container's /tmp and can never appear. Fail such a session (it stays
+  # user-recoverable) instead of handing it to an unbounded poll. This is
+  # race-free — we are in the branch where the owning AgentProcess is
+  # already gone.
+  defp adopt_or_fail(%Session{} = session, handle) do
+    if doomed_adoption?(container_started_for(handle), session.started_at) do
+      Logger.info(
+        "Reconciler: not adopting session #{session.id} — runner " <>
+          "container was replaced after the exec began; failing it so " <>
+          "it can be retried"
+      )
+
+      fail_stale_session(session)
+    else
+      adopt_stale_session(session)
+    end
+  end
+
+  @doc """
+  Whether a would-be adoption is doomed: the runner container was
+  replaced after the session's exec began, so the completion marker the
+  adoption polls for is gone.
+  """
+  @spec doomed_adoption?(DateTime.t() | nil, DateTime.t() | nil) :: boolean()
+  def doomed_adoption?(container_started_at, session_started_at) do
+    ExecSession.container_replaced?(container_started_at, session_started_at)
+  end
+
+  # Best-effort start time of the service's live replica, read from the
+  # manager task list (no node proxy needed). `nil` on any Swarm error or
+  # non-Swarm backend, in which case adoption proceeds and ExecSession's
+  # own budget bounds the poll.
+  defp container_started_for(handle) when is_binary(handle) do
+    if Runner.backend() == Swarm, do: swarm_task_created_at(handle)
+  end
+
+  defp container_started_for(_handle), do: nil
+
+  defp swarm_task_created_at(service_id) do
+    case list_runnable_swarm_tasks(service_id) do
+      {:ok, [_ | _] = tasks} ->
+        tasks
+        |> Enum.map(&Map.get(&1, "CreatedAt"))
+        |> Enum.reject(&is_nil/1)
+        |> Enum.flat_map(&parse_datetime/1)
+        |> latest_datetime()
+
+      _ ->
+        nil
+    end
+  end
+
+  defp parse_datetime(iso) do
+    case DateTime.from_iso8601(iso) do
+      {:ok, dt, _offset} -> [dt]
+      _ -> []
+    end
+  end
+
+  defp latest_datetime([]), do: nil
+  defp latest_datetime([_ | _] = dts), do: Enum.max(dts, DateTime)
 
   @doc """
   Pure decision for a stale `:running` session: `:adopt` only when a

--- a/lib/camelot/runtime/runner/spec.ex
+++ b/lib/camelot/runtime/runner/spec.ex
@@ -31,7 +31,8 @@ defmodule Camelot.Runtime.Runner.Spec do
             resources: %{},
             service_name: nil,
             task_id: nil,
-            adopt?: false
+            adopt?: false,
+            adopt_since: nil
 
   @type secret :: %{kind: atom(), name: String.t(), value: String.t()}
 
@@ -52,7 +53,8 @@ defmodule Camelot.Runtime.Runner.Spec do
           resources: %{optional(String.t()) => String.t()},
           service_name: String.t() | nil,
           task_id: String.t() | nil,
-          adopt?: boolean()
+          adopt?: boolean(),
+          adopt_since: DateTime.t() | nil
         }
 
   @doc """

--- a/lib/camelot/runtime/runner/swarm/exec_session.ex
+++ b/lib/camelot/runtime/runner/swarm/exec_session.ex
@@ -42,6 +42,20 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
   @adopt_poll_ms 2_000
   @transport_budget_ms 60_000
 
+  # Unlike the live-run loops above, adoption polling MUST be bounded:
+  # it waits for a completion marker written by the exec-wrapper, and if
+  # the runner container was replaced (Swarm reschedule / OOM) after the
+  # session's exec began, that marker lived in the prior container's
+  # /tmp and can never appear. An unbounded poll strands the session as
+  # `:running` and the task in `executing` forever. 15 min comfortably
+  # exceeds any real re-attach settle time.
+  @adopt_budget_ms 900_000
+
+  # Non-zero exit reported to the owner when an adoption is abandoned, so
+  # `AgentProcess` finalises the session as failed (recoverable) instead
+  # of leaving it stranded `:running`.
+  @adopt_giveup_exit_code 1
+
   defstruct [
     :owner,
     :session_id,
@@ -137,6 +151,21 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
     {:stop, :normal, state}
   end
 
+  # Adoption gave up (container replaced or budget exhausted): tell the
+  # owner the run is over with a non-zero code so it finalises the
+  # session, then stop. Normal stop so the owner's monitor DOWN is a
+  # no-op after the reset that {:runner_exit, ...} triggers.
+  def handle_info({:adopt_give_up, reason}, %__MODULE__{} = state) do
+    Logger.warning(
+      "Swarm.ExecSession: abandoning adoption of session " <>
+        "#{state.session_id} (#{reason}); finalising as failed so it " <>
+        "can be recovered"
+    )
+
+    send(state.owner, {:runner_exit, self(), @adopt_giveup_exit_code})
+    {:stop, :normal, state}
+  end
+
   def handle_info({ref, _}, state) when is_reference(ref), do: {:noreply, state}
   def handle_info({:DOWN, _, _, _, _}, state), do: {:noreply, state}
   def handle_info(_msg, state), do: {:noreply, state}
@@ -184,21 +213,60 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
       }
 
       parent = self()
-      poll_task = Task.async(fn -> poll_adopt_exit(state, parent) end)
+      container_started = container_started_at(state)
+      session_started = spec.adopt_since
+      started_mono = System.monotonic_time(:millisecond)
+
+      poll_task =
+        Task.async(fn ->
+          poll_adopt_exit(state, parent, started_mono, container_started, session_started)
+        end)
+
       {:ok, %{state | poll_task: poll_task}}
     end
   end
 
-  defp poll_adopt_exit(%__MODULE__{} = state, parent) do
-    case read_marker(state) do
-      {:ok, code} ->
-        send(parent, {:exit_code, code})
+  # Poll the wrapper's completion marker, but bounded: give up (and let
+  # the owner finalise the session as failed, so it can recover) once the
+  # runner container is known to have been replaced after the session's
+  # exec — its marker is gone — or the wall-clock budget is exhausted.
+  defp poll_adopt_exit(%__MODULE__{} = state, parent, started_mono, container_started, session_started) do
+    elapsed = System.monotonic_time(:millisecond) - started_mono
 
-      :none ->
-        Process.sleep(@adopt_poll_ms)
-        poll_adopt_exit(state, parent)
+    case adopt_action(container_started, session_started, elapsed, @adopt_budget_ms) do
+      {:give_up, reason} ->
+        send(parent, {:adopt_give_up, reason})
+
+      :poll ->
+        case read_marker(state) do
+          {:ok, code} ->
+            send(parent, {:exit_code, code})
+
+          :none ->
+            Process.sleep(@adopt_poll_ms)
+            poll_adopt_exit(state, parent, started_mono, container_started, session_started)
+        end
     end
   end
+
+  # StartedAt of the resolved runner container, parsed to a DateTime, so
+  # adoption can tell whether the container was replaced since the
+  # session's exec began. `nil` on any missing field or Docker error —
+  # the caller then falls back to the wall-clock budget alone.
+  defp container_started_at(%__MODULE__{container_id: cid, node_req: req}) when is_binary(cid) and not is_nil(req) do
+    with {:ok, %Req.Response{status: 200, body: %{"State" => %{"StartedAt" => started}}}} <-
+           Req.get(req, url: "/containers/#{cid}/json"),
+         true <- is_binary(started),
+         {:ok, dt, _offset} <- DateTime.from_iso8601(started) do
+      dt
+    else
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  end
+
+  defp container_started_at(_), do: nil
 
   defp read_marker(%__MODULE__{session_id: sid, container_id: cid, node_req: req})
        when is_binary(sid) and is_binary(cid) and not is_nil(req) do
@@ -259,6 +327,47 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSession do
     Process.sleep(@ready_poll_ms)
     resolve_container(service_id, transport_budget_ms)
   end
+
+  @doc """
+  Decides whether an adoption should keep polling for the exec-wrapper's
+  completion marker or give up.
+
+  Gives up when the runner container was (re)started *after* the
+  session's exec began — the marker that exec would have written lived in
+  the prior container's `/tmp` and is unrecoverable, so polling can never
+  terminate. Also gives up once the wall-clock budget is exhausted, a
+  backstop for missing/skewed timestamps. Otherwise keeps polling.
+  """
+  @spec adopt_action(
+          DateTime.t() | nil,
+          DateTime.t() | nil,
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: :poll | {:give_up, :container_replaced | :timeout}
+  def adopt_action(container_started_at, session_started_at, elapsed_ms, budget_ms) do
+    cond do
+      container_replaced?(container_started_at, session_started_at) ->
+        {:give_up, :container_replaced}
+
+      elapsed_ms >= budget_ms ->
+        {:give_up, :timeout}
+
+      true ->
+        :poll
+    end
+  end
+
+  @doc """
+  True when the runner container started strictly after the session's
+  exec did — proof that the completion marker (and tee'd output) the exec
+  wrote no longer exist, so an adoption polling for them would hang.
+  """
+  @spec container_replaced?(DateTime.t() | nil, DateTime.t() | nil) :: boolean()
+  def container_replaced?(%DateTime{} = container_started, %DateTime{} = session_started) do
+    DateTime.after?(container_started, session_started)
+  end
+
+  def container_replaced?(_container_started, _session_started), do: false
 
   @doc """
   Selects the container id + node id of the service's live

--- a/test/camelot/runtime/reconciler_test.exs
+++ b/test/camelot/runtime/reconciler_test.exs
@@ -34,4 +34,29 @@ defmodule Camelot.Runtime.ReconcilerTest do
       assert :fail = Reconciler.recovery_action(LocalPort, :task, "svc123", :present)
     end
   end
+
+  describe "doomed_adoption?/2" do
+    defp dt(iso), do: elem(DateTime.from_iso8601(iso), 1)
+
+    test "doomed when the live container was replaced after the exec began" do
+      # The incident: exec started 10:44, container rescheduled 12:47.
+      assert Reconciler.doomed_adoption?(
+               dt("2026-07-14T12:47:00Z"),
+               dt("2026-07-14T10:44:00Z")
+             )
+    end
+
+    test "adoptable when the container predates the exec (same container)" do
+      refute Reconciler.doomed_adoption?(
+               dt("2026-07-14T10:40:00Z"),
+               dt("2026-07-14T10:44:00Z")
+             )
+    end
+
+    test "adoptable when the container start time is unknown" do
+      # No timestamp -> proceed; ExecSession's wall-clock budget still
+      # bounds the poll.
+      refute Reconciler.doomed_adoption?(nil, dt("2026-07-14T10:44:00Z"))
+    end
+  end
 end

--- a/test/camelot/runtime/runner/swarm/exec_session_test.exs
+++ b/test/camelot/runtime/runner/swarm/exec_session_test.exs
@@ -18,6 +18,69 @@ defmodule Camelot.Runtime.Runner.Swarm.ExecSessionTest do
     }
   end
 
+  describe "adopt_action/4" do
+    # The reconciler adopts a `:running` session after a restart by
+    # re-attaching to the still-alive runner container and polling for
+    # the exec-wrapper's completion marker. If the container was
+    # *replaced* (Swarm reschedule / OOM on a tiny node) after the
+    # session's exec began, the marker lived in the prior container's
+    # /tmp and can never appear — polling must give up rather than hang
+    # forever (the regression that stranded a task in `executing`).
+    defp dt(iso), do: elem(DateTime.from_iso8601(iso), 1)
+
+    test "keeps polling while the container predates the session exec" do
+      # Container booted before the session started -> same container the
+      # exec ran in; its marker is still recoverable.
+      container = dt("2026-07-14T10:40:00Z")
+      session = dt("2026-07-14T10:44:00Z")
+
+      assert ExecSession.adopt_action(container, session, 0, 900_000) == :poll
+    end
+
+    test "gives up when the container was replaced after the session exec" do
+      # The actual incident: container rescheduled at 12:47, session exec
+      # began at 10:44 -> marker unrecoverable.
+      container = dt("2026-07-14T12:47:00Z")
+      session = dt("2026-07-14T10:44:00Z")
+
+      assert ExecSession.adopt_action(container, session, 0, 900_000) ==
+               {:give_up, :container_replaced}
+    end
+
+    test "gives up once the wall-clock budget is exhausted" do
+      # Backstop for missing/again-skewed timestamps: never poll forever.
+      assert ExecSession.adopt_action(nil, nil, 900_000, 900_000) ==
+               {:give_up, :timeout}
+    end
+
+    test "polls within budget when timestamps are unavailable" do
+      assert ExecSession.adopt_action(nil, nil, 1_000, 900_000) == :poll
+    end
+  end
+
+  describe "container_replaced?/2" do
+    defp t(iso), do: elem(DateTime.from_iso8601(iso), 1)
+
+    test "true when the container started strictly after the session" do
+      assert ExecSession.container_replaced?(
+               t("2026-07-14T12:47:00Z"),
+               t("2026-07-14T10:44:00Z")
+             )
+    end
+
+    test "false when the container started before the session" do
+      refute ExecSession.container_replaced?(
+               t("2026-07-14T10:40:00Z"),
+               t("2026-07-14T10:44:00Z")
+             )
+    end
+
+    test "false when either timestamp is missing" do
+      refute ExecSession.container_replaced?(nil, t("2026-07-14T10:44:00Z"))
+      refute ExecSession.container_replaced?(t("2026-07-14T10:44:00Z"), nil)
+    end
+  end
+
   describe "pick_running_task/1" do
     test "picks the desired-running, status-running placement" do
       tasks = [task("running", "running", node: "node-live", cid: "cid-live")]


### PR DESCRIPTION
## Problem

Tasks were sticking in `stage=executing, state=in_progress` with `pr_number = NULL` **even after the agent opened (and the user merged) a PR**. The merge poller (`check_pr_status`) can't help — it only looks at tasks with `stage == :pr AND pr_number != nil`.

Concrete incident: task `8de1723e` opened & merged PR #50 but sat in `executing` for over a day.

## Root cause

After a redeploy the **Reconciler adopts** a still-`:running` session by re-attaching a `Swarm.ExecSession` in `adopt?: true` mode, which polls the exec-wrapper's completion marker `/tmp/camelot-exit-<session_id>`. When the runner container was **replaced** (Swarm reschedule / OOM on the tiny 1 GB nodes) after the session's exec began, that marker lived in the *prior* container's `/tmp` and can never reappear — and `poll_adopt_exit/2` had **no deadline**, so it looped forever.

The session stayed `:running` and the task stayed `executing`, and nothing recovered it:
- owner `AgentProcess` was *alive* → `fail_stale_running_sessions/0` skips it;
- swarm service was *present* → `sweep_stale_task_runner_handles/0` skips it;
- `pr_number = NULL` + `stage = executing` → `check_pr_status` never looks at it.

Live confirmation: the `Swarm.ExecSession` process sat `status: :waiting` with a 0-byte buffer, and the current runner container's `/tmp` had no `camelot-exit-*` / `camelot-output-*` files.

## Changes

- **`Swarm.ExecSession.adopt_action/4`** bounds the adopt poll — gives up when the container was **replaced** after the session's exec began (`container_replaced?/2`: container `StartedAt` vs `spec.adopt_since`) or once a **15-min wall-clock budget** is exhausted, reporting `{:runner_exit, _, 1}` so `AgentProcess` finalises the session (failed, recoverable) instead of stranding it `:running`.
- **`Spec.adopt_since`** carries the session's `started_at`; `AgentProcess.start_adoption` threads it into the adopt spec.
- **`Reconciler.doomed_adoption?/2`** refuses to even *start* a doomed adoption (fails the session instead), using the swarm task `CreatedAt` as the live container's start time. Race-free — only runs in the branch where the owning `AgentProcess` is already gone.

Also included on this branch (earlier commit `7af31fd`): recover the executing stage when the agent finishes without opening a PR — execution-stage system prompt, deterministic `camelot/task-<id>` branch, GitHub open-PR fallback, and routing clean-exit-no-PR to `waiting_for_input` instead of terminal `:error`.

## Testing

- New pure-function unit tests: `adopt_action/4` + `container_replaced?/2` (ExecSession), `doomed_adoption?/2` (Reconciler).
- `mix compile` (no warnings), `mix test` all green, `mix format --check-formatted`, `mix credo`, and `mix dialyzer` all pass.

The stuck task `8de1723e` was manually recovered (PR #50 recorded, transitioned to `done`, hung processes stopped, orphan runner service removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)