### PR TITLE
feat: act on inline PR review comments and monitor human commits

### DIFF
--- a/lib/camelot/agents/changes/dispatch_tasks.ex
+++ b/lib/camelot/agents/changes/dispatch_tasks.ex
@@ -178,23 +178,41 @@ defmodule Camelot.Agents.Changes.DispatchTasks do
 
   defp fetch_pr_comments(task) do
     project = task.project
+    opts = [installation_id: installation_id(task)]
+    owner = project.github_owner
+    repo = project.github_repo
+    pr = task.pr_number
 
-    case Client.list_pull_request_comments(
-           project.github_owner,
-           project.github_repo,
-           task.pr_number,
-           installation_id: installation_id(task)
-         ) do
-      {:ok, comments} ->
-        Enum.map_join(comments, "\n\n---\n\n", fn c ->
-          "@#{get_in(c, ["user", "login"])}: " <>
-            (c["body"] || "")
-        end)
+    issue = list_or_empty(Client.list_pull_request_comments(owner, repo, pr, opts))
+    review = list_or_empty(Client.list_pull_request_review_comments(owner, repo, pr, opts))
 
-      {:error, _} ->
-        ""
-    end
+    (issue ++ review)
+    |> Enum.sort_by(& &1["created_at"])
+    |> Enum.map_join("\n\n---\n\n", &format_pr_comment/1)
   end
+
+  defp list_or_empty({:ok, comments}), do: comments
+  defp list_or_empty({:error, _reason}), do: []
+
+  # Inline review comments carry path/line; surface them so the agent
+  # knows which code each note refers to.
+  defp format_pr_comment(comment) do
+    login = get_in(comment, ["user", "login"])
+    "@#{login}#{comment_location(comment)}: " <> (comment["body"] || "")
+  end
+
+  @doc """
+  Renders the ` (path:line)` locator for an inline review comment.
+
+  Top-level issue comments have no `path` and render to an empty
+  string; a review comment on an outdated line has `line == nil` and
+  renders just the path.
+  """
+  @spec comment_location(map()) :: String.t()
+  def comment_location(%{"path" => nil}), do: ""
+  def comment_location(%{"path" => path, "line" => nil}), do: " (#{path})"
+  def comment_location(%{"path" => path, "line" => line}), do: " (#{path}:#{line})"
+  def comment_location(_comment), do: ""
 
   defp append_conversation(prompt, messages) when is_list(messages) and messages != [] do
     sorted = Enum.sort_by(messages, & &1.inserted_at)

--- a/lib/camelot/board/changes/check_pr_status.ex
+++ b/lib/camelot/board/changes/check_pr_status.ex
@@ -11,6 +11,16 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
   - changes_requested → queued for agent fix (via request_pr_changes)
   - new comments after last commit → queued for agent fix
   - approved → done (via complete)
+
+  "Comments" covers three GitHub surfaces: top-level issue comments,
+  inline review comments on the diff (`pulls/{n}/comments`), and the
+  body of a `COMMENTED` review — a reviewer who leaves inline notes or
+  a plain "Comment" review (not "Request changes") is acted on too.
+
+  Merge-conflict and CI-failure auto-fixes are suppressed while a human
+  authored the latest commit: a reviewer hand-fixing the branch during
+  review is re-verified, not fought. The agent's own commits (authored
+  by the Camelot agent) never count as human activity.
   """
   use Ash.Resource.Change
 
@@ -50,7 +60,9 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
            Client.list_pull_request_commits(owner, repo, pr, opts),
          {:ok, check_runs} <-
            fetch_check_runs(owner, repo, pr_data, opts) do
-      apply_pr_state(task, pr_data, reviews, comments, commits, check_runs)
+      review_comments = fetch_review_comments(owner, repo, pr, opts)
+      feedback = merge_review_feedback(comments, review_comments, reviews)
+      apply_pr_state(task, pr_data, reviews, feedback, commits, check_runs)
     else
       {:error, reason} ->
         Logger.warning(
@@ -75,6 +87,47 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
     end
   end
 
+  # Best-effort: inline review comments enrich detection but must never
+  # block the core transition flow, so a failure degrades to no comments.
+  defp fetch_review_comments(owner, repo, pr, opts) do
+    case Client.list_pull_request_review_comments(owner, repo, pr, opts) do
+      {:ok, review_comments} -> review_comments
+      {:error, _reason} -> []
+    end
+  end
+
+  @doc """
+  Merges the three reviewer-feedback surfaces into one comment list.
+
+  GitHub splits reviewer feedback across top-level issue comments,
+  inline review comments on the diff, and review bodies. Inline
+  comments already carry `created_at`; a review body is normalised to
+  `created_at` from its `submitted_at`. Empty review bodies are dropped
+  — an inline-only review has an empty body, and its content lives in
+  the review comments instead.
+  """
+  @spec merge_review_feedback([map()], [map()], [map()]) :: [map()]
+  def merge_review_feedback(comments, review_comments, reviews) do
+    comments ++ review_comments ++ review_body_comments(reviews)
+  end
+
+  defp review_body_comments(reviews) do
+    reviews
+    |> Enum.filter(&review_has_body?/1)
+    |> Enum.map(fn review ->
+      %{
+        "created_at" => review["submitted_at"],
+        "user" => review["user"],
+        "body" => review["body"]
+      }
+    end)
+  end
+
+  defp review_has_body?(%{"body" => ""}), do: false
+  defp review_has_body?(%{"body" => nil}), do: false
+  defp review_has_body?(%{"body" => _body}), do: true
+  defp review_has_body?(_review), do: false
+
   defp apply_pr_state(task, pr, reviews, comments, commits, check_runs) do
     cond do
       pr["merged"] == true ->
@@ -92,11 +145,17 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
   end
 
   defp apply_waiting_for_input(task, pr, reviews, comments, commits, check_runs) do
+    # A human hand-fixing the branch during review is re-verified, not
+    # fought: suppress the CI/merge auto-fix while a human authored the
+    # latest commit. Explicit feedback (changes requested / comments)
+    # still wakes the agent regardless of who pushed last.
+    human_pushed_last? = latest_commit_human?(commits)
+
     cond do
-      merge_conflict?(pr) ->
+      not human_pushed_last? and merge_conflict?(pr) ->
         transition_with_seen_at(task, comments)
 
-      ci_failing?(check_runs) ->
+      not human_pushed_last? and ci_failing?(check_runs) ->
         transition_with_seen_at(task, comments)
 
       has_review_state?(reviews, "CHANGES_REQUESTED") ->
@@ -183,6 +242,33 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
       nil -> nil
       commit -> get_in(commit, ["commit", "committer", "date"])
     end
+  end
+
+  # The Camelot agent authors commits under these git identities; a
+  # commit touched by either (as author or committer) is agent work,
+  # never a human hand-fix.
+  @agent_emails ~w(camelot-agent@anthropic.com noreply@anthropic.com)
+
+  @doc """
+  True if the latest commit on the PR was authored by a human.
+
+  Used to suppress CI/merge auto-fixes while a reviewer is hand-fixing
+  the branch. An empty commit list is not human, so the agent's own
+  self-heal path is preserved when no commits have landed yet.
+  """
+  @spec latest_commit_human?([map()]) :: boolean()
+  def latest_commit_human?(commits) do
+    case List.last(commits) do
+      nil -> false
+      commit -> human_commit?(commit)
+    end
+  end
+
+  defp human_commit?(commit) do
+    author = get_in(commit, ["commit", "author", "email"])
+    committer = get_in(commit, ["commit", "committer", "email"])
+
+    author not in @agent_emails and committer not in @agent_emails
   end
 
   defp latest_comment_date(comments) do

--- a/lib/camelot/github/client.ex
+++ b/lib/camelot/github/client.ex
@@ -51,6 +51,20 @@ defmodule Camelot.Github.Client do
     )
   end
 
+  @spec list_pull_request_review_comments(
+          String.t(),
+          String.t(),
+          integer(),
+          keyword()
+        ) :: {:ok, [map()]} | {:error, term()}
+  def list_pull_request_review_comments(owner, repo, pr_number, opts \\ []) do
+    request(
+      :get,
+      "/repos/#{owner}/#{repo}/pulls/#{pr_number}/comments",
+      opts
+    )
+  end
+
   @spec list_pull_request_commits(
           String.t(),
           String.t(),

--- a/test/camelot/agents/changes/dispatch_tasks_test.exs
+++ b/test/camelot/agents/changes/dispatch_tasks_test.exs
@@ -6,6 +6,26 @@ defmodule Camelot.Agents.Changes.DispatchTasksTest do
   alias Camelot.Board.Task
   alias Camelot.Github.Installation
 
+  describe "comment_location/1" do
+    test "inline review comment renders path and line" do
+      comment = %{"path" => "lib/foo.ex", "line" => 42}
+      assert DispatchTasks.comment_location(comment) == " (lib/foo.ex:42)"
+    end
+
+    test "outdated review comment (nil line) renders just the path" do
+      comment = %{"path" => "lib/foo.ex", "line" => nil}
+      assert DispatchTasks.comment_location(comment) == " (lib/foo.ex)"
+    end
+
+    test "top-level issue comment has no locator" do
+      assert DispatchTasks.comment_location(%{"body" => "hi"}) == ""
+    end
+
+    test "nil path renders no locator" do
+      assert DispatchTasks.comment_location(%{"path" => nil, "line" => 3}) == ""
+    end
+  end
+
   describe "installation_id/1" do
     test "resolves the task creator's connected installation id" do
       task = %Task{creator: %User{github_installation: %Installation{installation_id: 7}}}

--- a/test/camelot/board/changes/check_pr_status_test.exs
+++ b/test/camelot/board/changes/check_pr_status_test.exs
@@ -154,6 +154,119 @@ defmodule Camelot.Board.Changes.CheckPrStatusTest do
     end
   end
 
+  describe "merge_review_feedback/3" do
+    test "folds inline review comments into the comment set" do
+      review_comment = %{
+        "created_at" => "2026-07-10T05:19:45Z",
+        "user" => %{"login" => "T0ha"},
+        "body" => "is_list is not needed here.",
+        "path" => "lib/foo.ex",
+        "line" => 12
+      }
+
+      assert [%{"body" => "is_list is not needed here."}] =
+               CheckPrStatus.merge_review_feedback([], [review_comment], [])
+    end
+
+    test "folds a COMMENTED review body into the comment set" do
+      review = %{
+        "state" => "COMMENTED",
+        "submitted_at" => "2026-07-10T05:19:45Z",
+        "user" => %{"login" => "T0ha"},
+        "body" => "Please tidy this up."
+      }
+
+      assert [%{"created_at" => "2026-07-10T05:19:45Z", "body" => "Please tidy this up."}] =
+               CheckPrStatus.merge_review_feedback([], [], [review])
+    end
+
+    test "drops empty-body reviews (inline-only reviews carry no body)" do
+      review = %{
+        "state" => "COMMENTED",
+        "submitted_at" => "2026-07-10T05:19:45Z",
+        "user" => %{"login" => "T0ha"},
+        "body" => ""
+      }
+
+      assert CheckPrStatus.merge_review_feedback([], [], [review]) == []
+    end
+
+    test "keeps existing issue comments alongside review feedback" do
+      issue = comment("2026-07-10T05:00:00Z")
+      review_comment = %{"created_at" => "2026-07-10T05:19:45Z", "user" => %{}, "body" => "x"}
+
+      merged = CheckPrStatus.merge_review_feedback([issue], [review_comment], [])
+
+      assert length(merged) == 2
+    end
+
+    test "an inline review comment newer than the last commit triggers detection" do
+      review_comment = %{"created_at" => "2026-07-10T05:19:45Z", "user" => %{}, "body" => "x"}
+      merged = CheckPrStatus.merge_review_feedback([], [review_comment], [])
+
+      assert CheckPrStatus.new_comments?(merged, @commit, nil)
+    end
+  end
+
+  describe "latest_commit_human?/1" do
+    defp agent_commit do
+      %{
+        "commit" => %{
+          "author" => %{"email" => "camelot-agent@anthropic.com"},
+          "committer" => %{"email" => "camelot-agent@anthropic.com"}
+        }
+      }
+    end
+
+    defp human_commit(email \\ "anton@rollhub.com") do
+      %{
+        "commit" => %{
+          "author" => %{"email" => email},
+          "committer" => %{"email" => email}
+        }
+      }
+    end
+
+    test "a human-authored last commit is human" do
+      assert CheckPrStatus.latest_commit_human?([agent_commit(), human_commit()])
+    end
+
+    test "an agent-authored last commit is not human" do
+      refute CheckPrStatus.latest_commit_human?([human_commit(), agent_commit()])
+    end
+
+    test "only the last commit decides" do
+      refute CheckPrStatus.latest_commit_human?([human_commit(), agent_commit()])
+      assert CheckPrStatus.latest_commit_human?([agent_commit(), human_commit()])
+    end
+
+    test "no commits is not human (preserves agent self-heal path)" do
+      refute CheckPrStatus.latest_commit_human?([])
+    end
+
+    test "the Claude co-author noreply email counts as agent" do
+      commit = %{
+        "commit" => %{
+          "author" => %{"email" => "noreply@anthropic.com"},
+          "committer" => %{"email" => "noreply@anthropic.com"}
+        }
+      }
+
+      refute CheckPrStatus.latest_commit_human?([commit])
+    end
+
+    test "an agent author with a human committer is still agent" do
+      commit = %{
+        "commit" => %{
+          "author" => %{"email" => "camelot-agent@anthropic.com"},
+          "committer" => %{"email" => "anton@rollhub.com"}
+        }
+      }
+
+      refute CheckPrStatus.latest_commit_human?([commit])
+    end
+  end
+
   describe "installation_id/1" do
     test "resolves the task creator's connected installation id" do
       task = %Task{creator: %User{github_installation: %Installation{installation_id: 42}}}


### PR DESCRIPTION
## Problem

Task `59aa8430-…` (PR #87 on test) sat in `pr / waiting_for_input` despite review feedback. Root cause is in the code, not infra — the `CheckPrStatus` poller runs fine every 2 min with no errors.

The reviewer left **3 inline comments on the diff**, submitted as a single **`COMMENTED`** review with an empty body. But `CheckPrStatus`:

1. only fetched **issue-box** comments (`issues/{n}/comments`) — inline diff comments live at `pulls/{n}/comments`, never queried; and
2. only reacted to review states `CHANGES_REQUESTED` / `APPROVED` — a `COMMENTED` review is neither.

So `apply_waiting_for_input/6` fell through to `:ok` and nothing moved. The agent-dispatch (`fetch_pr_comments`) had the same issue-only gap, so even a re-queue would have handed the agent empty comments.

## Changes

- **`Camelot.Github.Client`** — add `list_pull_request_review_comments/4` (`GET /repos/{o}/{r}/pulls/{n}/comments`).
- **`CheckPrStatus`** — `merge_review_feedback/3` folds issue comments + inline review comments + non-empty review bodies into one set used for detection and `pr_comments_seen_at` dedup. Empty-body reviews (inline-only) are dropped; their content comes through the review comments.
- **`CheckPrStatus`** — monitor commits: suppress the CI-failing / merge-conflict auto-fix while a **human** authored the latest commit (`latest_commit_human?/1`), so a reviewer hand-fixing the branch mid-review is re-verified, not fought. The agent's own commits (`camelot-agent@anthropic.com` / `noreply@anthropic.com`) never count as human, preserving self-heal. Explicit comments / `CHANGES_REQUESTED` still dispatch regardless of who pushed last.
- **`DispatchTasks.fetch_pr_comments`** — include inline comments, sorted by time, each rendered with its `path:line` (`comment_location/1`) so the agent knows which code each note refers to.

## Behavior matrix (state `pr / waiting_for_input`)

| Reviewer action | Before | After |
|---|---|---|
| Issue-box comment | ✅ dispatch | ✅ dispatch |
| Request changes | ✅ dispatch | ✅ dispatch |
| Approve | ✅ complete | ✅ complete |
| **Inline diff comment** | ❌ ignored | ✅ dispatch, agent gets `path:line` |
| **"Comment" review (COMMENTED)** | ❌ ignored | ✅ dispatch |
| **Human hand-fix commit** (CI fail/conflict) | agent re-dispatched | re-verify only, no dispatch |

## Testing

- New pure-function tests for `merge_review_feedback/3`, `latest_commit_human?/1`, `comment_location/1`.
- Full suite: 526 tests, 0 failures. `mix credo --strict` clean, `mix dialyzer` clean, `mix format` applied.
- Traced PR #87's **real** payload through the new functions: detection → true, agent prompt carries all three `path:line` notes, agent commit correctly classified non-human. Once merged to `develop` (→ deploys to test), PR #87 auto-recovers on the next poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)