### PR TITLE
fix: clear New Task form fields after successful creation

### DIFF
--- a/lib/camelot_web/live/board_live.ex
+++ b/lib/camelot_web/live/board_live.ex
@@ -41,6 +41,10 @@ defmodule CamelotWeb.BoardLive do
   @impl true
   @task_fields ~w(title description priority project_id)
 
+  def handle_event("validate_task", params, socket) do
+    {:noreply, assign(socket, task_form: to_form(Map.take(params, @task_fields)))}
+  end
+
   def handle_event("create_task", params, socket) do
     user = socket.assigns.current_user
     task_params = Map.take(params, @task_fields)
@@ -161,6 +165,7 @@ defmodule CamelotWeb.BoardLive do
         <h3 class="font-bold text-lg mb-4">New Task</h3>
         <.simple_form
           for={@task_form}
+          phx-change="validate_task"
           phx-submit={
             hide_modal("new-task-modal")
             |> JS.push("create_task")

--- a/test/camelot_web/live/board_live_test.exs
+++ b/test/camelot_web/live/board_live_test.exs
@@ -25,6 +25,32 @@ defmodule CamelotWeb.BoardLiveTest do
     assert render(view) =~ "Board"
   end
 
+  test "New Task form clears fields after successful creation", %{conn: conn, user: user} do
+    {:ok, project} =
+      Ash.create(
+        Project,
+        %{name: "p-#{System.unique_integer()}", path: "/tmp/z"},
+        actor: user
+      )
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    task_form =
+      form(view, "#new-task-form", %{
+        "title" => "Write the plan",
+        "description" => "some details",
+        "project_id" => project.id,
+        "priority" => "2"
+      })
+
+    render_change(task_form)
+    render_submit(task_form)
+
+    form_html = view |> element("#new-task-form") |> render()
+    refute form_html =~ "Write the plan"
+    refute form_html =~ "some details"
+  end
+
   describe "scoping" do
     test "non-admin sees only tasks from member projects", %{conn: conn, user: user} do
       {:ok, mine} =


### PR DESCRIPTION
## Summary
- The "New Task" modal form had no `phx-change` binding, so LiveView never tracked the live values of the title/description/project/priority inputs server-side.
- When `create_task` succeeded, `load_board/1` reset `task_form` back to blank, but since LiveView's stale server-side state was already blank, the diff against the new (also blank) render was empty, so no patch was sent to the client — leaving the typed values visible in the browser.
- Added `phx-change="validate_task"` to the form and a `validate_task` event handler that keeps `task_form` in sync with what the user types, so the post-submit reset now produces a real diff.

## Test plan
- [x] `mix compile` — no warnings
- [x] `mix test` — 353 tests, 0 failures (includes new regression test using `render_change`/`render_submit` against the simulated client DOM)
- [x] `mix dialyzer` — no new errors
- [x] `mix credo --strict` on changed files — no issues
- [x] `mix format` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)