### PR TITLE
fix(ci): pin caprover CLI to 2.3.1 (2.4.0 broke all deploys)

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -109,10 +109,20 @@ jobs:
             -t ${{ env.IMAGE }}:${{ github.sha }} \
             $(printf '${{ env.IMAGE }}@sha256:%s ' *)
 
+      # Pin the caprover CLI: the caprover/deploy-from-github action
+      # installs it unpinned, and caprover 2.4.0 (2026-08-05) bumped
+      # commander (duplicate -t flag crash) and update-notifier (ESM
+      # require crash), breaking every deploy. 2.3.1 is the last good
+      # release. --caproverUrl auto-prepends https://captain. to the
+      # root domain.
       - name: Deploy Image to CapRover (test)
-        uses: caprover/deploy-from-github@v1.2.0
-        with:
-          server: "${{ vars.CAPROVER_SERVER }}"
-          app: "${{ vars.APP_NAME }}"
-          token: "${{ secrets.APP_TOKEN }}"
-          image: "${{ env.IMAGE }}:${{ github.sha }}"
+        env:
+          CAPROVER_URL: "${{ vars.CAPROVER_SERVER }}"
+          CAPROVER_APP_TOKEN: "${{ secrets.APP_TOKEN }}"
+          CAPROVER_IMAGE_NAME: "${{ env.IMAGE }}:${{ github.sha }}"
+        run: |
+          npx --yes caprover@2.3.1 deploy \
+            --caproverUrl "$CAPROVER_URL" \
+            --appToken "$CAPROVER_APP_TOKEN" \
+            --appName "${{ vars.APP_NAME }}" \
+            --imageName "$CAPROVER_IMAGE_NAME"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -53,10 +53,20 @@ jobs:
             exit 1
           }
 
+      # Pin the caprover CLI: the caprover/deploy-from-github action
+      # installs it unpinned, and caprover 2.4.0 (2026-08-05) bumped
+      # commander (duplicate -t flag crash) and update-notifier (ESM
+      # require crash), breaking every deploy. 2.3.1 is the last good
+      # release. --caproverUrl auto-prepends https://captain. to the
+      # root domain.
       - name: Deploy Image to CapRover (production)
-        uses: caprover/deploy-from-github@v1.2.0
-        with:
-          server: "${{ vars.CAPROVER_SERVER }}"
-          app: "${{ vars.APP_NAME }}"
-          token: "${{ secrets.APP_TOKEN }}"
-          image: "${{ env.IMAGE }}:${{ steps.image.outputs.sha }}"
+        env:
+          CAPROVER_URL: "${{ vars.CAPROVER_SERVER }}"
+          CAPROVER_APP_TOKEN: "${{ secrets.APP_TOKEN }}"
+          CAPROVER_IMAGE_NAME: "${{ env.IMAGE }}:${{ steps.image.outputs.sha }}"
+        run: |
+          npx --yes caprover@2.3.1 deploy \
+            --caproverUrl "$CAPROVER_URL" \
+            --appToken "$CAPROVER_APP_TOKEN" \
+            --appName "${{ vars.APP_NAME }}" \
+            --imageName "$CAPROVER_IMAGE_NAME"


### PR DESCRIPTION
## Problem

Both recent `develop`→test deploys crashed at the CapRover step. The v1.2.0 action bump (#91) got past the first crash only to hit a second:

```
# before #91 (node 16):
Error [ERR_REQUIRE_ESM]: require() of ES Module .../update-notifier/index.js
# after #91 (node 22):
Error: Cannot add option '-t, --appToken <value>' to command 'deploy'
  due to conflicting flag '-t' — already used by option '-t, --tarFile <value>'
```

## Root cause

**`caprover@2.4.0` was published 2026-08-05 04:35 UTC — ~2 hours before these deploys.** The `caprover/deploy-from-github` action installs the CLI **unpinned** (`npm i -g caprover`), so it picked up 2.4.0, which bumped two deps:

| dep | 2.3.1 | 2.4.0 | breakage |
|---|---|---|---|
| `commander` | `^2.20.0` | `^12.1.0` | v12 throws on the duplicate `-t` short flag (`--tarFile` / `--appToken`) |
| `update-notifier` | `^3.0.1` | `^7.3.1` | v7 is ESM-only → `require()` crash |

So both crashes trace to one same-morning release. Chasing the action's Node version can't fix a broken CLI.

## Fix

Replace the action with a `run:` step pinned to **`caprover@2.3.1`** (last good release — commander 2.x + update-notifier 3.x, both CJS and fine on any Node). Verified locally: `caprover@2.3.1 deploy --help` loads cleanly and supports `--caproverUrl`, `--appToken`, `--appName`, `--imageName`.

`--caproverUrl` auto-prepends `https://captain.` to the root domain (its help: `"[http[s]://][captain.]your-captain-root.domain"`), so `CAPROVER_SERVER` handling is identical to the action. Applied to both `build-docker-image.yml` (test) and `deploy-production.yml` (prod).

Confirmed the captain API host while debugging: `https://captain.test.camelotai.tech` (dashboard + `/api/v2/login` respond as CapRover).

## Note

Still relies on npm resolving 2.3.1's (pinned-major) sub-deps, but those are frozen old majors with no ESM/commander drift. If we ever want zero-npm determinism, the fallback is a direct API call (`POST /api/v2/user/apps/appData/{app}?detached=1`, header `x-captain-app-token`).

## Unblocks

Merging this lets the test deploy complete → brings #90 (inline PR review-comment handling) live → task `59aa8430…` / PR #87 auto-recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)