### PR TITLE
Allow admins and project owners to invite users to a project

### DIFF
--- a/lib/camelot/projects/membership.ex
+++ b/lib/camelot/projects/membership.ex
@@ -15,6 +15,8 @@ defmodule Camelot.Projects.Membership do
     data_layer: AshPostgres.DataLayer,
     authorizers: []
 
+  require Ash.Query
+
   @roles [:owner, :member]
 
   postgres do
@@ -66,6 +68,43 @@ defmodule Camelot.Projects.Membership do
 
     update :set_role do
       accept([:role])
+    end
+
+    create :invite do
+      argument :project_id, :uuid do
+        allow_nil?(false)
+      end
+
+      argument :email, :ci_string do
+        allow_nil?(false)
+      end
+
+      argument :role, :atom do
+        constraints(one_of: @roles)
+        default(:member)
+      end
+
+      change(Camelot.Projects.Membership.Changes.ResolveInvitee)
+      change(Camelot.Projects.Membership.Changes.SendProjectInviteEmail)
+    end
+  end
+
+  @doc """
+  Whether `user_id` holds an `owner` membership on `project_id`.
+
+  Shared by `Membership.Changes.ResolveInvitee` (resource-level
+  authorization for `:invite`) and `ProjectLive.Show` (UI-level
+  gating for the invite form), so the two checks can't drift apart.
+  """
+  @spec owner?(Ash.UUID.t(), Ash.UUID.t()) :: boolean()
+  def owner?(project_id, user_id) do
+    __MODULE__
+    |> Ash.Query.filter(project_id == ^project_id and user_id == ^user_id and role == :owner)
+    |> Ash.read_one(authorize?: false)
+    |> case do
+      {:ok, nil} -> false
+      {:ok, _membership} -> true
+      _ -> false
     end
   end
 end

--- a/lib/camelot/projects/membership/changes/resolve_invitee.ex
+++ b/lib/camelot/projects/membership/changes/resolve_invitee.ex
@@ -1,0 +1,104 @@
+defmodule Camelot.Projects.Membership.Changes.ResolveInvitee do
+  @moduledoc """
+  Authorizes and resolves the invitee for `Membership.:invite`,
+  running before the insert inside the same transaction:
+
+  1. the actor must be a global admin or already `role: :owner`
+     on the target project, otherwise the changeset fails with a
+     clear error instead of hitting the database.
+  2. looks up (or creates, via `User.:create_user`) the `User`
+     for the given email. Reusing `:create_user` unmodified keeps
+     this immune to the duplicate-confirmation-email bug fixed in
+     `d867153` — `SendInvitationEmail` fires exactly as it does
+     for the admin `/admin/users` page.
+  3. rejects the invite if the resolved user is already a member
+     of the project, instead of hitting the composite-PK unique
+     constraint.
+
+  Stashes the resolved `User` in changeset context under
+  `:invitee` for `SendProjectInviteEmail` to use, and force-sets
+  `project_id`/`user_id`/`role` on the changeset.
+  """
+  use Ash.Resource.Change
+
+  alias Camelot.Accounts.User
+  alias Camelot.Projects.Membership
+
+  require Ash.Query
+
+  @impl Ash.Resource.Change
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.before_action(changeset, &resolve/1)
+  end
+
+  defp resolve(changeset) do
+    actor = changeset.context[:private][:actor] || changeset.context[:actor]
+    project_id = Ash.Changeset.get_argument(changeset, :project_id)
+    email = Ash.Changeset.get_argument(changeset, :email)
+    role = Ash.Changeset.get_argument(changeset, :role) || :member
+
+    with :ok <- authorize(actor, project_id),
+         {:ok, user} <- find_or_create_user(email, actor),
+         :ok <- ensure_not_member(project_id, user.id) do
+      changeset
+      |> Ash.Changeset.force_change_attribute(:project_id, project_id)
+      |> Ash.Changeset.force_change_attribute(:user_id, user.id)
+      |> Ash.Changeset.force_change_attribute(:role, role)
+      |> Ash.Changeset.put_context(:invitee, user)
+    else
+      {:error, message} when is_binary(message) ->
+        Ash.Changeset.add_error(changeset, field: :project_id, message: message)
+
+      {:error, error} ->
+        Ash.Changeset.add_error(changeset, error)
+    end
+  end
+
+  defp authorize(%User{role: :admin}, _project_id), do: :ok
+
+  defp authorize(%User{id: user_id}, project_id) when is_binary(project_id) do
+    if Membership.owner?(project_id, user_id) do
+      :ok
+    else
+      {:error, "You must be an admin or the project's owner to invite members."}
+    end
+  end
+
+  defp authorize(_actor, _project_id) do
+    {:error, "You must be an admin or the project's owner to invite members."}
+  end
+
+  defp find_or_create_user(email, actor) do
+    User
+    |> Ash.Query.filter(email == ^email)
+    |> Ash.read_one(authorize?: false)
+    |> case do
+      {:ok, %User{} = user} ->
+        {:ok, user}
+
+      {:ok, nil} ->
+        User
+        |> Ash.Changeset.for_create(
+          :create_user,
+          %{email: email, role: :user},
+          actor: actor,
+          authorize?: false
+        )
+        |> Ash.create()
+
+      {:error, error} ->
+        {:error, error}
+    end
+  end
+
+  defp ensure_not_member(project_id, user_id) do
+    Membership
+    |> Ash.Query.filter(project_id == ^project_id and user_id == ^user_id)
+    |> Ash.read_one(authorize?: false)
+    |> case do
+      {:ok, nil} -> :ok
+      {:ok, %Membership{}} -> {:error, "This user is already a member of this project."}
+      {:error, error} -> {:error, error}
+    end
+  end
+end

--- a/lib/camelot/projects/membership/changes/send_project_invite_email.ex
+++ b/lib/camelot/projects/membership/changes/send_project_invite_email.ex
@@ -1,0 +1,44 @@
+defmodule Camelot.Projects.Membership.Changes.SendProjectInviteEmail do
+  @moduledoc """
+  Sends a project-specific "you've been added to `<project>`"
+  email after a `Membership.:invite` succeeds.
+
+  Sent to both brand-new and pre-existing invitees. For a
+  brand-new user this is intentionally their second email — the
+  account-ready invite already fired from `User.:create_user`
+  inside `ResolveInvitee`, and this one carries distinct content,
+  not a repeat of the duplicate-email bug fixed in `d867153`.
+
+  Delivery failure is non-fatal: the membership is created either way.
+  """
+  use Ash.Resource.Change
+
+  alias Camelot.Projects.Membership.Senders.SendProjectInviteEmail
+  alias Camelot.Projects.Project
+
+  require Logger
+
+  @impl Ash.Resource.Change
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.after_action(changeset, fn changeset, membership ->
+      _ = safely_deliver(changeset, membership)
+      {:ok, membership}
+    end)
+  end
+
+  defp safely_deliver(changeset, membership) do
+    user = changeset.context[:invitee]
+    project = Ash.get!(Project, membership.project_id, authorize?: false)
+
+    SendProjectInviteEmail.deliver(user, project)
+  rescue
+    error ->
+      Logger.warning(
+        "SendProjectInviteEmail: delivery failed for membership " <>
+          "#{membership.project_id}/#{membership.user_id} — " <>
+          Exception.format(:error, error, __STACKTRACE__)
+      )
+
+      {:error, error}
+  end
+end

--- a/lib/camelot/projects/membership/senders/send_project_invite_email.ex
+++ b/lib/camelot/projects/membership/senders/send_project_invite_email.ex
@@ -1,0 +1,79 @@
+defmodule Camelot.Projects.Membership.Senders.SendProjectInviteEmail do
+  @moduledoc """
+  Sends a "you've been added to a project" email to a project
+  invitee via Swoosh. In dev mode, viewable at /dev/mailbox.
+  """
+
+  import Swoosh.Email
+
+  @spec deliver(Ash.Resource.record(), Ash.Resource.record()) :: :ok
+  def deliver(user, project) do
+    email = to_string(user.email)
+    url = project_url(project)
+
+    email
+    |> build_email(project, url)
+    |> Camelot.Mailer.deliver!()
+
+    :ok
+  end
+
+  defp project_url(project) do
+    CamelotWeb.Endpoint.url() <> "/projects/#{project.id}"
+  end
+
+  defp build_email(to, project, url) do
+    new()
+    |> from(Camelot.Mailer.from())
+    |> to(to)
+    |> subject("You've been added to #{project.name} on Camelot AI")
+    |> html_body(render_html_body(project, url))
+    |> text_body(render_text_body(project, url))
+  end
+
+  defp render_html_body(project, url) do
+    """
+    <div style="background: #f5f5f5; padding: 24px;">
+      <div style="font-family: -apple-system, Helvetica, Arial, sans-serif; \
+    max-width: 560px; margin: 0 auto; color: #1a1a2e; background: #ffffff; \
+    border-radius: 0.75rem; overflow: hidden; \
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);">
+        <div style="background: #1a1a2e; padding: 32px 24px; text-align: center;">
+          <h1 style="font-family: 'MedievalSharp', cursive; font-weight: 900; \
+    letter-spacing: 0.025em; color: #ffffff; font-size: 24px; margin: 0;">
+            Camelot AI
+          </h1>
+        </div>
+        <div style="padding: 32px 24px;">
+          <h2 style="margin-top: 0;">You've been added to #{project.name}</h2>
+          <p>
+            You can now collaborate on this project's tasks and agents.
+          </p>
+          <p style="text-align: center; margin: 32px 0;">
+            <a href="#{url}" style="background: #7c3aed; color: #ffffff; \
+    padding: 12px 24px; border-radius: 6px; text-decoration: none; \
+    font-weight: bold; display: inline-block;">
+              Open #{project.name}
+            </a>
+          </p>
+          <p style="color: #666666; font-size: 14px;">
+            If the button doesn't work, copy and paste this link into your browser:<br>
+            <a href="#{url}" style="color: #7c3aed;">#{url}</a>
+          </p>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_text_body(project, url) do
+    """
+    You've been added to #{project.name}
+
+    You can now collaborate on this project's tasks and agents.
+
+    Open #{project.name}:
+    #{url}
+    """
+  end
+end

--- a/lib/camelot_web/components/members_editor.ex
+++ b/lib/camelot_web/components/members_editor.ex
@@ -1,0 +1,119 @@
+defmodule CamelotWeb.Components.MembersEditor do
+  @moduledoc """
+  Lists a project's `Camelot.Projects.Membership` rows and, when
+  `can_invite?`, lets an admin or the project's owner add a new
+  member by email — existing or brand-new — via `Membership.:invite`.
+
+      <.live_component
+        module={CamelotWeb.Components.MembersEditor}
+        id="project-members"
+        project_id={@project.id}
+        current_user={@current_user}
+        can_invite?={@can_invite?}
+      />
+  """
+  use CamelotWeb, :live_component
+
+  alias Camelot.Projects.Membership
+
+  require Ash.Query
+
+  @roles [:member, :owner]
+
+  @impl true
+  def update(assigns, socket) do
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(memberships: list_memberships(assigns.project_id), roles: @roles)
+     |> assign_new(:form, fn -> to_form(blank_params()) end)
+     |> assign_new(:error, fn -> nil end)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <section class="space-y-4">
+      <h2 class="text-lg font-semibold">Team</h2>
+
+      <.table id={"members-#{@id}"} rows={@memberships}>
+        <:col :let={membership} label="Email">
+          {membership.user.email}
+          <span :if={membership.user_id == @current_user.id} class="badge badge-ghost">
+            you
+          </span>
+        </:col>
+        <:col :let={membership} label="Role">
+          {membership.role}
+        </:col>
+      </.table>
+
+      <.simple_form
+        :if={@can_invite?}
+        for={@form}
+        id={"invite-form-#{@id}"}
+        phx-submit="invite_member"
+        phx-target={@myself}
+      >
+        <p :if={@error} class="text-sm text-error">{@error}</p>
+
+        <div class="flex flex-wrap gap-3 items-end">
+          <.input
+            field={@form[:email]}
+            type="email"
+            label="Email"
+            placeholder="teammate@example.com"
+          />
+          <.input field={@form[:role]} type="select" label="Role" options={@roles} />
+          <.button phx-disable-with="Inviting..." class="btn btn-primary btn-sm">
+            Invite
+          </.button>
+        </div>
+      </.simple_form>
+    </section>
+    """
+  end
+
+  @impl true
+  def handle_event("invite_member", %{"email" => email, "role" => role}, socket) do
+    actor = socket.assigns.current_user
+
+    attrs = %{
+      project_id: socket.assigns.project_id,
+      email: email,
+      role: parse_role(role)
+    }
+
+    Membership
+    |> Ash.Changeset.for_create(:invite, attrs, actor: actor)
+    |> Ash.create()
+    |> case do
+      {:ok, _membership} ->
+        {:noreply,
+         assign(socket,
+           memberships: list_memberships(socket.assigns.project_id),
+           form: to_form(blank_params()),
+           error: nil
+         )}
+
+      {:error, error} ->
+        {:noreply, assign(socket, error: format_error(error))}
+    end
+  end
+
+  defp parse_role("owner"), do: :owner
+  defp parse_role(_), do: :member
+
+  defp format_error(%Ash.Error.Invalid{errors: [%{message: msg} | _]}) when is_binary(msg), do: msg
+  defp format_error(_), do: "Could not invite that user."
+
+  defp list_memberships(project_id) do
+    Membership
+    |> Ash.Query.filter(project_id == ^project_id)
+    |> Ash.Query.load(:user)
+    |> Ash.Query.sort(:role)
+    |> Ash.read!(authorize?: false)
+  end
+
+  defp blank_params, do: %{"email" => "", "role" => "member"}
+end

--- a/lib/camelot_web/live/project_live/show.ex
+++ b/lib/camelot_web/live/project_live/show.ex
@@ -5,9 +5,11 @@ defmodule CamelotWeb.ProjectLive.Show do
   use CamelotWeb, :live_view
 
   alias Camelot.Accounts.User
+  alias Camelot.Projects.Membership
   alias Camelot.Projects.Project
   alias Camelot.Runtime.Runner.DockerApi
   alias CamelotWeb.Components.EnvVarEditor
+  alias CamelotWeb.Components.MembersEditor
   alias CamelotWeb.Scope
   alias Phoenix.LiveView.Socket
 
@@ -23,7 +25,8 @@ defmodule CamelotWeb.ProjectLive.Show do
          assign(socket,
            page_title: project.name,
            project: project,
-           node_labels: node_labels(socket.assigns.current_user)
+           node_labels: node_labels(socket.assigns.current_user),
+           can_invite?: can_invite?(project.id, socket.assigns.current_user)
          )}
 
       :forbidden ->
@@ -71,6 +74,9 @@ defmodule CamelotWeb.ProjectLive.Show do
 
   defp node_labels(%User{role: :admin}), do: DockerApi.list_node_labels_or_empty()
   defp node_labels(%User{}), do: []
+
+  defp can_invite?(_project_id, %User{role: :admin}), do: true
+  defp can_invite?(project_id, %User{id: user_id}), do: Membership.owner?(project_id, user_id)
 
   @impl true
   def render(assigns) do
@@ -140,6 +146,14 @@ defmodule CamelotWeb.ProjectLive.Show do
           />
         </form>
       </div>
+
+      <.live_component
+        module={MembersEditor}
+        id="project-members"
+        project_id={@project.id}
+        current_user={@current_user}
+        can_invite?={@can_invite?}
+      />
 
       <.live_component
         module={EnvVarEditor}

--- a/test/camelot/projects/membership/changes/resolve_invitee_test.exs
+++ b/test/camelot/projects/membership/changes/resolve_invitee_test.exs
@@ -1,0 +1,149 @@
+defmodule Camelot.Projects.Membership.Changes.ResolveInviteeTest do
+  use Camelot.DataCase, async: false
+
+  import Swoosh.TestAssertions
+
+  alias Ash.Error.Invalid
+  alias Ash.Resource.Info
+  alias Camelot.Accounts.User
+  alias Camelot.Projects.Membership
+  alias Camelot.Projects.Membership.Changes.ResolveInvitee
+  alias Camelot.Projects.Membership.Changes.SendProjectInviteEmail
+  alias Camelot.Projects.Project
+
+  require Ash.Query
+
+  defp create_project!(owner, name \\ "proj-#{System.unique_integer()}") do
+    Ash.create!(Project, %{name: name, path: "/tmp/#{name}"}, actor: owner)
+  end
+
+  defp invite(project, email, actor, opts \\ []) do
+    Membership
+    |> Ash.Changeset.for_create(
+      :invite,
+      Map.merge(%{project_id: project.id, email: email}, Map.new(opts)),
+      actor: actor
+    )
+    |> Ash.create()
+  end
+
+  describe ":invite action" do
+    test "admin can invite an unknown email, creating a new confirmed user and membership" do
+      admin = Ash.Seed.seed!(User, %{email: "admin@e.com", role: :admin})
+      project = create_project!(admin)
+
+      assert {:ok, membership} = invite(project, "new-invitee@e.com", admin)
+
+      assert membership.role == :member
+      assert membership.project_id == project.id
+
+      user = Ash.get!(User, membership.user_id, authorize?: false)
+      assert to_string(user.email) == "new-invitee@e.com"
+      assert user.confirmed_at
+
+      assert_email_sent(subject: "You're invited to Camelot AI")
+      assert_email_sent(subject: "You've been added to #{project.name} on Camelot AI")
+    end
+
+    test "project owner (non-admin) can invite an unknown email into their project" do
+      owner = Ash.Seed.seed!(User, %{email: "owner@e.com", role: :user})
+      project = create_project!(owner)
+
+      assert {:ok, membership} = invite(project, "owner-invitee@e.com", owner)
+
+      assert membership.role == :member
+      user = Ash.get!(User, membership.user_id, authorize?: false)
+      assert to_string(user.email) == "owner-invitee@e.com"
+    end
+
+    test "inviting a known email attaches the existing user without creating a duplicate or account email" do
+      admin = Ash.Seed.seed!(User, %{email: "admin2@e.com", role: :admin})
+      project = create_project!(admin)
+      existing = Ash.Seed.seed!(User, %{email: "existing@e.com", role: :user})
+
+      assert {:ok, membership} = invite(project, "existing@e.com", admin)
+
+      assert membership.user_id == existing.id
+
+      assert Enum.count(Ash.read!(Ash.Query.filter(User, email == "existing@e.com"), authorize?: false)) == 1
+
+      refute_email_sent(subject: "You're invited to Camelot AI")
+      assert_email_sent(subject: "You've been added to #{project.name} on Camelot AI")
+    end
+
+    test "a plain member (not owner, not admin) is rejected with a clear error" do
+      owner = Ash.Seed.seed!(User, %{email: "owner2@e.com", role: :user})
+      project = create_project!(owner)
+      member = Ash.Seed.seed!(User, %{email: "member@e.com", role: :user})
+
+      Membership
+      |> Ash.Changeset.for_create(
+        :create,
+        %{project_id: project.id, user_id: member.id, role: :member},
+        authorize?: false
+      )
+      |> Ash.create!()
+
+      assert {:error, error} = invite(project, "someone-else@e.com", member)
+
+      assert %Invalid{} = error
+
+      assert Enum.any?(
+               error.errors,
+               &(&1.message =~ "admin or the project's owner")
+             )
+    end
+
+    test "inviting someone already on the project is rejected, not a database error" do
+      admin = Ash.Seed.seed!(User, %{email: "admin3@e.com", role: :admin})
+      project = create_project!(admin)
+
+      assert {:ok, _membership} = invite(project, "dupe@e.com", admin)
+      assert {:error, error} = invite(project, "dupe@e.com", admin)
+
+      assert %Invalid{} = error
+      assert Enum.any?(error.errors, &(&1.message =~ "already a member"))
+    end
+
+    test "defaults to role :member" do
+      admin = Ash.Seed.seed!(User, %{email: "admin4@e.com", role: :admin})
+      project = create_project!(admin)
+
+      assert {:ok, membership} = invite(project, "default-role@e.com", admin)
+      assert membership.role == :member
+    end
+
+    test "accepts role: :owner from an authorized actor" do
+      admin = Ash.Seed.seed!(User, %{email: "admin5@e.com", role: :admin})
+      project = create_project!(admin)
+
+      assert {:ok, membership} = invite(project, "co-owner@e.com", admin, role: :owner)
+      assert membership.role == :owner
+    end
+  end
+
+  describe "resource-level wiring" do
+    test "ResolveInvitee and SendProjectInviteEmail are wired to :invite only" do
+      invite_action = Info.action(Membership, :invite)
+
+      assert Enum.any?(invite_action.changes, fn change ->
+               match?(%{change: {ResolveInvitee, []}}, change)
+             end),
+             "ResolveInvitee should be wired into :invite. Configured changes: " <>
+               inspect(invite_action.changes)
+
+      assert Enum.any?(invite_action.changes, fn change ->
+               match?(%{change: {SendProjectInviteEmail, []}}, change)
+             end),
+             "SendProjectInviteEmail should be wired into :invite. Configured changes: " <>
+               inspect(invite_action.changes)
+
+      resource_changes = Info.changes(Membership)
+
+      refute Enum.any?(resource_changes, fn change ->
+               change.change in [{ResolveInvitee, []}, {SendProjectInviteEmail, []}]
+             end),
+             "these changes should not be resource-wide"
+    end
+  end
+end

--- a/test/camelot_web/live/project_live_test.exs
+++ b/test/camelot_web/live/project_live_test.exs
@@ -154,6 +154,71 @@ defmodule CamelotWeb.ProjectLiveTest do
     end
   end
 
+  describe "team" do
+    setup %{user: user} do
+      {:ok, project} =
+        Ash.create(Project, %{name: "team-#{System.unique_integer()}", path: "/tmp/team"}, actor: user)
+
+      %{project: project}
+    end
+
+    test "the owner sees the invite form and can invite a new member by email", %{
+      conn: conn,
+      project: project
+    } do
+      {:ok, view, html} = live(conn, ~p"/projects/#{project.id}")
+      assert html =~ "invite-form-project-members"
+
+      html =
+        view
+        |> form("#invite-form-project-members", %{"email" => "teammate@e.com", "role" => "member"})
+        |> render_submit()
+
+      assert html =~ "teammate@e.com"
+    end
+
+    test "shows an error and does not add a duplicate row when inviting an existing member", %{
+      conn: conn,
+      project: project,
+      user: user
+    } do
+      {:ok, view, _html} = live(conn, ~p"/projects/#{project.id}")
+
+      html =
+        view
+        |> form("#invite-form-project-members", %{
+          "email" => to_string(user.email),
+          "role" => "member"
+        })
+        |> render_submit()
+
+      assert html =~ "already a member"
+    end
+
+    test "invite form is hidden for a plain member", %{conn: conn} do
+      owner = Ash.Seed.seed!(User, %{email: "team-owner-#{System.unique_integer()}@x.com"})
+
+      {:ok, project} =
+        Ash.create(Project, %{name: "team-member-#{System.unique_integer()}", path: "/tmp/tm"}, actor: owner)
+
+      member = Ash.Seed.seed!(User, %{email: "team-plain-#{System.unique_integer()}@x.com"})
+
+      Camelot.Projects.Membership
+      |> Ash.Changeset.for_create(
+        :create,
+        %{project_id: project.id, user_id: member.id, role: :member},
+        authorize?: false
+      )
+      |> Ash.create!()
+
+      %{conn: conn} = log_in_user(conn, member)
+
+      {:ok, _view, html} = live(conn, ~p"/projects/#{project.id}")
+
+      refute html =~ "invite-form-project-members"
+    end
+  end
+
   describe "scoping" do
     test "non-admin sees only memberships", %{conn: conn, user: user} do
       {:ok, _mine} =

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -55,10 +55,15 @@ defmodule CamelotWeb.ConnCase do
           %{conn: Plug.Conn.t(), user: Ash.Resource.record()}
   def register_and_log_in_admin(%{conn: conn}), do: log_in_with_role(conn, :admin)
 
-  defp log_in_with_role(conn, role) do
-    email = "test-#{role}-#{System.unique_integer()}@example.com"
-    user = Ash.Seed.seed!(User, %{email: email, role: role})
-
+  @doc """
+  Stores an already-created user in the connection session for
+  authenticated test requests, without seeding a new one. Useful
+  when a test needs to log in as a specific user it created
+  earlier (e.g. a project owner or a plain member).
+  """
+  @spec log_in_user(Plug.Conn.t(), Ash.Resource.record()) ::
+          %{conn: Plug.Conn.t(), user: Ash.Resource.record()}
+  def log_in_user(conn, user) do
     {:ok, token, _claims} = AshAuthentication.Jwt.token_for_user(user)
     user = %{user | __metadata__: Map.put(user.__metadata__, :token, token)}
 
@@ -68,5 +73,12 @@ defmodule CamelotWeb.ConnCase do
       |> AuthHelpers.store_in_session(user)
 
     %{conn: conn, user: user}
+  end
+
+  defp log_in_with_role(conn, role) do
+    email = "test-#{role}-#{System.unique_integer()}@example.com"
+    user = Ash.Seed.seed!(User, %{email: email, role: role})
+
+    log_in_user(conn, user)
   end
 end


### PR DESCRIPTION
## Summary
- Add `Membership.:invite` create action: authorizes the actor (global admin or the project's `owner` member), finds or creates the invited `User` by email (reusing `User.:create_user` for unknown emails so it stays immune to the duplicate-confirmation-email bug fixed in d867153), guards against duplicate membership, and sends a new project-specific "you've been added" email.
- Add a `Camelot.Projects.Membership.owner?/2` helper shared by the resource-level authorization check and the LiveView gating check, so they can't drift apart.
- Add a "Team" section to `ProjectLive.Show` backed by a new `MembersEditor` live_component (modeled on `EnvVarEditor`): lists current members, and — for admins/owners only — an email+role invite form.

## Test plan
- [x] `mix compile --warnings-as-errors`
- [x] `mix test` (363 tests, 0 failures — includes new resource-level and LiveView tests)
- [x] `mix credo --strict` (no new issues)
- [x] `mix dialyzer` (passed)
- [x] `mix format --check-formatted`
- [x] Booted with `mix run`/Bandit and manually hit `/sign-in` and `/projects`

🤖 Generated with [Claude Code](https://claude.com/claude-code)