### PR TITLE
fix(github): make check-runs best-effort so a missing Checks perm can't kill PR polling

### DIFF
--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -19,10 +19,24 @@ GitHub App installation).
 On github.com, create a new GitHub App (either a personal or org App) with:
 
 - **Permissions**: Repository — Contents (read/write), Pull requests
-  (read/write), Issues (read/write), Metadata (read).
+  (read/write), Issues (read/write), Checks (read), Metadata (read).
 - **Webhook events**: `installation`, `installation_repositories`.
 - **Setup URL**: `https://<your-camelot-host>/github/setup`
 - **Webhook URL**: `https://<your-camelot-host>/github/webhooks`
+
+**Checks (read) is required** for PR CI-status polling — Camelot reads
+`commits/{sha}/check-runs` to auto-fix a task when CI fails. Without it that
+endpoint returns `403 "Resource not accessible by integration"`. Camelot now
+degrades gracefully (CI-failure detection is skipped; merge-conflict, review,
+and comment handling keep working), so it is safe to omit, but CI-failure
+auto-fix stays off until the permission is granted.
+
+> **Changing permissions on an already-installed App does not take effect
+> immediately.** GitHub raises a *pending permission request* that the
+> account/org owner must approve (Settings → Installed GitHub Apps → the App →
+> "Review request"), and Camelot caches installation access tokens for up to
+> ~1h — so a newly granted permission can take up to an hour to apply unless
+> the app is restarted.
 
 Both URLs are also shown on `/admin/settings` once the App is configured
 (see below), so you can copy them from there.

--- a/lib/camelot/board/changes/check_pr_status.ex
+++ b/lib/camelot/board/changes/check_pr_status.ex
@@ -89,9 +89,37 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
 
   defp fetch_check_runs(owner, repo, pr_data, opts) do
     case get_in(pr_data, ["head", "sha"]) do
-      nil -> {:ok, []}
-      sha -> Client.list_check_runs(owner, repo, sha, opts)
+      nil ->
+        {:ok, []}
+
+      sha ->
+        owner
+        |> Client.list_check_runs(repo, sha, opts)
+        |> best_effort_check_runs()
     end
+  end
+
+  @doc """
+  Coerces a check-runs fetch into an always-`{:ok, runs}` result.
+
+  CI status only *enriches* PR reconciliation (a failing run queues an
+  auto-fix); it must never block it. A missing **Checks** permission on
+  the App installation 403s the check-runs endpoint — degrade that to
+  "no checks" so merge-conflict, review, and comment handling still run,
+  mirroring `fetch_review_comments/4`. The trade-off is intentional: CI
+  failures simply go undetected until the permission is granted.
+  """
+  @spec best_effort_check_runs({:ok, [map()]} | {:error, term()}) ::
+          {:ok, [map()]}
+  def best_effort_check_runs({:ok, runs}), do: {:ok, runs}
+
+  def best_effort_check_runs({:error, reason}) do
+    Logger.warning(
+      "check-runs unavailable (#{inspect(reason)}); treating as " <>
+        "no checks"
+    )
+
+    {:ok, []}
   end
 
   # Best-effort: inline review comments enrich detection but must never

--- a/test/camelot/board/changes/check_pr_status_test.exs
+++ b/test/camelot/board/changes/check_pr_status_test.exs
@@ -268,6 +268,25 @@ defmodule Camelot.Board.Changes.CheckPrStatusTest do
     end
   end
 
+  describe "best_effort_check_runs/1" do
+    test "passes a successful fetch through unchanged" do
+      runs = [%{"status" => "completed", "conclusion" => "success"}]
+
+      assert CheckPrStatus.best_effort_check_runs({:ok, runs}) == {:ok, runs}
+    end
+
+    test "degrades an error to no checks so the poll never aborts" do
+      # Regression: a missing Checks permission 403s the check-runs
+      # endpoint; that must not take down the whole PR reconciliation.
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert CheckPrStatus.best_effort_check_runs({:error, {:http_error, 403, %{"message" => "no"}}}) == {:ok, []}
+        end)
+
+      assert log =~ "check-runs unavailable"
+    end
+  end
+
   describe "installation_id/1" do
     test "resolves the task creator's connected installation id" do
       task = %Task{creator: %User{github_installations: [%Installation{installation_id: 42, account_login: "acme-org"}]}}


### PR DESCRIPTION
## Background

Investigating why a production task's PR merge conflict was never auto-resolved, I found the 2-minute PR poller (`Camelot.Board.Changes.CheckPrStatus`) failing every cycle with:

```
GitHub API 403: "Resource not accessible by integration"
  → GET /repos/{owner}/{repo}/commits/{sha}/check-runs
Failed to check PR for task …
```

The App installation lacked the **Checks** permission, so the `check-runs` call 403'd. Because all five GitHub reads are chained in a single `with`, that one failure aborted the **entire** reconciliation — merge-conflict, review, comment, and merged/closed handling all silently stopped (only a `Logger.warning` was emitted). The task sat with an unresolved conflict for days.

## Changes

1. **Code — `check_pr_status.ex`:** make the check-runs fetch best-effort, mirroring the existing `fetch_review_comments/4`. An error now degrades to `{:ok, []}` (CI-failure detection is skipped) so merge-conflict / review / comment handling keep working. The coercion lives in a small pure `best_effort_check_runs/1` exposed for unit testing, matching the module's existing test seam (`merge_conflict?`, `ci_failing?`, …).
2. **Docs — `docs/github-app.md`:** add the missing **Checks (read)** permission to the setup guide (its omission is what caused the incident), and document that permission changes on an already-installed App require owner approval and are subject to the ~1h installation-token cache.

## Note

The related multi-installation resolution fix (resolve the installation by matching `account_login` to `project.github_owner` instead of an arbitrary `has_one` pick) is **already on `develop`** via `Camelot.Github.Resolver` — it just hasn't shipped to prod yet (`develop → main` gap). This PR covers the remaining `with`-chain fragility plus the docs gap.

## Testing

- `mix compile --warnings-as-errors` ✓
- `mix test test/camelot/board/changes/check_pr_status_test.exs` → 42 tests, 0 failures ✓ (2 new)
- `mix format --check-formatted` ✓
- `mix credo` ✓
- `mix dialyzer` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)