### PR TITLE
fix(agents): stop legacy credential kinds from breaking template load

### DIFF
--- a/lib/camelot/accounts/credential.ex
+++ b/lib/camelot/accounts/credential.ex
@@ -28,6 +28,10 @@ defmodule Camelot.Accounts.Credential do
     :generic
   ]
 
+  @doc "Currently-valid credential kinds."
+  @spec valid_kinds() :: [atom()]
+  def valid_kinds, do: @kinds
+
   postgres do
     table("credentials")
     repo(Camelot.Repo)

--- a/lib/camelot/agents/agent_template.ex
+++ b/lib/camelot/agents/agent_template.ex
@@ -158,7 +158,7 @@ defmodule Camelot.Agents.AgentTemplate do
       )
     end
 
-    attribute :required_credential_kinds, {:array, :atom} do
+    attribute :required_credential_kinds, Camelot.Agents.CredentialKinds do
       allow_nil?(false)
       public?(true)
       default([])

--- a/lib/camelot/agents/credential_kinds.ex
+++ b/lib/camelot/agents/credential_kinds.ex
@@ -1,0 +1,62 @@
+defmodule Camelot.Agents.CredentialKinds do
+  @moduledoc """
+  Array-of-atom Ash type for `AgentTemplate.required_credential_kinds`.
+
+  `{:array, :atom}` fails to load the whole row if any stored
+  element isn't a currently-known atom — retiring a credential kind
+  (removing its atom literal from the app entirely, e.g.
+  `github_pat`/`github_oauth` in PR #75) permanently breaks loading
+  any template row still carrying it in Postgres, which silently
+  stalls task dispatch. Drop unknown/legacy entries on load instead
+  of failing, so a template stays loadable even if a cleanup
+  migration hasn't run (or missed a row).
+  """
+  use Ash.Type
+
+  alias Camelot.Accounts.Credential
+
+  @impl true
+  def storage_type(_), do: {:array, :string}
+
+  @impl true
+  def cast_input(nil, _), do: {:ok, nil}
+
+  def cast_input(value, _) when is_list(value) do
+    if Enum.all?(value, &(&1 in Credential.valid_kinds())) do
+      {:ok, value}
+    else
+      :error
+    end
+  end
+
+  def cast_input(_, _), do: :error
+
+  @impl true
+  def cast_stored(nil, _), do: {:ok, nil}
+
+  def cast_stored(value, _) when is_list(value) do
+    known = Enum.map(Credential.valid_kinds(), &Atom.to_string/1)
+
+    atoms =
+      value
+      |> Enum.filter(&(&1 in known))
+      |> Enum.map(&String.to_existing_atom/1)
+
+    {:ok, atoms}
+  end
+
+  def cast_stored(_, _), do: :error
+
+  @impl true
+  def dump_to_native(nil, _), do: {:ok, nil}
+
+  def dump_to_native(value, _) when is_list(value) do
+    {:ok, Enum.map(value, &to_string/1)}
+  end
+
+  def dump_to_native(_, _), do: :error
+
+  @impl true
+  def matches_type?(value, _) when is_list(value), do: Enum.all?(value, &is_atom/1)
+  def matches_type?(_, _), do: false
+end

--- a/priv/repo/migrations/20260730120000_remove_legacy_credential_kinds_from_templates.exs
+++ b/priv/repo/migrations/20260730120000_remove_legacy_credential_kinds_from_templates.exs
@@ -1,0 +1,27 @@
+defmodule Camelot.Repo.Migrations.RemoveLegacyCredentialKindsFromTemplates do
+  @moduledoc """
+  PR #75 dropped `github_pat`/`github_oauth` from the set of valid
+  credential kinds and cleaned up `credentials` rows of those kinds,
+  but left any `agent_templates.required_credential_kinds` array
+  still listing them untouched. Since those atoms no longer exist
+  anywhere in the compiled app, `String.to_existing_atom/1` fails
+  loading such a row, permanently breaking task dispatch for any
+  agent using that template. Strip the retired kinds from the array
+  instead of deleting the template. One-way: no meaningful `down`.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    UPDATE agent_templates
+    SET required_credential_kinds =
+      array_remove(array_remove(required_credential_kinds, 'github_pat'), 'github_oauth')
+    WHERE required_credential_kinds && ARRAY['github_pat', 'github_oauth']
+    """)
+  end
+
+  def down do
+    :ok
+  end
+end

--- a/test/camelot/agents/agent_template_test.exs
+++ b/test/camelot/agents/agent_template_test.exs
@@ -2,6 +2,7 @@ defmodule Camelot.Agents.AgentTemplateTest do
   use Camelot.DataCase, async: true
 
   alias Camelot.Agents.AgentTemplate
+  alias Ecto.Adapters.SQL
 
   describe "seeded data" do
     test "claude_code template exists with expected fields" do
@@ -75,6 +76,27 @@ defmodule Camelot.Agents.AgentTemplateTest do
 
       assert updated.base_args == ["--quiet", "--no-color"]
       assert updated.slug == "codex"
+    end
+  end
+
+  describe "required_credential_kinds legacy values" do
+    test "loads a row carrying a retired kind, dropping it instead of failing" do
+      template = agent_template!("claude_code")
+
+      # Simulate data left behind by a credential-kind retirement (e.g.
+      # PR #75 removing github_pat/github_oauth) without a cleanup
+      # migration having run yet: a raw SQL write, bypassing Ash, since
+      # `String.to_existing_atom("github_pat")` no longer succeeds and
+      # Ash's own `one_of`-validated write path would reject it outright.
+      SQL.query!(
+        Camelot.Repo,
+        "UPDATE agent_templates SET required_credential_kinds = $1 WHERE id = $2",
+        [["claude_api_key", "github_pat"], Ecto.UUID.dump!(template.id)]
+      )
+
+      reloaded = agent_template!("claude_code")
+
+      assert reloaded.required_credential_kinds == [:claude_api_key]
     end
   end
 end


### PR DESCRIPTION
## Summary
- PR #75 removed `github_pat`/`github_oauth` from the valid credential kinds but never migrated `agent_templates.required_credential_kinds` rows still carrying them, and the attribute was a bare `{:array, :atom}`. Loading such a row raises (`String.to_existing_atom` fails on the retired atom), which permanently aborts task dispatch and strands the task in `in_progress` with no session.
- Adds a one-off migration to strip the retired kinds from existing `agent_templates` rows.
- Replaces the attribute type with `Camelot.Agents.CredentialKinds`, a custom Ash type that drops unknown/legacy kinds on load instead of failing the whole row — so a template stays loadable even if a future kind retirement's cleanup migration is incomplete or hasn't run yet.

Found while investigating a task stuck at `https://test.camelotai.tech/tasks/1dafe896-1425-4b18-9a28-d7dcb23e7494` — dispatch log showed:
```
Failed to dispatch task ...: cannot load ["claude_api_key", "github_pat"] as type {:array, Ash.Type.Atom.EctoType<...>}
```

## Test plan
- [x] `mix compile` — no warnings
- [x] `mix test` — 456 tests, 0 failures (includes new regression test simulating a legacy `github_pat` value via raw SQL)
- [x] `mix credo --strict` — clean (no new findings)
- [x] `mix dialyzer` — clean
- [x] `mix format`
- [x] Verified live against dev Postgres via `mix run`: a template row with `required_credential_kinds = ["claude_api_key", "github_pat"]` now loads as `[:claude_api_key]` instead of raising

🤖 Generated with [Claude Code](https://claude.com/claude-code)