### PR TITLE
fix(runner): self-heal proxy IP caches on :ehostunreach

### DIFF
--- a/lib/camelot/runtime/runner/docker_api.ex
+++ b/lib/camelot/runtime/runner/docker_api.ex
@@ -12,9 +12,17 @@ defmodule Camelot.Runtime.Runner.DockerApi do
   must reach a manager-hosted proxy task — workers'
   daemons 503 on cluster-state endpoints. We resolve a
   manager-hosted proxy task's overlay IP via Swarm's
-  embedded DNS at first use and cache it. Cache is
-  invalidated on a 503 response so we re-probe if the
-  cluster's manager set changes.
+  embedded DNS at first use and cache it.
+
+  The cache self-heals: every request built for the proxy
+  transport carries response/error steps that drop the
+  cached IP when a call comes back `503` (the cached IP is
+  a worker proxy) or fails with a transport error such as
+  `:ehostunreach`/`:timeout` (the proxy task was
+  rescheduled to a new overlay IP after a redeploy). The
+  next `request/0` then re-discovers a live manager proxy.
+  Without this, a proxy reschedule would strand every
+  management call on a dead IP until the app restarted.
   """
 
   require Logger
@@ -63,16 +71,46 @@ defmodule Camelot.Runtime.Runner.DockerApi do
   end
 
   @doc """
-  Drop the cached manager-proxy IP. Call after a 503
-  from a management endpoint so the next `request/0`
+  Drop the cached manager-proxy IP so the next `request/0`
   re-discovers — e.g. when a manager is demoted or its
-  proxy task is rescheduled.
+  proxy task is rescheduled. Called automatically by the
+  self-healing request steps (see `stale_proxy?/1`); also
+  safe to call directly.
   """
   @spec invalidate_manager_proxy() :: :ok
   def invalidate_manager_proxy do
     :persistent_term.erase(@manager_proxy_key)
     :ok
   end
+
+  @doc """
+  Returns `true` when a proxy response/error means the
+  cached proxy IP is stale and should be dropped so the
+  next call re-resolves: a transport failure (the proxy
+  task was rescheduled to a new overlay IP —
+  `:ehostunreach`, `:timeout`, `:econnrefused`, ...) or a
+  `503` (the cached IP is a worker proxy that can't serve
+  cluster-state endpoints).
+  """
+  @spec stale_proxy?(Req.Response.t() | Exception.t()) :: boolean()
+  def stale_proxy?(%Req.Response{status: 503}), do: true
+  def stale_proxy?(%Req.TransportError{}), do: true
+  def stale_proxy?(_other), do: false
+
+  @doc false
+  # Response/error step: drops the cached manager-proxy IP
+  # when the result signals a stale proxy, then passes the
+  # result through unchanged. Public only so the wiring can
+  # be asserted on in tests.
+  @spec drop_stale_manager_proxy({Req.Request.t(), Req.Response.t() | Exception.t()}) ::
+          {Req.Request.t(), Req.Response.t() | Exception.t()}
+  def drop_stale_manager_proxy({_request, result} = acc) do
+    maybe_invalidate_manager(stale_proxy?(result))
+    acc
+  end
+
+  defp maybe_invalidate_manager(true), do: invalidate_manager_proxy()
+  defp maybe_invalidate_manager(false), do: :ok
 
   @doc """
   Lists the distinct `camelot-home` label values currently set
@@ -135,7 +173,10 @@ defmodule Camelot.Runtime.Runner.DockerApi do
   end
 
   defp tcp_request(host_and_port) do
-    Req.new(base_url: "http://#{host_and_port}/#{@api_version}")
+    [base_url: "http://#{host_and_port}/#{@api_version}"]
+    |> Req.new()
+    |> Req.Request.append_response_steps(camelot_stale_proxy: &drop_stale_manager_proxy/1)
+    |> Req.Request.append_error_steps(camelot_stale_proxy: &drop_stale_manager_proxy/1)
   end
 
   # If the configured host is a Swarm service name on the

--- a/lib/camelot/runtime/runner/swarm/proxy_router.ex
+++ b/lib/camelot/runtime/runner/swarm/proxy_router.ex
@@ -14,9 +14,14 @@ defmodule Camelot.Runtime.Runner.Swarm.ProxyRouter do
 
   Cache: results are stored in `:persistent_term` keyed
   by `node_id`. Each entry is the overlay IP of the
-  proxy task on that node. Writes happen on the first
-  lookup per node and on explicit `invalidate/1`. Reads
-  are zero-overhead.
+  proxy task on that node. Reads are zero-overhead.
+
+  The cache self-heals: the `Req` client handed back for a
+  node carries response/error steps that drop that node's
+  cached IP whenever a call returns `503` or fails with a
+  transport error such as `:ehostunreach`/`:timeout` — the
+  proxy task was rescheduled to a new overlay IP. The next
+  `request_for_node/1` then re-resolves via `GET /tasks`.
   """
 
   alias Camelot.Runtime.Runner.DockerApi
@@ -39,13 +44,13 @@ defmodule Camelot.Runtime.Runner.Swarm.ProxyRouter do
   def request_for_node(node_id) when is_binary(node_id) do
     case Map.fetch(get_cache(), node_id) do
       {:ok, ip} ->
-        {:ok, req_for_ip(ip)}
+        {:ok, req_for_ip(ip, node_id)}
 
       :error ->
         case resolve_ip(node_id) do
           {:ok, ip} ->
             put_cache(Map.put(get_cache(), node_id, ip))
-            {:ok, req_for_ip(ip)}
+            {:ok, req_for_ip(ip, node_id)}
 
           {:error, _} = err ->
             err
@@ -54,10 +59,12 @@ defmodule Camelot.Runtime.Runner.Swarm.ProxyRouter do
   end
 
   @doc """
-  Drop the cached proxy IP for `node_id`. Call when an
-  exec request returns `:econnrefused` / a 5xx — the
-  proxy task may have been rescheduled and its overlay
-  IP changed.
+  Drop the cached proxy IP for `node_id`. Happens
+  automatically via the request's self-healing steps when a
+  call returns `503` or fails with a transport error
+  (`:ehostunreach`, `:timeout`, `:econnrefused`, ...) — the
+  proxy task was rescheduled and its overlay IP changed.
+  Also safe to call directly.
   """
   @spec invalidate(String.t()) :: :ok
   def invalidate(node_id) do
@@ -65,11 +72,31 @@ defmodule Camelot.Runtime.Runner.Swarm.ProxyRouter do
     :ok
   end
 
+  @doc false
+  # Response/error step: drops this node's cached proxy IP
+  # when the result signals a stale proxy, then passes the
+  # result through unchanged. Public only so the wiring can
+  # be asserted on in tests.
+  @spec drop_stale_node_proxy(
+          {Req.Request.t(), Req.Response.t() | Exception.t()},
+          String.t()
+        ) :: {Req.Request.t(), Req.Response.t() | Exception.t()}
+  def drop_stale_node_proxy({_request, result} = acc, node_id) do
+    maybe_invalidate_node(DockerApi.stale_proxy?(result), node_id)
+    acc
+  end
+
+  defp maybe_invalidate_node(true, node_id), do: invalidate(node_id)
+  defp maybe_invalidate_node(false, _node_id), do: :ok
+
   defp get_cache, do: :persistent_term.get(@cache_key, %{})
   defp put_cache(map), do: :persistent_term.put(@cache_key, map)
 
-  defp req_for_ip(ip) do
-    Req.new(base_url: "http://#{ip}:2375/v1.43")
+  defp req_for_ip(ip, node_id) do
+    [base_url: "http://#{ip}:2375/v1.43"]
+    |> Req.new()
+    |> Req.Request.append_response_steps(camelot_stale_proxy: &drop_stale_node_proxy(&1, node_id))
+    |> Req.Request.append_error_steps(camelot_stale_proxy: &drop_stale_node_proxy(&1, node_id))
   end
 
   defp resolve_ip(node_id) do

--- a/test/camelot/runtime/runner/docker_api_test.exs
+++ b/test/camelot/runtime/runner/docker_api_test.exs
@@ -42,4 +42,62 @@ defmodule Camelot.Runtime.Runner.DockerApiTest do
       assert DockerApi.extract_node_labels([]) == []
     end
   end
+
+  describe "stale_proxy?/1" do
+    test "true for a 503 response (cached IP is a worker proxy)" do
+      assert DockerApi.stale_proxy?(%Req.Response{status: 503})
+    end
+
+    test "false for a healthy response" do
+      refute DockerApi.stale_proxy?(%Req.Response{status: 200})
+      refute DockerApi.stale_proxy?(%Req.Response{status: 404})
+    end
+
+    test "true for any transport error (rescheduled proxy, new overlay IP)" do
+      for reason <- [:ehostunreach, :timeout, :econnrefused, :closed, :nxdomain] do
+        assert DockerApi.stale_proxy?(%Req.TransportError{reason: reason}),
+               "expected #{reason} to be treated as a stale proxy"
+      end
+    end
+
+    test "false for unrelated exceptions" do
+      refute DockerApi.stale_proxy?(%RuntimeError{message: "boom"})
+    end
+  end
+
+  describe "drop_stale_manager_proxy/1 (self-healing step)" do
+    @manager_key {DockerApi, :manager_proxy_ip}
+
+    setup do
+      on_exit(fn -> :persistent_term.erase(@manager_key) end)
+      :ok
+    end
+
+    test "drops the cached IP on :ehostunreach and passes the result through" do
+      :persistent_term.put(@manager_key, "10.0.1.11")
+      err = %Req.TransportError{reason: :ehostunreach}
+
+      assert DockerApi.drop_stale_manager_proxy({%Req.Request{}, err}) ==
+               {%Req.Request{}, err}
+
+      assert :persistent_term.get(@manager_key, :dropped) == :dropped
+    end
+
+    test "drops the cached IP on a 503 response" do
+      :persistent_term.put(@manager_key, "10.0.1.11")
+      resp = %Req.Response{status: 503}
+
+      DockerApi.drop_stale_manager_proxy({%Req.Request{}, resp})
+
+      assert :persistent_term.get(@manager_key, :dropped) == :dropped
+    end
+
+    test "keeps the cached IP on a healthy response" do
+      :persistent_term.put(@manager_key, "10.0.1.11")
+
+      DockerApi.drop_stale_manager_proxy({%Req.Request{}, %Req.Response{status: 200}})
+
+      assert :persistent_term.get(@manager_key, :dropped) == "10.0.1.11"
+    end
+  end
 end

--- a/test/camelot/runtime/runner/swarm/proxy_router_test.exs
+++ b/test/camelot/runtime/runner/swarm/proxy_router_test.exs
@@ -41,4 +41,41 @@ defmodule Camelot.Runtime.Runner.Swarm.ProxyRouterTest do
       assert ProxyRouter.proxy_ip_for_node(tasks, "node-a") == nil
     end
   end
+
+  describe "drop_stale_node_proxy/2 (self-healing step)" do
+    @cache_key {ProxyRouter, :proxy_ips}
+
+    setup do
+      on_exit(fn -> :persistent_term.erase(@cache_key) end)
+      :ok
+    end
+
+    test "drops only the failing node's cached IP on a transport error" do
+      :persistent_term.put(@cache_key, %{"node-a" => "10.0.1.19", "node-b" => "10.0.1.20"})
+      err = %Req.TransportError{reason: :ehostunreach}
+
+      assert ProxyRouter.drop_stale_node_proxy({%Req.Request{}, err}, "node-a") ==
+               {%Req.Request{}, err}
+
+      cache = :persistent_term.get(@cache_key)
+      refute Map.has_key?(cache, "node-a")
+      assert cache["node-b"] == "10.0.1.20"
+    end
+
+    test "drops the node's cached IP on a 503 response" do
+      :persistent_term.put(@cache_key, %{"node-a" => "10.0.1.19"})
+
+      ProxyRouter.drop_stale_node_proxy({%Req.Request{}, %Req.Response{status: 503}}, "node-a")
+
+      refute Map.has_key?(:persistent_term.get(@cache_key), "node-a")
+    end
+
+    test "keeps the node's cached IP on a healthy response" do
+      :persistent_term.put(@cache_key, %{"node-a" => "10.0.1.19"})
+
+      ProxyRouter.drop_stale_node_proxy({%Req.Request{}, %Req.Response{status: 200}}, "node-a")
+
+      assert :persistent_term.get(@cache_key)["node-a"] == "10.0.1.19"
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Both docker-socket-proxy IP caches store an overlay IP in `:persistent_term`:

- `DockerApi` — the **manager** proxy IP (for all `/services`, `/tasks`, `/nodes`, `/secrets` calls)
- `ProxyRouter` — the **per-node** proxy IP (for `docker exec` into runner containers)

When the `docker-socket-proxy` service is redeployed or rescheduled, its overlay IP rotates. Requests to the old (now shut-down) task come back as `%Req.TransportError{reason: :ehostunreach}` — **not** `:econnrefused`/5xx. Neither cache treated `:ehostunreach` as an invalidation trigger, and `DockerApi.invalidate_manager_proxy/0` had **no callers at all**. So after any proxy reschedule, every management + exec call was stranded on a dead IP until the app was restarted (or the persistent-terms were cleared by hand).

This was hit in production after a Swarm rebuild: task planning failed repeatedly with `(stop) %Req.TransportError{reason: :ehostunreach}` even though the overlay itself was healthy — the app was dialing the previous proxy IPs.

## Fix

Attach `Req` response/error steps to both proxy-targeted clients that drop the cached IP when a call:

- fails with **any** `%Req.TransportError{}` (covers `:ehostunreach`, `:timeout`, `:econnrefused`, ...), or
- returns **`503`** (the cached IP is a worker proxy that can't serve cluster-state endpoints).

The next call then re-resolves a live proxy. A shared `DockerApi.stale_proxy?/1` predicate encodes the decision. No call-site changes were needed (≈36 `DockerApi.request()` sites all benefit), and this finally wires up the previously-dead `invalidate_manager_proxy/0`.

## Tests

- `stale_proxy?/1`: 503 and every transport-error reason → stale; 200/404 and unrelated exceptions → not stale.
- `drop_stale_manager_proxy/1` and `drop_stale_node_proxy/2`: drop the cached IP on `:ehostunreach`/503, keep it on 200, and (for the per-node case) only evict the failing node's entry.
- Full `test/camelot/runtime/` suite green (132 tests); `mix format`, `mix credo`, `mix dialyzer` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)