### PR TITLE
feat: rebrand invitation email to Camelot AI and align design with site

### DIFF
--- a/lib/camelot/accounts/user/senders/send_invitation_email.ex
+++ b/lib/camelot/accounts/user/senders/send_invitation_email.ex
@@ -36,42 +36,52 @@ defmodule Camelot.Accounts.User.Senders.SendInvitationEmail do
     new()
     |> from(Camelot.Mailer.from())
     |> to(to)
-    |> subject("You're invited to Camelot")
+    |> subject("You're invited to Camelot AI")
     |> html_body(html_body(url))
     |> text_body(text_body(url))
   end
 
   defp html_body(url) do
     """
-    <div style="font-family: -apple-system, Helvetica, Arial, sans-serif; \
-    max-width: 560px; margin: 0 auto; color: #1a1a2e;">
-      <div style="background: #1a1a2e; padding: 32px 24px; text-align: center;">
-        <h1 style="color: #ffffff; font-size: 20px; margin: 0;">Camelot</h1>
-      </div>
-      <div style="padding: 32px 24px; background: #ffffff;">
-        <h2 style="margin-top: 0;">Your Camelot account is ready</h2>
-        <p>
-          Delegate coding tasks to AI agents and manage them from a kanban
-          board. Create tasks, let agents plan and implement them, then
-          review and approve before anything ships.
-        </p>
-        <ul style="padding-left: 20px; line-height: 1.6;">
-          <li><strong>Kanban board</strong> — track every task from todo to done.</li>
-          <li><strong>Multi-agent coordination</strong> — run agents in parallel across projects.</li>
-          <li><strong>Human-in-the-loop</strong> — approve plans before anything is written.</li>
-          <li><strong>GitHub-native</strong> — syncs issues, tracks PRs, auto-completes on merge.</li>
-        </ul>
-        <p style="text-align: center; margin: 32px 0;">
-          <a href="#{url}" style="background: #7c3aed; color: #ffffff; \
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=MedievalSharp&display=swap');
+    </style>
+    <div style="background: #f5f5f5; padding: 24px;">
+      <div style="font-family: -apple-system, Helvetica, Arial, sans-serif; \
+    max-width: 560px; margin: 0 auto; color: #1a1a2e; background: #ffffff; \
+    border-radius: 0.75rem; overflow: hidden; \
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);">
+        <div style="background: #1a1a2e; padding: 32px 24px; text-align: center;">
+          <h1 style="font-family: 'MedievalSharp', cursive; font-weight: 900; \
+    letter-spacing: 0.025em; color: #ffffff; font-size: 24px; margin: 0;">
+            Camelot AI
+          </h1>
+        </div>
+        <div style="padding: 32px 24px;">
+          <h2 style="margin-top: 0;">Your Camelot AI account is ready</h2>
+          <p>
+            Delegate coding tasks to AI agents and manage them from a kanban
+            board. Create tasks, let agents plan and implement them, then
+            review and approve before anything ships.
+          </p>
+          <ul style="padding-left: 20px; line-height: 1.6;">
+            <li><strong>Kanban board</strong> — track every task from todo to done.</li>
+            <li><strong>Multi-agent coordination</strong> — run agents in parallel across projects.</li>
+            <li><strong>Human-in-the-loop</strong> — approve plans before anything is written.</li>
+            <li><strong>GitHub-native</strong> — syncs issues, tracks PRs, auto-completes on merge.</li>
+          </ul>
+          <p style="text-align: center; margin: 32px 0;">
+            <a href="#{url}" style="background: #7c3aed; color: #ffffff; \
     padding: 12px 24px; border-radius: 6px; text-decoration: none; \
     font-weight: bold; display: inline-block;">
-            Sign in to Camelot
-          </a>
-        </p>
-        <p style="color: #666666; font-size: 14px;">
-          If the button doesn't work, copy and paste this link into your browser:<br>
-          <a href="#{url}" style="color: #7c3aed;">#{url}</a>
-        </p>
+              Sign in to Camelot AI
+            </a>
+          </p>
+          <p style="color: #666666; font-size: 14px;">
+            If the button doesn't work, copy and paste this link into your browser:<br>
+            <a href="#{url}" style="color: #7c3aed;">#{url}</a>
+          </p>
+        </div>
       </div>
     </div>
     """
@@ -79,7 +89,7 @@ defmodule Camelot.Accounts.User.Senders.SendInvitationEmail do
 
   defp text_body(url) do
     """
-    Your Camelot account is ready
+    Your Camelot AI account is ready
 
     Delegate coding tasks to AI agents and manage them from a kanban
     board. Create tasks, let agents plan and implement them, then
@@ -90,7 +100,7 @@ defmodule Camelot.Accounts.User.Senders.SendInvitationEmail do
     - Human-in-the-loop — approve plans before anything is written.
     - GitHub-native — syncs issues, tracks PRs, auto-completes on merge.
 
-    Sign in to Camelot:
+    Sign in to Camelot AI:
     #{url}
     """
   end

--- a/test/camelot/accounts/user/senders/send_invitation_email_test.exs
+++ b/test/camelot/accounts/user/senders/send_invitation_email_test.exs
@@ -18,6 +18,8 @@ defmodule Camelot.Accounts.User.Senders.SendInvitationEmailTest do
       assert email.html_body =~ "utm_source=email"
       assert email.html_body =~ "utm_medium=invitation"
       assert email.html_body =~ "utm_campaign=admin_invite"
+      assert email.html_body =~ "Camelot AI"
+      assert email.html_body =~ "MedievalSharp"
       assert email.text_body =~ "/sign-in?"
     end)
   end


### PR DESCRIPTION
## Summary
- Header wordmark in the user invitation email now reads "Camelot AI" (matching the site's title-suffix brand name), set in the site's brand font (`MedievalSharp`, weight 900, letter-spaced) — inlined for email-client compatibility with a `<style>@import</style>` fallback.
- Card visual design aligned with site tokens: wrapped in the `#f5f5f5` (base-200) page background, rounded corners (`0.75rem`, matching `--radius-box`), and a subtle shadow. Existing dark-header (`#1a1a2e`) and purple-CTA (`#7c3aed`) colors already matched site tokens and were kept.
- Subject, greeting, button, and text-body copy updated from "Camelot" to "Camelot AI" for consistency within the same email.
- Scope limited to the invitation email only — the in-app header and other transactional emails are untouched.

## Test plan
- [x] Added assertions to `send_invitation_email_test.exs` for "Camelot AI" and the `MedievalSharp` brand font reference (TDD, written before the implementation change)
- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix format` — no diff
- [x] `mix credo --strict` — no issues
- [x] `mix dialyzer` — passed
- [ ] `mix test` — **could not run**: this sandbox has no PostgreSQL available (no docker, no local postgres binary, no root to install one) and `Camelot.Repo` requires it. The changed test/implementation were manually reviewed and the HTML was rendered/verified to be well-formed outside of the DB-dependent `deliver/1` path. Please run `mix test test/camelot/accounts/user/senders/send_invitation_email_test.exs` in CI/local dev to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)