### PR TITLE
fix: UI fixes — prose markdown styling + board-card restart button

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -110,3 +110,112 @@
 [data-phx-session], [data-phx-teleported-src] { display: contents }
 
 /* This file is for your main application CSS */
+
+/* Prose markdown styling for plan/description cards */
+.prose h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-top: 1.25rem;
+  margin-bottom: 0.75rem;
+  line-height: 1.2;
+}
+
+.prose h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-top: 1.25rem;
+  margin-bottom: 0.5rem;
+  line-height: 1.25;
+}
+
+.prose h3 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+  line-height: 1.3;
+}
+
+.prose h4 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-top: 0.75rem;
+  margin-bottom: 0.25rem;
+  line-height: 1.3;
+}
+
+.prose p {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  line-height: 1.6;
+}
+
+.prose ul,
+.prose ol {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  padding-left: 1.5rem;
+}
+
+.prose ul {
+  list-style-type: disc;
+}
+
+.prose ol {
+  list-style-type: decimal;
+}
+
+.prose li {
+  margin-top: 0.125rem;
+  margin-bottom: 0.125rem;
+}
+
+.prose a {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.prose blockquote {
+  border-left: 3px solid oklch(70% 0 0 / 40%);
+  padding-left: 0.75rem;
+  margin: 0.75rem 0;
+  color: oklch(from currentColor l c h / 0.75);
+  font-style: italic;
+}
+
+.prose hr {
+  border: 0;
+  border-top: 1px solid oklch(70% 0 0 / 25%);
+  margin: 1rem 0;
+}
+
+.prose table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.875rem;
+}
+
+.prose th,
+.prose td {
+  border: 1px solid oklch(70% 0 0 / 30%);
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+
+.prose th {
+  font-weight: 600;
+  background-color: oklch(50% 0 0 / 10%);
+}
+
+.prose tr:nth-child(even) {
+  background-color: oklch(50% 0 0 / 5%);
+}
+
+.prose pre {
+  overflow-x: auto;
+}
+
+.prose code {
+  font-size: 0.85em;
+  word-break: break-word;
+}

--- a/lib/camelot_web/components/board_components.ex
+++ b/lib/camelot_web/components/board_components.ex
@@ -76,6 +76,16 @@ defmodule CamelotWeb.BoardComponents do
           <span class="badge badge-xs badge-ghost">
             P{@task.priority}
           </span>
+          <button
+            :if={@task.state in [:error, :in_progress]}
+            phx-click="restart_task"
+            phx-value-id={@task.id}
+            data-confirm="Restart this task?"
+            class="btn btn-xs btn-warning ml-auto"
+            title="Restart this task"
+          >
+            <.icon name="hero-arrow-path" class="size-3" />
+          </button>
         </div>
       </div>
     </div>

--- a/lib/camelot_web/live/board_live.ex
+++ b/lib/camelot_web/live/board_live.ex
@@ -80,6 +80,19 @@ defmodule CamelotWeb.BoardLive do
     {:noreply, socket |> assign(see_all: !socket.assigns.see_all) |> load_board()}
   end
 
+  def handle_event("restart_task", %{"id" => id}, socket) do
+    task = Ash.get!(Task, id)
+
+    case Ash.update(task, %{}, action: :reset) do
+      {:ok, task} ->
+        broadcast_task_event(:task_updated, task)
+        {:noreply, socket |> put_flash(:info, "Task restarted") |> load_board()}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, "Cannot restart task")}
+    end
+  end
+
   defp load_board(socket) do
     user = socket.assigns.current_user
     see_all = socket.assigns.see_all

--- a/lib/camelot_web/live/task_live.ex
+++ b/lib/camelot_web/live/task_live.ex
@@ -17,6 +17,15 @@ defmodule CamelotWeb.TaskLive do
 
   @task_load [:project, :agent, :creator, :sessions, :messages]
 
+  # GFM extensions so plan/description markdown renders tables,
+  # strikethrough, autolinks and task lists instead of raw text.
+  @markdown_extensions [
+    table: true,
+    strikethrough: true,
+    autolink: true,
+    tasklist: true
+  ]
+
   @impl true
   def mount(%{"id" => id}, _session, socket) do
     case load_or_forbid(id, socket.assigns.current_user) do
@@ -467,12 +476,12 @@ defmodule CamelotWeb.TaskLive do
             </:item>
           </.list>
 
-          <div :if={@task.description} class="prose max-w-none">
+          <div :if={@task.description} class="prose max-w-none overflow-x-auto">
             <h3>Description</h3>
             {render_markdown(@task.description)}
           </div>
 
-          <div :if={@task.plan} class="prose max-w-none">
+          <div :if={@task.plan} class="prose max-w-none overflow-x-auto">
             <h3>Plan</h3>
             {render_markdown(@task.plan)}
           </div>
@@ -699,7 +708,7 @@ defmodule CamelotWeb.TaskLive do
   end
 
   defp render_markdown(text) when is_binary(text) do
-    case MDEx.to_html(text) do
+    case MDEx.to_html(text, extension: @markdown_extensions) do
       {:ok, html} -> Phoenix.HTML.raw(html)
       {:error, _} -> text
     end

--- a/lib/camelot_web/live/task_live.ex
+++ b/lib/camelot_web/live/task_live.ex
@@ -32,7 +32,8 @@ defmodule CamelotWeb.TaskLive do
             task: task,
             message_input: "",
             live_output: "",
-            subscribed_agent_id: nil
+            subscribed_agent_id: nil,
+            focused_column: :none
           )
           |> maybe_subscribe_agent(task)
 
@@ -267,6 +268,31 @@ defmodule CamelotWeb.TaskLive do
     end
   end
 
+  def handle_event("toggle_column", %{"col" => "left"}, socket) do
+    {:noreply, toggle_focused_column(socket, :left)}
+  end
+
+  def handle_event("toggle_column", %{"col" => "right"}, socket) do
+    {:noreply, toggle_focused_column(socket, :right)}
+  end
+
+  defp toggle_focused_column(socket, target) do
+    next =
+      case socket.assigns.focused_column do
+        ^target -> :none
+        _ -> target
+      end
+
+    assign(socket, focused_column: next)
+  end
+
+  defp grid_class(:none), do: "grid grid-cols-1 lg:grid-cols-2 gap-6"
+  defp grid_class(_focused), do: "grid grid-cols-1 gap-6"
+
+  defp column_hidden?(:left, :right), do: true
+  defp column_hidden?(:right, :left), do: true
+  defp column_hidden?(_col, _focused), do: false
+
   defp reset_task_and_agent(socket, task) do
     stop_agent_process(task.agent.id)
 
@@ -387,8 +413,34 @@ defmodule CamelotWeb.TaskLive do
         </div>
       </div>
 
-      <div class="grid grid-cols-2 gap-6">
-        <div class="space-y-4">
+      <div class={grid_class(@focused_column)}>
+        <div class={[
+          "space-y-4",
+          column_hidden?(:left, @focused_column) && "hidden"
+        ]}>
+          <div class="flex justify-end">
+            <button
+              type="button"
+              phx-click="toggle_column"
+              phx-value-col="left"
+              class="btn btn-xs btn-ghost"
+              aria-label="Toggle details column full-width"
+              title={
+                if @focused_column == :left,
+                  do: "Restore split view",
+                  else: "Expand to full width"
+              }
+            >
+              <.icon
+                name={
+                  if @focused_column == :left,
+                    do: "hero-arrows-pointing-in",
+                    else: "hero-arrows-pointing-out"
+                }
+                class="size-4"
+              />
+            </button>
+          </div>
           <.list>
             <:item title="Stage">
               <span class={["badge", stage_class(@task.stage)]}>
@@ -466,8 +518,34 @@ defmodule CamelotWeb.TaskLive do
           </form>
         </div>
 
-        <div class="space-y-4">
-          <h3 class="font-semibold">Sessions</h3>
+        <div class={[
+          "space-y-4",
+          column_hidden?(:right, @focused_column) && "hidden"
+        ]}>
+          <div class="flex items-center justify-between">
+            <h3 class="font-semibold">Sessions</h3>
+            <button
+              type="button"
+              phx-click="toggle_column"
+              phx-value-col="right"
+              class="btn btn-xs btn-ghost"
+              aria-label="Toggle sessions column full-width"
+              title={
+                if @focused_column == :right,
+                  do: "Restore split view",
+                  else: "Expand to full width"
+              }
+            >
+              <.icon
+                name={
+                  if @focused_column == :right,
+                    do: "hero-arrows-pointing-in",
+                    else: "hero-arrows-pointing-out"
+                }
+                class="size-4"
+              />
+            </button>
+          </div>
           <div
             :if={Ash.Resource.loaded?(@task, :sessions) && @task.sessions != []}
             class="space-y-2"

--- a/test/camelot_web/live/board_live_test.exs
+++ b/test/camelot_web/live/board_live_test.exs
@@ -51,6 +51,30 @@ defmodule CamelotWeb.BoardLiveTest do
     refute form_html =~ "some details"
   end
 
+  test "restart_task resets an errored task back to queued", %{conn: conn, user: user} do
+    {:ok, project} =
+      Ash.create(
+        Project,
+        %{name: "p-#{System.unique_integer()}", path: "/tmp/r"},
+        actor: user
+      )
+
+    task =
+      Ash.Seed.seed!(Task, %{
+        title: "stuck-task-#{System.unique_integer()}",
+        project_id: project.id,
+        creator_id: user.id,
+        stage: :executing,
+        state: :error
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    render_click(view, "restart_task", %{"id" => task.id})
+
+    assert Ash.get!(Task, task.id).state == :queued
+  end
+
   describe "scoping" do
     test "non-admin sees only tasks from member projects", %{conn: conn, user: user} do
       {:ok, mine} =

--- a/test/camelot_web/live/task_live_test.exs
+++ b/test/camelot_web/live/task_live_test.exs
@@ -208,6 +208,32 @@ defmodule CamelotWeb.TaskLiveTest do
     end
   end
 
+  describe "column focus" do
+    test "toggling a column expands it to full width", %{conn: conn, task: task} do
+      {:ok, view, html} = live(conn, ~p"/tasks/#{task.id}")
+      refute html =~ "Restore split view"
+
+      html =
+        view
+        |> element(~s(button[phx-value-col="left"]))
+        |> render_click()
+
+      assert html =~ "Restore split view"
+      assert html =~ "hero-arrows-pointing-in"
+    end
+
+    test "toggling the same column again restores the split view", %{conn: conn, task: task} do
+      {:ok, view, _html} = live(conn, ~p"/tasks/#{task.id}")
+
+      button = fn -> element(view, ~s(button[phx-value-col="left"])) end
+
+      render_click(button.())
+      html = render_click(button.())
+
+      refute html =~ "Restore split view"
+    end
+  end
+
   describe "scoping" do
     test "redirects non-member from another user's task", %{conn: conn} do
       other = Ash.Seed.seed!(Camelot.Accounts.User, %{email: "to-#{System.unique_integer()}@x.com"})

--- a/test/camelot_web/live/task_live_test.exs
+++ b/test/camelot_web/live/task_live_test.exs
@@ -35,6 +35,22 @@ defmodule CamelotWeb.TaskLiveTest do
       assert html =~ "Live task"
       assert html =~ "todo"
     end
+
+    test "renders GFM markdown tables in the description", %{conn: conn, project: project, user: user} do
+      {:ok, task} =
+        Ash.create(Task, %{
+          title: "Tabular task",
+          description: "| A | B |\n|---|---|\n| 1 | 2 |",
+          project_id: project.id,
+          creator_id: user.id
+        })
+
+      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.id}")
+
+      assert html =~ "<table>"
+      assert html =~ "<th>A</th>"
+      refute html =~ "| A | B |"
+    end
   end
 
   describe "cancel" do


### PR DESCRIPTION
## What & why

The stale `fixes/pipeline` branch (last touched ~May, since diverged ~176 commits behind `develop`) carried a headline commit *"bunch of UI and pipeline fixes"*. Merging it wholesale would have dragged in an unfinished pipeline/runtime rewrite that conflicts with — and would regress — the runtime work merged since. This PR salvages **only the UI parts** that are still relevant, re-applied cleanly on top of current `develop`.

## Changes

- **Prose markdown styling** (`assets/css/app.css`): `task_live` already renders plan/description with `class="prose max-w-none"` and MDEx is already a dependency, but `develop` shipped no CSS to style it. Adds headings/lists/tables/blockquote/code styling so rendered markdown looks right.
- **Board-card restart button** (`board_components.ex` + `board_live.ex`): errored / in-progress task cards get a restart button wired to the existing `:reset` action, with a matching `restart_task` handler + test.
- **Task detail column full-width toggle** (`task_live.ex`): each of the two columns (details / sessions) gets an expand button that focuses it to full width and hides the other, then restores the split view. Adapted to develop's current two-column layout.

## Deliberately dropped

- Landing-page `html/*` changes — the landing page was moved to the ops vault, so `html/` no longer exists in this repo.
- The unfinished pipeline rewrite (`agent_process.ex`, `dispatch_tasks.ex`, `check_pr_status.ex`, …) — superseded by newer runtime work on `develop`.

## Checks

- `mix compile --warnings-as-errors` ✅
- `mix test` — 375 tests, 0 failures ✅ (added `restart_task` + column-focus tests)
- `mix credo` on changed files — no issues ✅
- `mix format` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)