### PR TITLE
fix(task): cap rendered session output_log to its tail

### DIFF
--- a/lib/camelot_web/live/task_live.ex
+++ b/lib/camelot_web/live/task_live.ex
@@ -692,7 +692,7 @@ defmodule CamelotWeb.TaskLive do
               <pre
                 :if={session.output_log}
                 class="mt-2 text-xs overflow-auto max-h-40 bg-base-300 p-2 rounded"
-              >{session.output_log}</pre>
+              >{output_tail(session.output_log)}</pre>
             </div>
           </div>
           <p
@@ -754,6 +754,22 @@ defmodule CamelotWeb.TaskLive do
       str
     end
   end
+
+  # A completed session's persisted output_log can be several MB. The
+  # panel only ever shows a scrollable tail, so shipping the whole blob
+  # in the LiveView diff is wasted bytes (and on longpoll it overflows
+  # the proxy buffer and kills the socket). Render only the tail.
+  @output_log_limit 20_000
+
+  defp output_tail(log) when is_binary(log) do
+    if String.length(log) > @output_log_limit do
+      "… (truncated — showing last 20 KB) …\n" <> cap_tail(log, @output_log_limit)
+    else
+      log
+    end
+  end
+
+  defp output_tail(log), do: log
 
   # Best-effort render of the NDJSON stream-json feed: surface
   # assistant text and tool calls, collapse other events to a marker,

--- a/test/camelot_web/live/task_live_test.exs
+++ b/test/camelot_web/live/task_live_test.exs
@@ -162,6 +162,56 @@ defmodule CamelotWeb.TaskLiveTest do
     end
   end
 
+  describe "session output log" do
+    setup %{project: project, user: user} do
+      {:ok, agent} =
+        Ash.create(Agent, %{
+          name: "output-log-agent",
+          template_id: agent_template!("claude_code").id,
+          project_id: project.id,
+          user_id: user.id
+        })
+
+      {:ok, task} =
+        Ash.create(Task, %{
+          title: "Output log task",
+          project_id: project.id,
+          creator_id: user.id
+        })
+
+      {:ok, task} = Ash.update(task, %{agent_id: agent.id}, action: :begin_work)
+
+      {:ok, session} = Ash.create(Session, %{agent_id: agent.id, task_id: task.id})
+
+      %{agent: agent, task: task, session: session}
+    end
+
+    test "a large output log is truncated to its tail in the render",
+         %{conn: conn, task: task, session: session} do
+      log = "HEAD_MARKER" <> String.duplicate("x", 30_000) <> "TAIL_MARKER"
+
+      {:ok, _session} =
+        Ash.update(session, %{output_log: log, exit_code: 0}, action: :complete)
+
+      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.id}")
+
+      assert html =~ "TAIL_MARKER"
+      refute html =~ "HEAD_MARKER"
+      assert html =~ "truncated"
+    end
+
+    test "a small output log renders in full without truncation",
+         %{conn: conn, task: task, session: session} do
+      {:ok, _session} =
+        Ash.update(session, %{output_log: "SHORT_OUTPUT", exit_code: 0}, action: :complete)
+
+      {:ok, _view, html} = live(conn, ~p"/tasks/#{task.id}")
+
+      assert html =~ "SHORT_OUTPUT"
+      refute html =~ "truncated"
+    end
+  end
+
   describe "agent updates" do
     test "survives an {:agent_updated, agent} broadcast and reflects new status",
          %{conn: conn, project: project, user: user} do


### PR DESCRIPTION
## Problem

Users on `app.camelotai.tech` hit **"Something went wrong! Attempting to reconnect"** in a loop on the task detail page — but only for tasks with large runner output. `test.camelotai.tech` never reproduces it because no task there has a big log.

### Root cause (data-driven, not infra)

`CamelotWeb.TaskLive` rendered `session.output_log` **in full** for every session (`task_live.ex`) and re-pushed it on every `{:task_updated}` broadcast. A completed runner session's log can be several MB — one prod task (`30cf32e8…`) carried **~6 MB** across its sessions (one session alone was 5.3 MB).

The `max-h-40 overflow-auto` box only ever *displays* the tail, yet the whole blob was shipped in the LiveView diff. On a WebSocket-hostile network the client falls back to longpoll (`longPollFallbackMs: 2500`), where that oversized response overflows nginx's proxy buffer (spilled to a temp file — confirmed by `buffered to a temporary file` warnings, 29× on prod), stalls ~20 s, then dies with `NS_BINDING_ABORTED` → socket crash → reconnect → re-send → loop.

Verified end-to-end: raw WebSocket, `check_origin`, DB, and nginx config are all healthy and identical across prod/test — the difference was purely the payload size of this task's data.

## Fix

Render only the last **20 KB** of `output_log` (with a `… (truncated …) …` marker), mirroring the existing 20k cap already applied to the live-output buffer (`cap_tail/2`). Drops this task's payload from ~6 MB to ~80 KB and stops the reconnect loop on both websocket and longpoll.

Follow-up worth considering separately (out of scope): avoid *loading* the full column from the DB on every task update via an Ash `select`/substring — a memory win on the small prod node.

## Tests

- New `describe "session output log"`: large log is truncated to its tail (head marker absent, tail present, truncation notice shown); small log renders in full.
- Full suite green: **397 tests, 0 failures**. `mix format`, `credo`, `compile --warnings-as-errors`, and `dialyzer` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)