### PR TITLE
feat(runner): auto-update floating-tag runner images on boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ npm-debug.log
 
 .envrc
 .DS_Store
+
+# Private keys / certs (e.g. GitHub App keys) — never commit.
+*.pem

--- a/lib/camelot/runtime/reconciler.ex
+++ b/lib/camelot/runtime/reconciler.ex
@@ -57,6 +57,7 @@ defmodule Camelot.Runtime.Reconciler do
   alias Camelot.Runtime.Runner
   alias Camelot.Runtime.Runner.DockerApi
   alias Camelot.Runtime.Runner.LocalPort
+  alias Camelot.Runtime.Runner.Spec
   alias Camelot.Runtime.Runner.Swarm
   alias Camelot.Runtime.Runner.Swarm.ExecSession
   alias Camelot.Runtime.RunnerPool
@@ -87,8 +88,19 @@ defmodule Camelot.Runtime.Reconciler do
 
   @impl GenServer
   def init(_opts) do
-    if !skip_initial_tick?(), do: Process.send_after(self(), :tick, initial_delay_ms())
+    if !skip_initial_tick?(), do: schedule_boot_work(self())
     {:ok, %{}}
+  end
+
+  # Boot work fires once, `initial_delay_ms` after start (which, in a
+  # release, is after `Camelot.Release.migrate` has run — see
+  # `rel/overlays/bin/server`): the recurring reconcile tick plus a
+  # one-shot pass that re-resolves floating-tag runner images so a
+  # redeploy picks up freshly-published runner images.
+  defp schedule_boot_work(pid) do
+    delay = initial_delay_ms()
+    Process.send_after(pid, :tick, delay)
+    Process.send_after(pid, :autoupdate_runner_images, delay)
   end
 
   defp skip_initial_tick? do
@@ -119,6 +131,12 @@ defmodule Camelot.Runtime.Reconciler do
     {:noreply, state}
   end
 
+  # One-shot on boot only (never rescheduled).
+  def handle_info(:autoupdate_runner_images, state) do
+    autoupdate_runner_images()
+    {:noreply, state}
+  end
+
   def handle_info(_msg, state), do: {:noreply, state}
 
   # --- Reconciliation pass ---
@@ -144,6 +162,23 @@ defmodule Camelot.Runtime.Reconciler do
   rescue
     e ->
       Logger.warning("Reconciler pass failed: #{Exception.message(e)}")
+      :ok
+  end
+
+  # One-shot boot sweep: re-resolve every Swarm task service whose
+  # image uses a floating tag (`latest` or untagged) to the newest
+  # published digest, in place. Idempotent — a service already on the
+  # current digest is not rolled. Swarm-only; best-effort so a Docker
+  # hiccup can't crash the reconciler.
+  defp autoupdate_runner_images do
+    if Runner.backend() == Swarm and backend_available?() do
+      ids = list_task_runners()
+      Enum.each(ids, &Swarm.TaskService.autoupdate_image(Spec.task_runner_name(&1)))
+      Logger.info("Reconciler: autoupdate swept #{length(ids)} task runner image(s)")
+    end
+  rescue
+    e ->
+      Logger.warning("Reconciler autoupdate pass failed: #{Exception.message(e)}")
       :ok
   end
 

--- a/lib/camelot/runtime/runner/image_ref.ex
+++ b/lib/camelot/runtime/runner/image_ref.ex
@@ -1,0 +1,101 @@
+defmodule Camelot.Runtime.Runner.ImageRef do
+  @moduledoc """
+  Pure parsing of an OCI image reference into its
+  `name` / `tag` / `digest` parts, plus the two questions
+  the auto-update sweep asks of a runner image:
+
+    * `floating?/1` — is the tag one that should track the
+      newest published digest (`latest` or no tag), rather
+      than a pinned version (`:1.19`) or a digest?
+    * `without_digest/1` — the reference with any `@sha256:…`
+      stripped, so a `POST /services/{id}/update` sends a bare
+      tag and the Swarm daemon re-resolves it to the current
+      digest.
+
+  A `:` separates the tag only inside the final path segment,
+  so a registry host with a port (`registry:5000/foo/bar`)
+  is not mistaken for a tag.
+  """
+
+  @type t :: %{name: String.t(), tag: String.t() | nil, digest: String.t() | nil}
+
+  @doc """
+  Split an image reference into `%{name:, tag:, digest:}`.
+
+  ## Examples
+
+      iex> Camelot.Runtime.Runner.ImageRef.parse("ghcr.io/acme/runner:latest@sha256:abc")
+      %{name: "ghcr.io/acme/runner", tag: "latest", digest: "sha256:abc"}
+
+      iex> Camelot.Runtime.Runner.ImageRef.parse("registry:5000/acme/runner")
+      %{name: "registry:5000/acme/runner", tag: nil, digest: nil}
+  """
+  @spec parse(String.t()) :: t()
+  def parse(image) when is_binary(image) do
+    {ref, digest} = split_digest(image)
+    {name, tag} = split_tag(ref)
+    %{name: name, tag: tag, digest: digest}
+  end
+
+  @doc """
+  Whether the reference tracks a moving target: the `latest`
+  tag (Swarm resolves it to a digest, but it is still floating)
+  or a bare name with no tag and no digest (implicit `latest`).
+
+  A deliberate pin returns `false`: an explicit version tag
+  (`:1.19`) or a digest with no tag (`name@sha256:…`).
+  """
+  @spec floating?(String.t()) :: boolean()
+  def floating?(image) when is_binary(image) do
+    case parse(image) do
+      %{tag: "latest"} -> true
+      %{tag: nil, digest: nil} -> true
+      _ -> false
+    end
+  end
+
+  @doc """
+  The reference with any `@digest` removed — `name` or
+  `name:tag`. Sending this bare form back on a service update
+  makes the daemon re-resolve the tag to the current digest.
+  """
+  @spec without_digest(String.t()) :: String.t()
+  def without_digest(image) when is_binary(image) do
+    {ref, _digest} = split_digest(image)
+    ref
+  end
+
+  @doc """
+  The reference pinned to `digest` — its current tag (if any) is
+  kept and any prior digest replaced. This is the fully-resolved
+  form (`name:tag@sha256:…`) sent to Swarm so every node runs the
+  exact image.
+
+  ## Examples
+
+      iex> Camelot.Runtime.Runner.ImageRef.pin("ghcr.io/acme/runner:latest@sha256:old", "sha256:new")
+      "ghcr.io/acme/runner:latest@sha256:new"
+  """
+  @spec pin(String.t(), String.t()) :: String.t()
+  def pin(image, digest) when is_binary(image) and is_binary(digest) do
+    without_digest(image) <> "@" <> digest
+  end
+
+  defp split_digest(image) do
+    case String.split(image, "@", parts: 2) do
+      [ref, digest] -> {ref, digest}
+      [ref] -> {ref, nil}
+    end
+  end
+
+  # A colon is a tag separator only in the last `/`-segment;
+  # anything earlier (a registry `host:port`) stays in the name.
+  defp split_tag(ref) do
+    last = ref |> String.split("/") |> List.last()
+
+    case String.split(last, ":", parts: 2) do
+      [_name_part, tag] -> {String.replace_suffix(ref, ":" <> tag, ""), tag}
+      [_name_part] -> {ref, nil}
+    end
+  end
+end

--- a/lib/camelot/runtime/runner/registry_client.ex
+++ b/lib/camelot/runtime/runner/registry_client.ex
@@ -1,0 +1,150 @@
+defmodule Camelot.Runtime.Runner.RegistryClient do
+  @moduledoc """
+  Resolves the current digest an image tag points to by
+  querying its OCI registry directly over HTTPS.
+
+  We cannot lean on the Docker daemon for this: the app talks
+  to Docker through a socket-proxy that only exposes
+  `/services`, `/tasks` and `POST`, and — unlike the `docker`
+  CLI — the raw `POST /services/{id}/update` API does **not**
+  re-resolve a bare tag to a digest. So to pick up a freshly
+  published image under a floating tag we ask the registry
+  ourselves and send Swarm a fully digest-pinned reference.
+
+  Implements the standard token flow: an unauthenticated
+  `GET /v2/<repo>/manifests/<ref>` answered with `401` carries a
+  `WWW-Authenticate: Bearer realm=…,service=…,scope=…`
+  challenge; we fetch a bearer token from `realm` and retry. The
+  returned `Docker-Content-Digest` is the manifest-list/index
+  digest — exactly what Swarm pins into a service spec.
+
+  Anonymous pulls only (the runner image is public); a private
+  registry would need credentials threaded into the token
+  request, which is out of scope here.
+  """
+
+  alias Camelot.Runtime.Runner.ImageRef
+
+  @default_registry "registry-1.docker.io"
+
+  # Accept both OCI and Docker media types, indexes and single
+  # manifests, so the registry answers with a digest for any of them.
+  @manifest_accept Enum.join(
+                     [
+                       "application/vnd.oci.image.index.v1+json",
+                       "application/vnd.docker.distribution.manifest.list.v2+json",
+                       "application/vnd.oci.image.manifest.v1+json",
+                       "application/vnd.docker.distribution.manifest.v2+json"
+                     ],
+                     ", "
+                   )
+
+  @timeout_ms 8_000
+
+  @doc """
+  The digest the image's tag currently resolves to, e.g.
+  `{:ok, "sha256:a745…"}`. `{:error, reason}` on any network or
+  registry failure — callers treat it as "leave the service as
+  is".
+  """
+  @spec current_digest(String.t()) :: {:ok, String.t()} | {:error, term()}
+  def current_digest(image) when is_binary(image) do
+    %{name: name, tag: tag} = ImageRef.parse(image)
+    {host, repo} = split_host_repo(name)
+    url = "https://#{host}/v2/#{repo}/manifests/#{tag || "latest"}"
+    fetch_digest(url)
+  end
+
+  defp fetch_digest(url) do
+    case manifest_request(url, []) do
+      {:ok, %Req.Response{status: 200} = resp} -> digest_header(resp)
+      {:ok, %Req.Response{status: 401} = resp} -> authenticated_fetch(url, resp)
+      {:ok, %Req.Response{status: status}} -> {:error, {:manifest_status, status}}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp authenticated_fetch(url, challenge_resp) do
+    with {:ok, token} <- token_from_challenge(challenge_resp),
+         {:ok, %Req.Response{status: 200} = resp} <-
+           manifest_request(url, [{"authorization", "Bearer #{token}"}]) do
+      digest_header(resp)
+    else
+      {:ok, %Req.Response{status: status}} -> {:error, {:manifest_status, status}}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp manifest_request(url, extra_headers) do
+    Req.get(url,
+      headers: [{"accept", @manifest_accept} | extra_headers],
+      decode_body: false,
+      retry: false,
+      receive_timeout: @timeout_ms
+    )
+  end
+
+  defp digest_header(%Req.Response{} = resp) do
+    case Req.Response.get_header(resp, "docker-content-digest") do
+      [digest | _] -> {:ok, digest}
+      _ -> {:error, :no_digest_header}
+    end
+  end
+
+  defp token_from_challenge(%Req.Response{} = resp) do
+    with [header | _] <- Req.Response.get_header(resp, "www-authenticate"),
+         %{"realm" => realm} = params <- parse_bearer_challenge(header) do
+      request_token(realm, params)
+    else
+      _ -> {:error, :unparseable_challenge}
+    end
+  end
+
+  defp request_token(realm, params) do
+    query = Map.take(params, ["service", "scope"])
+
+    case Req.get(realm, params: query, retry: false, receive_timeout: @timeout_ms) do
+      {:ok, %Req.Response{status: 200, body: %{"token" => token}}} -> {:ok, token}
+      {:ok, %Req.Response{status: 200, body: %{"access_token" => token}}} -> {:ok, token}
+      {:ok, %Req.Response{status: status}} -> {:error, {:token_status, status}}
+      {:error, _} = err -> err
+    end
+  end
+
+  @doc false
+  # Public only so the challenge parsing can be asserted on in
+  # tests. Turns `Bearer realm="…",service="…",scope="…"` into a
+  # map of its key="value" pairs.
+  @spec parse_bearer_challenge(String.t()) :: %{optional(String.t()) => String.t()}
+  def parse_bearer_challenge(header) when is_binary(header) do
+    ~r/(\w+)="([^"]*)"/
+    |> Regex.scan(header)
+    |> Map.new(fn [_, k, v] -> {k, v} end)
+  end
+
+  @doc false
+  # Public only for tests. Splits an image name into its registry
+  # host and repository path. A first segment that looks like a host
+  # (contains `.` or `:`, or is `localhost`) is the registry;
+  # otherwise the default registry is assumed and a bare name is
+  # prefixed with `library/` (Docker Hub convention).
+  @spec split_host_repo(String.t()) :: {String.t(), String.t()}
+  def split_host_repo(name) when is_binary(name) do
+    case String.split(name, "/", parts: 2) do
+      [maybe_host, repo] -> host_or_default(maybe_host, repo, name)
+      [single] -> {@default_registry, "library/#{single}"}
+    end
+  end
+
+  defp host_or_default(maybe_host, repo, name) do
+    if registry_host?(maybe_host) do
+      {maybe_host, repo}
+    else
+      {@default_registry, name}
+    end
+  end
+
+  defp registry_host?(segment) do
+    String.contains?(segment, ".") or String.contains?(segment, ":") or segment == "localhost"
+  end
+end

--- a/lib/camelot/runtime/runner/swarm/task_service.ex
+++ b/lib/camelot/runtime/runner/swarm/task_service.ex
@@ -21,6 +21,8 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
 
   alias Camelot.Board.Task
   alias Camelot.Runtime.Runner.DockerApi
+  alias Camelot.Runtime.Runner.ImageRef
+  alias Camelot.Runtime.Runner.RegistryClient
   alias Camelot.Runtime.Runner.Spec
   alias Camelot.Runtime.Runner.Swarm.SelfNetworks
   alias Camelot.Runtime.SecretSync
@@ -117,6 +119,60 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
            fetch_service(service_id) do
       post_service_update(service_id, version, bump_force_update(spec))
     end
+  end
+
+  @doc """
+  Pin a service's floating-tag image to the newest published
+  digest, in place. Best-effort and idempotent:
+
+    * pinned images (`:1.19`, or a digest with no tag) are left
+      untouched;
+    * for a floating image (`latest` or no tag) the current
+      registry digest is resolved and, only when it differs from
+      the digest the service already runs, the spec is POSTed back
+      with a fully digest-pinned image so Swarm rolls the container.
+
+  Called by the Reconciler's boot sweep. Never raises; logs the
+  outcome and always returns `:ok` so one bad service can't abort
+  the sweep.
+  """
+  @spec autoupdate_image(String.t()) :: :ok
+  def autoupdate_image(service_ref) when is_binary(service_ref) do
+    with {:ok, %{"Version" => %{"Index" => version}, "Spec" => spec}} <-
+           fetch_service(service_ref),
+         image when is_binary(image) <- get_in(spec, ["TaskTemplate", "ContainerSpec", "Image"]),
+         true <- ImageRef.floating?(image),
+         {:ok, digest} <- RegistryClient.current_digest(image) do
+      apply_image_update(service_ref, version, plan_pinned_update(spec, image, digest))
+    else
+      {:error, reason} ->
+        Logger.warning("Swarm.TaskService autoupdate_image #{service_ref}: #{inspect(reason)}")
+
+        :ok
+
+      _pinned_or_missing ->
+        :ok
+    end
+  end
+
+  defp apply_image_update(service_ref, version, {:update, new_spec}) do
+    log_autoupdate(service_ref, post_service_update(service_ref, version, new_spec))
+  end
+
+  defp apply_image_update(_service_ref, _version, :unchanged), do: :ok
+
+  defp log_autoupdate(service_ref, :ok) do
+    Logger.info("Swarm.TaskService autoupdate_image #{service_ref}: pinned newest digest")
+    :ok
+  end
+
+  defp log_autoupdate(service_ref, {:error, reason}) do
+    Logger.warning(
+      "Swarm.TaskService autoupdate_image #{service_ref}: " <>
+        "update failed: #{inspect(reason)}"
+    )
+
+    :ok
   end
 
   # --- GenServer plumbing ---
@@ -310,6 +366,23 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
     template = Map.get(spec, "TaskTemplate", %{})
     current = Map.get(template, "ForceUpdate", 0)
     Map.put(spec, "TaskTemplate", Map.put(template, "ForceUpdate", current + 1))
+  end
+
+  @doc false
+  # Public only so the digest-comparison decision can be asserted on
+  # in tests. Given a live service `Spec` map, the service's current
+  # image string, and the digest its tag now resolves to: returns
+  # `:unchanged` when the service already runs that digest, or
+  # `{:update, spec}` with the image pinned to the new digest.
+  @spec plan_pinned_update(map(), String.t(), String.t()) :: {:update, map()} | :unchanged
+  def plan_pinned_update(spec, image, digest) do
+    case ImageRef.parse(image).digest do
+      ^digest ->
+        :unchanged
+
+      _ ->
+        {:update, put_in(spec, ["TaskTemplate", "ContainerSpec", "Image"], ImageRef.pin(image, digest))}
+    end
   end
 
   defp post_service_update(id, version, spec) do

--- a/test/camelot/runtime/runner/image_ref_test.exs
+++ b/test/camelot/runtime/runner/image_ref_test.exs
@@ -1,0 +1,101 @@
+defmodule Camelot.Runtime.Runner.ImageRefTest do
+  use ExUnit.Case, async: true
+
+  alias Camelot.Runtime.Runner.ImageRef
+
+  describe "parse/1" do
+    test "bare name (no tag, no digest)" do
+      assert ImageRef.parse("ghcr.io/t0ha/camelot-runner-elixir") ==
+               %{name: "ghcr.io/t0ha/camelot-runner-elixir", tag: nil, digest: nil}
+    end
+
+    test "name with tag" do
+      assert ImageRef.parse("ghcr.io/t0ha/camelot-runner-elixir:1.19") ==
+               %{name: "ghcr.io/t0ha/camelot-runner-elixir", tag: "1.19", digest: nil}
+    end
+
+    test "name with tag and digest" do
+      assert ImageRef.parse("ghcr.io/t0ha/camelot-runner-elixir:latest@sha256:abc123") ==
+               %{
+                 name: "ghcr.io/t0ha/camelot-runner-elixir",
+                 tag: "latest",
+                 digest: "sha256:abc123"
+               }
+    end
+
+    test "name with digest only" do
+      assert ImageRef.parse("ghcr.io/t0ha/camelot-runner-elixir@sha256:abc123") ==
+               %{name: "ghcr.io/t0ha/camelot-runner-elixir", tag: nil, digest: "sha256:abc123"}
+    end
+
+    test "registry host with a port is not mistaken for a tag" do
+      assert ImageRef.parse("registry:5000/acme/runner") ==
+               %{name: "registry:5000/acme/runner", tag: nil, digest: nil}
+    end
+
+    test "registry host with a port plus a real tag" do
+      assert ImageRef.parse("registry:5000/acme/runner:1.2") ==
+               %{name: "registry:5000/acme/runner", tag: "1.2", digest: nil}
+    end
+  end
+
+  describe "floating?/1" do
+    test "bare name is floating" do
+      assert ImageRef.floating?("ghcr.io/t0ha/camelot-runner-elixir")
+    end
+
+    test "latest tag is floating" do
+      assert ImageRef.floating?("ghcr.io/t0ha/camelot-runner-elixir:latest")
+    end
+
+    test "latest tag with a digest is still floating (digest is re-resolvable)" do
+      assert ImageRef.floating?("ghcr.io/t0ha/camelot-runner-elixir:latest@sha256:abc")
+    end
+
+    test "explicit version tag is pinned" do
+      refute ImageRef.floating?("ghcr.io/t0ha/camelot-runner-elixir:1.19")
+    end
+
+    test "digest-only reference is pinned" do
+      refute ImageRef.floating?("ghcr.io/t0ha/camelot-runner-elixir@sha256:abc")
+    end
+
+    test "registry-port bare name is floating" do
+      assert ImageRef.floating?("registry:5000/acme/runner")
+    end
+  end
+
+  describe "without_digest/1" do
+    test "strips a digest, keeping the tag" do
+      assert ImageRef.without_digest("ghcr.io/acme/runner:latest@sha256:abc") ==
+               "ghcr.io/acme/runner:latest"
+    end
+
+    test "strips a digest from a tagless reference" do
+      assert ImageRef.without_digest("ghcr.io/acme/runner@sha256:abc") ==
+               "ghcr.io/acme/runner"
+    end
+
+    test "is a no-op when there is no digest" do
+      assert ImageRef.without_digest("ghcr.io/acme/runner:latest") ==
+               "ghcr.io/acme/runner:latest"
+    end
+  end
+
+  describe "pin/2" do
+    test "appends a digest to a tagged reference" do
+      assert ImageRef.pin("ghcr.io/acme/runner:latest", "sha256:abc") ==
+               "ghcr.io/acme/runner:latest@sha256:abc"
+    end
+
+    test "replaces an existing digest, keeping the tag" do
+      assert ImageRef.pin("ghcr.io/acme/runner:latest@sha256:old", "sha256:new") ==
+               "ghcr.io/acme/runner:latest@sha256:new"
+    end
+
+    test "pins a bare name" do
+      assert ImageRef.pin("ghcr.io/acme/runner", "sha256:abc") ==
+               "ghcr.io/acme/runner@sha256:abc"
+    end
+  end
+end

--- a/test/camelot/runtime/runner/registry_client_test.exs
+++ b/test/camelot/runtime/runner/registry_client_test.exs
@@ -1,0 +1,44 @@
+defmodule Camelot.Runtime.Runner.RegistryClientTest do
+  use ExUnit.Case, async: true
+
+  alias Camelot.Runtime.Runner.RegistryClient
+
+  describe "parse_bearer_challenge/1" do
+    test "parses a ghcr Bearer challenge into its parameters" do
+      header =
+        ~s(Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:t0ha/camelot-runner-elixir:pull")
+
+      assert RegistryClient.parse_bearer_challenge(header) == %{
+               "realm" => "https://ghcr.io/token",
+               "service" => "ghcr.io",
+               "scope" => "repository:t0ha/camelot-runner-elixir:pull"
+             }
+    end
+
+    test "returns an empty map when there are no key=\"value\" pairs" do
+      assert RegistryClient.parse_bearer_challenge("Bearer") == %{}
+    end
+  end
+
+  describe "split_host_repo/1" do
+    test "treats a first segment with a dot as the registry host" do
+      assert RegistryClient.split_host_repo("ghcr.io/t0ha/camelot-runner-elixir") ==
+               {"ghcr.io", "t0ha/camelot-runner-elixir"}
+    end
+
+    test "treats a first segment with a port as the registry host" do
+      assert RegistryClient.split_host_repo("registry:5000/acme/runner") ==
+               {"registry:5000", "acme/runner"}
+    end
+
+    test "defaults the registry and library/ prefix for a bare name" do
+      assert RegistryClient.split_host_repo("postgres") ==
+               {"registry-1.docker.io", "library/postgres"}
+    end
+
+    test "defaults the registry for an unqualified namespaced name" do
+      assert RegistryClient.split_host_repo("acme/runner") ==
+               {"registry-1.docker.io", "acme/runner"}
+    end
+  end
+end

--- a/test/camelot/runtime/runner/swarm/task_service_test.exs
+++ b/test/camelot/runtime/runner/swarm/task_service_test.exs
@@ -89,4 +89,39 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskServiceTest do
              ]
     end
   end
+
+  describe "plan_pinned_update/3" do
+    defp service_spec(image) do
+      %{"TaskTemplate" => %{"ContainerSpec" => %{"Image" => image, "Command" => ["sleep"]}}}
+    end
+
+    test "pins a floating :latest tag to the newly resolved digest" do
+      spec = service_spec("ghcr.io/acme/runner:latest@sha256:old")
+
+      assert {:update, new_spec} =
+               TaskService.plan_pinned_update(spec, "ghcr.io/acme/runner:latest@sha256:old", "sha256:new")
+
+      assert get_in(new_spec, ["TaskTemplate", "ContainerSpec", "Image"]) ==
+               "ghcr.io/acme/runner:latest@sha256:new"
+
+      # unrelated fields survive untouched
+      assert get_in(new_spec, ["TaskTemplate", "ContainerSpec", "Command"]) == ["sleep"]
+    end
+
+    test "pins a bare (untagged, undigested) image to the resolved digest" do
+      spec = service_spec("ghcr.io/acme/runner")
+
+      assert {:update, new_spec} = TaskService.plan_pinned_update(spec, "ghcr.io/acme/runner", "sha256:new")
+
+      assert get_in(new_spec, ["TaskTemplate", "ContainerSpec", "Image"]) ==
+               "ghcr.io/acme/runner@sha256:new"
+    end
+
+    test "is a no-op when the service already runs the resolved digest" do
+      spec = service_spec("ghcr.io/acme/runner:latest@sha256:same")
+
+      assert :unchanged =
+               TaskService.plan_pinned_update(spec, "ghcr.io/acme/runner:latest@sha256:same", "sha256:same")
+    end
+  end
 end


### PR DESCRIPTION
## What

On app boot (after DB migrations, via the Reconciler's one-shot pass), sweep existing Swarm task services and **re-pin any whose image tag is floating** (`latest` or untagged) to the newest published digest. Pinned tags (`:1.19`) and digest-only refs are left untouched. Swarm backend only.

## Why

Manual validation showed an existing per-task Swarm service can pick up a new runner image in place (`docker service update`), preserving the service object / `Task.runner_handle`. This codifies that so a redeploy automatically rolls floating-tag runners onto freshly-published images.

## How it resolves digests (the non-obvious part)

The raw Docker API `POST /services/{id}/update` does **not** re-resolve a bare tag to a digest (only the `docker` CLI does, client-side), and the socket-proxy the app uses blocks `/distribution`. A bare `:latest` with no digest is also unsafe in Swarm (nodes may run a stale cached image).

So the app resolves the digest **itself** against the registry over HTTPS (standard OCI token flow), compares it to the digest currently pinned in the service spec, and POSTs a fully digest-pinned `image@digest` back — **only when it changed**, so an unchanged image never rolls the container (idempotent, no needless Erlang recompile).

Verified `RegistryClient` against real ghcr (latest / bare / missing-repo error paths) and confirmed the app container has egress to ghcr.io.

## Changes

- `Runner.ImageRef` *(new)* — pure `parse`/`floating?`/`without_digest`/`pin`
- `Runner.RegistryClient` *(new)* — `current_digest/1` via `/v2` manifests + bearer token
- `Swarm.TaskService` — `autoupdate_image/1` + pure `plan_pinned_update/3` (reuses `fetch_service/1`, `post_service_update/3`)
- `Reconciler` — one-shot `:autoupdate_runner_images` boot hook over `list_task_runners/0`

## Tests / checks

502 tests pass (7 new), `mix credo` clean, `mix dialyzer` 0 new, formatted.

## Notes

- Anonymous pulls only (runner image is public); a private registry would need creds in the token request — out of scope.
- Full end-to-end proof requires a deploy (running app doesn't yet have the new modules); all constituent pieces validated live on test.camelotai.tech.

🤖 Generated with [Claude Code](https://claude.com/claude-code)