### PR TITLE
fix(ci): bump caprover deploy action to v1.2.0 (fix ERR_REQUIRE_ESM)

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -110,7 +110,7 @@ jobs:
             $(printf '${{ env.IMAGE }}@sha256:%s ' *)
 
       - name: Deploy Image to CapRover (test)
-        uses: caprover/deploy-from-github@v1.1.2
+        uses: caprover/deploy-from-github@v1.2.0
         with:
           server: "${{ vars.CAPROVER_SERVER }}"
           app: "${{ vars.APP_NAME }}"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -54,7 +54,7 @@ jobs:
           }
 
       - name: Deploy Image to CapRover (production)
-        uses: caprover/deploy-from-github@v1.1.2
+        uses: caprover/deploy-from-github@v1.2.0
         with:
           server: "${{ vars.CAPROVER_SERVER }}"
           app: "${{ vars.APP_NAME }}"


### PR DESCRIPTION
## Problem

The `develop` deploy to test ([run 30982017068](https://github.com/T0ha/camelot/actions/runs/30982017068)) built and pushed the image fine, but the **Deploy Image to CapRover** step crashed before contacting the server:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module
.../caprover/node_modules/update-notifier/index.js
from .../caprover/built/commands/caprover.js not supported.
```

## Root cause

`caprover/deploy-from-github` installs the caprover CLI **unpinned** (`npm i -g caprover`). Its transitive dependency `update-notifier` drifted to an **ESM-only** release, and the CLI's CommonJS build does `require("update-notifier")`.

- **v1.1.2** runs the CLI on `node:16.16.0-alpine` — Node 16 cannot `require()` an ESM module → crash.
- **v1.2.0** runs on `node:22-alpine` — Node ≥22.12 supports `require()` of synchronous ES modules by default. The v1.2.0 release commit is literally *"Upgrade Node.js version in Dockerfile"* — the maintainer's fix for this crash.

Not caused by any app code; the merge that triggered this run was unrelated.

## Change

Bump `caprover/deploy-from-github@v1.1.2 → @v1.2.0` in both deploy workflows:
- `build-docker-image.yml` (test, on `develop`)
- `deploy-production.yml` (prod, on `main`) — same action, so prod's next deploy would have failed identically.

The action's inputs and `entrypoint.sh` (`caprover deploy --caproverUrl … --appToken … --appName … -i …`) are unchanged between the two versions, so URL/token handling is identical — only the container's Node version changes.

## Note

The action still installs caprover unpinned, so this is drift-prone by nature. If it recurs, the durable follow-up is to replace the action with a pinned CLI invocation or a direct CapRover API call (`POST /api/v2/user/apps/appData/{app}?detached=1`, header `x-captain-app-token`).

## Unblocks

Once merged, the test deploy succeeds and the previously-merged #90 (inline PR review-comment handling) goes live — then stuck task `59aa8430…` / PR #87 auto-recovers on the next 2-min poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)