### PR TITLE
fix: restore prod DB connection (ssl_options precedence)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -88,17 +88,20 @@ if config_env() == :prod do
       For example: ecto://USER:PASS@HOST/DATABASE
       """
 
-  ssl_options =
+  ssl_query =
     database_url
     |> URI.parse()
-    |> Map.get(:query, "") ||
-      ""
-      |> URI.decode_query()
-      |> case do
-        %{"sslmode" => "none"} -> false
-        %{"sslmode" => _} -> [ssl: true, ssl_opts: [verify: :verify_none]]
-        _ -> false
-      end
+    |> Map.get(:query)
+    |> Kernel.||("")
+    |> URI.decode_query()
+
+  ssl_options =
+    case ssl_query do
+      %{"sslmode" => "none"} -> false
+      %{"sslmode" => "disable"} -> false
+      %{"sslmode" => _} -> [verify: :verify_none]
+      _ -> false
+    end
 
   encryption_key =
     System.get_env("ENCRYPTION_KEY") ||


### PR DESCRIPTION
## Problem
Prod (`app.camelotai.tech`) is down (`0/1`), crash-looping on boot with a
`CaseClauseError` in `Postgrex.Protocol.connect/1`.

## Root cause
In `config/runtime.exs`, the `ssl_options` expression relied on `||` but
`|>` binds tighter, so it parsed as
`(URI.parse |> Map.get(:query)) || (case ...)`. The query string
`"sslmode=require"` is truthy, so `ssl_options` became that raw **string**
and the sslmode `case` never ran. Postgrex then received
`ssl: "sslmode=require"` and raised `CaseClauseError` on every connect.

## Fix
Split query extraction from the sslmode `case` so the case evaluates:
- `sslmode=require` → `[verify: :verify_none]` (SSL on, matches prior good config)
- `sslmode=none` / `disable` / absent → `false`

Verified via tidewave across all URL variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)