### PR TITLE
Detect merge conflicts and failing CI checks on monitored PRs

### DIFF
--- a/lib/camelot/board/changes/check_pr_status.ex
+++ b/lib/camelot/board/changes/check_pr_status.ex
@@ -6,6 +6,8 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
   Transitions:
   - merged → done (via complete)
   - closed → cancelled (via cancel)
+  - merge conflict → queued for agent fix (via request_pr_changes)
+  - failing CI checks → queued for agent fix (via request_pr_changes)
   - changes_requested → queued for agent fix (via request_pr_changes)
   - new comments after last commit → queued for agent fix
   - approved → done (via complete)
@@ -43,8 +45,10 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
          {:ok, comments} <-
            Client.list_pull_request_comments(owner, repo, pr),
          {:ok, commits} <-
-           Client.list_pull_request_commits(owner, repo, pr) do
-      apply_pr_state(task, pr_data, reviews, comments, commits)
+           Client.list_pull_request_commits(owner, repo, pr),
+         {:ok, check_runs} <-
+           fetch_check_runs(owner, repo, pr_data) do
+      apply_pr_state(task, pr_data, reviews, comments, commits, check_runs)
     else
       {:error, reason} ->
         Logger.warning(
@@ -54,7 +58,14 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
     end
   end
 
-  defp apply_pr_state(task, pr, reviews, comments, commits) do
+  defp fetch_check_runs(owner, repo, pr_data) do
+    case get_in(pr_data, ["head", "sha"]) do
+      nil -> {:ok, []}
+      sha -> Client.list_check_runs(owner, repo, sha)
+    end
+  end
+
+  defp apply_pr_state(task, pr, reviews, comments, commits, check_runs) do
     cond do
       pr["merged"] == true ->
         transition(task, :complete)
@@ -63,15 +74,21 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
         transition(task, :cancel)
 
       task.state == :waiting_for_input ->
-        apply_waiting_for_input(task, reviews, comments, commits)
+        apply_waiting_for_input(task, pr, reviews, comments, commits, check_runs)
 
       true ->
         :ok
     end
   end
 
-  defp apply_waiting_for_input(task, reviews, comments, commits) do
+  defp apply_waiting_for_input(task, pr, reviews, comments, commits, check_runs) do
     cond do
+      merge_conflict?(pr) ->
+        transition_with_seen_at(task, comments)
+
+      ci_failing?(check_runs) ->
+        transition_with_seen_at(task, comments)
+
       has_review_state?(reviews, "CHANGES_REQUESTED") ->
         transition_with_seen_at(task, comments)
 
@@ -84,6 +101,36 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
       true ->
         :ok
     end
+  end
+
+  @doc """
+  True if GitHub reports an unresolved merge conflict.
+
+  `mergeable` is `nil` while GitHub is still computing the merge —
+  must not trigger. `mergeable_state == "blocked"` is a branch
+  protection gate, not a git conflict, so only `"dirty"` counts.
+  """
+  @spec merge_conflict?(map()) :: boolean()
+  def merge_conflict?(pr) do
+    pr["mergeable"] == false and pr["mergeable_state"] == "dirty"
+  end
+
+  @failing_conclusions ~w(failure timed_out action_required cancelled)
+
+  @doc """
+  True if any completed check run failed.
+
+  Only `status == "completed"` runs are considered — `in_progress`/
+  `queued` runs have `conclusion == nil` and must not trigger, since
+  CI still running isn't CI failing. `cancelled` is included because a
+  cancelled run at a fixed head sha never reruns on its own.
+  """
+  @spec ci_failing?([map()]) :: boolean()
+  def ci_failing?(check_runs) do
+    Enum.any?(check_runs, fn run ->
+      run["status"] == "completed" and
+        run["conclusion"] in @failing_conclusions
+    end)
   end
 
   defp has_review_state?(reviews, state) do

--- a/lib/camelot/github/client.ex
+++ b/lib/camelot/github/client.ex
@@ -49,6 +49,21 @@ defmodule Camelot.Github.Client do
     )
   end
 
+  @spec list_check_runs(String.t(), String.t(), String.t() | nil) ::
+          {:ok, [map()]} | {:error, term()}
+  def list_check_runs(_owner, _repo, nil), do: {:error, :missing_sha}
+
+  def list_check_runs(owner, repo, sha) when is_binary(sha) do
+    case request(
+           :get,
+           "/repos/#{owner}/#{repo}/commits/#{sha}/check-runs"
+         ) do
+      {:ok, %{"check_runs" => runs}} when is_list(runs) -> {:ok, runs}
+      {:ok, _other} -> {:ok, []}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   @spec list_issues(String.t(), String.t(), keyword()) ::
           {:ok, [map()]} | {:error, term()}
   def list_issues(owner, repo, opts \\ []) do

--- a/test/camelot/board/changes/check_pr_status_test.exs
+++ b/test/camelot/board/changes/check_pr_status_test.exs
@@ -52,4 +52,102 @@ defmodule Camelot.Board.Changes.CheckPrStatusTest do
       refute CheckPrStatus.new_comments?([], @commit, nil)
     end
   end
+
+  describe "merge_conflict?/1" do
+    test "mergeable false and state dirty is a conflict" do
+      pr = %{"mergeable" => false, "mergeable_state" => "dirty"}
+
+      assert CheckPrStatus.merge_conflict?(pr)
+    end
+
+    test "mergeable nil (still computing) is not a conflict" do
+      pr = %{"mergeable" => nil, "mergeable_state" => "unknown"}
+
+      refute CheckPrStatus.merge_conflict?(pr)
+    end
+
+    test "mergeable true is not a conflict" do
+      pr = %{"mergeable" => true, "mergeable_state" => "clean"}
+
+      refute CheckPrStatus.merge_conflict?(pr)
+    end
+
+    test "mergeable false but state blocked (branch protection) is not a conflict" do
+      pr = %{"mergeable" => false, "mergeable_state" => "blocked"}
+
+      refute CheckPrStatus.merge_conflict?(pr)
+    end
+
+    test "mergeable false but state behind is not a conflict" do
+      pr = %{"mergeable" => false, "mergeable_state" => "behind"}
+
+      refute CheckPrStatus.merge_conflict?(pr)
+    end
+
+    test "empty map is not a conflict" do
+      refute CheckPrStatus.merge_conflict?(%{})
+    end
+
+    test "mergeable false with nil state is not a conflict" do
+      pr = %{"mergeable" => false, "mergeable_state" => nil}
+
+      refute CheckPrStatus.merge_conflict?(pr)
+    end
+  end
+
+  describe "ci_failing?/1" do
+    defp check_run(status, conclusion) do
+      %{"status" => status, "conclusion" => conclusion}
+    end
+
+    test "no check runs is not failing" do
+      refute CheckPrStatus.ci_failing?([])
+    end
+
+    test "single completed success is not failing" do
+      refute CheckPrStatus.ci_failing?([check_run("completed", "success")])
+    end
+
+    test "single completed failure is failing" do
+      assert CheckPrStatus.ci_failing?([check_run("completed", "failure")])
+    end
+
+    test "in_progress run with nil conclusion is not failing" do
+      refute CheckPrStatus.ci_failing?([check_run("in_progress", nil)])
+    end
+
+    test "queued run with nil conclusion is not failing" do
+      refute CheckPrStatus.ci_failing?([check_run("queued", nil)])
+    end
+
+    test "mix of success and failure is failing" do
+      runs = [check_run("completed", "success"), check_run("completed", "failure")]
+
+      assert CheckPrStatus.ci_failing?(runs)
+    end
+
+    test "completed neutral is not failing" do
+      refute CheckPrStatus.ci_failing?([check_run("completed", "neutral")])
+    end
+
+    test "completed skipped is not failing" do
+      refute CheckPrStatus.ci_failing?([check_run("completed", "skipped")])
+    end
+
+    test "completed cancelled is failing" do
+      assert CheckPrStatus.ci_failing?([check_run("completed", "cancelled")])
+    end
+
+    test "completed timed_out is failing" do
+      assert CheckPrStatus.ci_failing?([check_run("completed", "timed_out")])
+    end
+
+    test "completed action_required is failing" do
+      assert CheckPrStatus.ci_failing?([check_run("completed", "action_required")])
+    end
+
+    test "completed stale is not failing" do
+      refute CheckPrStatus.ci_failing?([check_run("completed", "stale")])
+    end
+  end
 end

--- a/test/camelot/github/client_test.exs
+++ b/test/camelot/github/client_test.exs
@@ -47,4 +47,24 @@ defmodule Camelot.Github.ClientTest do
                )
     end
   end
+
+  describe "list_check_runs/3" do
+    test "handles API errors gracefully" do
+      assert {:error, _} =
+               Client.list_check_runs(
+                 "nonexistent-owner",
+                 "nonexistent-repo",
+                 "deadbeef"
+               )
+    end
+
+    test "returns error without a network call when sha is nil" do
+      assert {:error, :missing_sha} =
+               Client.list_check_runs(
+                 "nonexistent-owner",
+                 "nonexistent-repo",
+                 nil
+               )
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- `CheckPrStatus` already re-queues a monitored PR's task (via `request_pr_changes`) when it sees `CHANGES_REQUESTED`/`APPROVED` reviews or new comments. This extends the same detection to two signals it previously ignored: **merge conflicts** and **failing CI/pipeline checks**.
- Added `Camelot.Github.Client.list_check_runs/3` to fetch check-run conclusions for the PR's head sha (unwraps GitHub's `%{"check_runs" => [...]}` object into the `{:ok, [map()]}` shape the rest of the client already uses).
- Added `Camelot.Board.Changes.CheckPrStatus.merge_conflict?/1` (true when `mergeable == false` and `mergeable_state == "dirty"` — ignores `nil` while GitHub is still computing, and `"blocked"` which is a branch-protection gate, not a conflict) and `.ci_failing?/1` (true when any `completed` check run concluded `failure`/`timed_out`/`action_required`/`cancelled`; `in_progress`/`queued` runs and non-blocking conclusions like `success`/`neutral`/`skipped`/`stale` don't count).
- Wired both into the existing `waiting_for_input` cond-chain, sitting above the `APPROVED` branch so an approved PR with an unresolved conflict or a failing check doesn't auto-complete. Both reuse `transition_with_seen_at/2` → `request_pr_changes`, so no new Ash action, state, or migration was needed.

## Test plan
- [x] `mix test test/camelot/board/changes/check_pr_status_test.exs test/camelot/github/client_test.exs` — all new cases pass
- [x] `mix test` — 337 tests, 0 failures, no regressions
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix dialyzer` — passed successfully
- [x] `mix credo --strict` on changed files — no issues
- [x] `mix format --check-formatted` — clean
- [x] Sanity-checked `merge_conflict?/1` and `ci_failing?/1` directly in `iex -S mix` against sample GitHub payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)