### PR TITLE
fix: stop sending duplicate confirmation email on admin invite

### DIFF
--- a/lib/camelot/accounts/user.ex
+++ b/lib/camelot/accounts/user.ex
@@ -41,7 +41,7 @@ defmodule Camelot.Accounts.User do
     add_ons do
       confirmation :confirm_new_user do
         monitor_fields([:email])
-        confirm_on_create?(true)
+        confirm_on_create?(false)
         confirm_on_update?(false)
         require_interaction?(true)
         auto_confirm_actions([:sign_in_with_magic_link])

--- a/test/camelot/accounts/user/changes/send_invitation_email_test.exs
+++ b/test/camelot/accounts/user/changes/send_invitation_email_test.exs
@@ -22,6 +22,37 @@ defmodule Camelot.Accounts.User.Changes.SendInvitationEmailTest do
 
       assert_email_sent(to: [{"", to_string(user.email)}])
     end
+
+    test "sends only the invitation email, no confirmation email" do
+      admin = Ash.Seed.seed!(User, %{email: "admin2@e.com", role: :admin})
+
+      {:ok, _user} =
+        User
+        |> Ash.Changeset.for_create(
+          :create_user,
+          %{email: "new2@e.com", role: :user},
+          actor: admin
+        )
+        |> Ash.create()
+
+      assert_email_sent(subject: "You're invited to Camelot AI")
+      assert_no_email_sent()
+    end
+
+    test "confirms the invited user immediately, since the admin invite is trusted" do
+      admin = Ash.Seed.seed!(User, %{email: "admin3@e.com", role: :admin})
+
+      {:ok, user} =
+        User
+        |> Ash.Changeset.for_create(
+          :create_user,
+          %{email: "new3@e.com", role: :user},
+          actor: admin
+        )
+        |> Ash.create()
+
+      assert user.confirmed_at
+    end
   end
 
   describe "resource-level wiring" do

--- a/test/camelot/accounts/user/magic_link_confirmation_test.exs
+++ b/test/camelot/accounts/user/magic_link_confirmation_test.exs
@@ -1,0 +1,47 @@
+defmodule Camelot.Accounts.User.MagicLinkConfirmationTest do
+  use Camelot.DataCase, async: false
+
+  import Swoosh.TestAssertions
+
+  alias Camelot.Accounts.User
+
+  describe "magic-link sign-in for an admin-invited user" do
+    test "an invited user can still sign in via magic link after confirm_on_create? is disabled" do
+      admin = Ash.Seed.seed!(User, %{email: "admin-ml@e.com", role: :admin})
+
+      {:ok, user} =
+        User
+        |> Ash.Changeset.for_create(
+          :create_user,
+          %{email: "invitee-ml@e.com", role: :user},
+          actor: admin
+        )
+        |> Ash.create()
+
+      assert user.confirmed_at
+
+      # Drain the invitation email sent by :create_user before
+      # requesting the magic link, so the mailbox assertion below
+      # matches the magic-link email, not the invitation one.
+      assert_email_sent()
+
+      strategy = AshAuthentication.Info.strategy!(User, :magic_link)
+
+      assert :ok =
+               AshAuthentication.Strategy.action(strategy, :request, %{
+                 email: to_string(user.email)
+               })
+
+      {:email, email} = assert_email_sent()
+
+      [token] =
+        Regex.run(~r{/magic_link/([^"\s]+)}, email.html_body, capture: :all_but_first)
+
+      assert {:ok, signed_in_user} =
+               AshAuthentication.Strategy.action(strategy, :sign_in, %{"token" => token})
+
+      assert signed_in_user.id == user.id
+      assert signed_in_user.confirmed_at
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Admin-invited users (`:create_user`) were getting two emails: the invitation email and an unwanted "confirm your email" token email, because `AshAuthentication.AddOn.Confirmation`'s `confirm_on_create?(true)` fires on every create action on `Camelot.Accounts.User`, not just self-registration.
- Disabled `confirm_on_create?` so only the invitation email is sent. `:create_user` still explicitly sets `confirmed_at` at invite time (unchanged) — the admin invite itself is the trust signal, so the account stays confirmed immediately, it just no longer gets a second, redundant confirmation email.

## Scope note: deferring confirmation to first login

The task also asked for confirmation to happen on first login (so `/admin/users` shows "pending" until then, instead of confirmed at invite time). I implemented and tested that path, but it doesn't work safely with this resource's current setup:

`AshAuthentication`'s magic-link strategy performs an upsert on sign-in. Whenever a `Confirmation` add-on monitors the identity field (`:email`, needed here to suppress the duplicate email above), the library unconditionally refuses that upsert for any row whose `confirmed_at` is already `nil` (`AshAuthentication.Errors.CannotConfirmUnconfirmedUser`) — this is its built-in account-hijacking guard, and it isn't gated by `confirm_on_create?`/`auto_confirm_actions`. So if an invited user's row starts out unconfirmed, their first magic-link sign-in is rejected outright, not just "not yet confirmed."

The only way around that guard is `prevent_hijacking?(false)` (on the confirmation add-on or the magic-link strategy), which is a real security-relevant tradeoff — it's normally used for apps mixing a password strategy with magic-link/social registration on the same identity field, which this app doesn't have, but disabling it is still a deliberate call that deserves an explicit decision rather than being bundled into a bug-fix PR. The alternative (not persisting a `User` row until first sign-in) is a much larger redesign of the invite flow (SSH key generation, admin listing, etc.).

This PR fixes the concrete duplicate-email bug and leaves the "pending until first login" behavior as a follow-up decision — happy to implement whichever option is preferred.

## Test plan
- [x] `mix compile` — no warnings
- [x] `mix test` — 350 tests, 0 failures (added: only-one-email assertion, confirmed-at-set-at-invite assertion, and a regression test driving a full magic-link request → sign-in cycle for an invited user)
- [x] `mix credo --strict` — only a pre-existing, unrelated finding in `task_live.ex` (confirmed present before this change too)
- [x] `mix dialyzer` — passed
- [x] `mix format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)