### PR TITLE
fix(runtime): re-run empty agent runs instead of silent waiting-for-input

### DIFF
--- a/lib/camelot/agents/session.ex
+++ b/lib/camelot/agents/session.ex
@@ -22,7 +22,7 @@ defmodule Camelot.Agents.Session do
     :prewarm,
     :custom
   ]
-  @statuses [:queued, :running, :completed, :failed, :cancelled]
+  @statuses [:queued, :running, :completed, :failed, :cancelled, :empty]
 
   attributes do
     uuid_primary_key(:id)
@@ -211,6 +211,18 @@ defmodule Camelot.Agents.Session do
 
     update :cancel do
       change(set_attribute(:status, :cancelled))
+      change(set_attribute(:finished_at, &DateTime.utc_now/0))
+    end
+
+    update :mark_empty do
+      accept([
+        :output_log,
+        :exit_code,
+        :error_message,
+        :permission_denials
+      ])
+
+      change(set_attribute(:status, :empty))
       change(set_attribute(:finished_at, &DateTime.utc_now/0))
     end
 

--- a/lib/camelot/runtime/agent_process.ex
+++ b/lib/camelot/runtime/agent_process.ex
@@ -345,25 +345,70 @@ defmodule Camelot.Runtime.AgentProcess do
   defp finalize_runner_exit(state, exit_code, died_reason) do
     parsed = parsed_for_exit(state, died_reason)
     denials = extract_denials(parsed)
-    finish_session(state, exit_code, parsed, denials)
+    empty? = exit_code == 0 and empty_result?(parsed)
+    finish_session(state, exit_code, parsed, denials, empty?)
     if state.current_session_id, do: SessionRegistry.unregister(state.current_session_id)
 
     failed? = exit_code != 0 or match?({:error, _}, parsed)
 
-    if failed? and state.retry_count < state.max_retries do
+    # A clean-but-empty run (agent produced nothing actionable) is retried
+    # on the same footing as a failure — bounded by the agent's
+    # `max_retries` — instead of silently parking the task.
+    if (failed? or empty?) and state.retry_count < state.max_retries do
       release_pool_slot(state)
       schedule_retry(state)
     else
+      finalize_terminal(state, exit_code, parsed, denials, failed?, empty?)
+    end
+  end
+
+  # Terminal handling once retries are exhausted (or none configured). An
+  # empty run bypasses the stage handlers and errors the task with a clear
+  # reason, so it never lands in a message-less `waiting_for_input`.
+  defp finalize_terminal(state, exit_code, parsed, denials, failed?, empty?) do
+    if empty? do
+      mark_task_error(state.current_task_id, empty_error_reason(state))
+    else
       handle_cli_exit(state, exit_code, parsed)
       if failed?, do: mark_task_error(state.current_task_id, parsed_error(parsed))
-      release_and_idle(state)
-
-      if denials == [] do
-        {:noreply, reset_runner(state)}
-      else
-        {:noreply, clear_runner(state)}
-      end
     end
+
+    release_and_idle(state)
+
+    if denials == [] do
+      {:noreply, reset_runner(state)}
+    else
+      {:noreply, clear_runner(state)}
+    end
+  end
+
+  @doc """
+  Whether a parsed run produced nothing actionable: no result text, no
+  structured payload, no permission denials, and no non-blank assistant
+  turns. Such a run is retried (up to the agent's `max_retries`) and its
+  session is marked `:empty`, rather than silently parking the task in
+  `waiting_for_input`.
+  """
+  @spec empty_result?(term()) :: boolean()
+  def empty_result?({:ok, parsed}) do
+    blank?(parsed.result_text) and is_nil(parsed.structured) and
+      (parsed.permission_denials || []) == [] and
+      Enum.all?(parsed.assistant_texts || [], &blank?/1)
+  end
+
+  def empty_result?(_parsed), do: false
+
+  defp blank?(nil), do: true
+  defp blank?(text) when is_binary(text), do: String.trim(text) == ""
+  defp blank?(_other), do: false
+
+  defp empty_error_reason(%{max_retries: 0}) do
+    "Agent finished without producing any output."
+  end
+
+  defp empty_error_reason(%{max_retries: retries}) do
+    "Agent finished without producing any output after " <>
+      "#{retries + 1} attempts."
   end
 
   defp parsed_for_exit(state, nil) do
@@ -969,11 +1014,26 @@ defmodule Camelot.Runtime.AgentProcess do
         request_user_input(task, result.text, task_id)
 
       true ->
-        transition(task, :request_input)
+        request_user_input(task, pr_review_message(result), task_id)
     end
   end
 
   defp handle_task_result(_state, _task, _result, _task_id), do: :ok
+
+  # A clean PR-stage run with no question and no denials: surface the
+  # agent's summary so the waiting-for-input email always corresponds to a
+  # visible message. A genuinely empty run never reaches here — it is
+  # retried and marked `:empty` in `finalize_runner_exit`.
+  defp pr_review_message(result) do
+    case String.trim(result.text) do
+      "" ->
+        "I finished reviewing the PR. Please review the changes, or " <>
+          "reply with further guidance."
+
+      text ->
+        text
+    end
+  end
 
   @doc """
   Decides the planning-stage outcome from a parsed runner result.
@@ -1216,14 +1276,16 @@ defmodule Camelot.Runtime.AgentProcess do
   # DB error (or a session deleted out from under us) logs and returns
   # instead of crashing AgentProcess mid-finalisation — which would
   # strand the session as :running until the Reconciler swept it.
-  @spec finish_session(t(), integer(), term(), [map()]) :: :ok
-  def finish_session(%__MODULE__{current_session_id: nil}, _exit_code, _parsed, _denials) do
+  @spec finish_session(t(), integer(), term(), [map()], boolean()) :: :ok
+  def finish_session(state, exit_code, parsed, denials, empty? \\ false)
+
+  def finish_session(%__MODULE__{current_session_id: nil}, _exit_code, _parsed, _denials, _empty?) do
     :ok
   end
 
-  def finish_session(state, exit_code, parsed, denials) do
+  def finish_session(state, exit_code, parsed, denials, empty?) do
     session = Ash.get!(Session, state.current_session_id)
-    action = session_action(exit_code)
+    action = session_action(exit_code, empty?)
 
     case Ash.update(
            session,
@@ -1254,8 +1316,9 @@ defmodule Camelot.Runtime.AgentProcess do
       :ok
   end
 
-  defp session_action(0), do: :complete
-  defp session_action(_exit_code), do: :fail
+  defp session_action(_exit_code, true), do: :mark_empty
+  defp session_action(0, false), do: :complete
+  defp session_action(_exit_code, false), do: :fail
 
   defp parsed_error({:error, msg}), do: msg
   defp parsed_error(_parsed), do: nil

--- a/lib/camelot/runtime/output_parser.ex
+++ b/lib/camelot/runtime/output_parser.ex
@@ -145,14 +145,32 @@ defmodule Camelot.Runtime.OutputParser do
   # already include the earlier invocations). Sub-agent streams are inlined
   # with a non-nil `parent_tool_use_id`; skip them so a sub-agent result can
   # never masquerade as the session result.
+  #
+  # Prefer the last top-level result event with a non-blank `result`: a
+  # resumed session's final invocation is sometimes a wake/yield turn that
+  # emits an empty result, which would otherwise discard the real answer
+  # produced by an earlier invocation (still present in the log). Fall back
+  # to the plain last event when every result is blank.
   defp last_result_event(objects) do
-    objects
-    |> Enum.filter(&(result_event?(&1) and top_level?(&1)))
-    |> List.last()
+    top_level = Enum.filter(objects, &(result_event?(&1) and top_level?(&1)))
+
+    top_level
+    |> Enum.reverse()
+    |> Enum.find(&result_present?/1)
+    |> case do
+      nil -> List.last(top_level)
+      event -> event
+    end
   end
 
   defp result_event?(%{"type" => "result"}), do: true
   defp result_event?(_), do: false
+
+  defp result_present?(%{"result" => result}) when is_binary(result) do
+    String.trim(result) != ""
+  end
+
+  defp result_present?(_), do: false
 
   defp top_level?(%{"parent_tool_use_id" => nil}), do: true
   defp top_level?(%{"parent_tool_use_id" => _id}), do: false

--- a/test/camelot/runtime/agent_process_test.exs
+++ b/test/camelot/runtime/agent_process_test.exs
@@ -470,6 +470,41 @@ defmodule Camelot.Runtime.AgentProcessTest do
     end
   end
 
+  describe "empty_result?/1" do
+    defp parsed(overrides) do
+      base = %{result_text: "", structured: nil, assistant_texts: [], permission_denials: []}
+      {:ok, Map.merge(base, Map.new(overrides))}
+    end
+
+    test "true when there is no result, structured, denials, or assistant text" do
+      assert AgentProcess.empty_result?(parsed([]))
+    end
+
+    test "false when there is result text" do
+      refute AgentProcess.empty_result?(parsed(result_text: "done"))
+    end
+
+    test "false when there is a structured payload" do
+      refute AgentProcess.empty_result?(parsed(structured: %{"decision" => "plan"}))
+    end
+
+    test "false when there are permission denials" do
+      refute AgentProcess.empty_result?(parsed(permission_denials: [%{"tool_name" => "Bash"}]))
+    end
+
+    test "false when an assistant turn has content" do
+      refute AgentProcess.empty_result?(parsed(assistant_texts: ["I did the thing"]))
+    end
+
+    test "true when assistant turns are all blank" do
+      assert AgentProcess.empty_result?(parsed(assistant_texts: ["", "  "]))
+    end
+
+    test "false for a runner-death/error parse" do
+      refute AgentProcess.empty_result?({:error, "runner died"})
+    end
+  end
+
   describe "finish_session/4" do
     test "is a no-op when there is no current session" do
       state = %AgentProcess{agent_id: "a", current_session_id: nil, output_buffer: ""}

--- a/test/camelot/runtime/output_parser_test.exs
+++ b/test/camelot/runtime/output_parser_test.exs
@@ -181,6 +181,34 @@ defmodule Camelot.Runtime.OutputParserTest do
       assert parsed.cost_usd == 0.74
     end
 
+    test "falls back to the last non-blank result when the final turn is empty" do
+      # Regression: a resumed session's final invocation can be a wake/yield
+      # turn that emits an empty result; the real answer from an earlier
+      # invocation (still in the log) must not be discarded.
+      buffer =
+        Enum.map_join(
+          [
+            %{
+              "type" => "result",
+              "subtype" => "success",
+              "result" => "Here is the real answer.",
+              "permission_denials" => []
+            },
+            %{
+              "type" => "result",
+              "subtype" => "success",
+              "result" => "",
+              "permission_denials" => []
+            }
+          ],
+          "\n",
+          &Jason.encode!/1
+        )
+
+      assert {:ok, parsed} = OutputParser.parse(:claude_code_json, buffer)
+      assert parsed.result_text == "Here is the real answer."
+    end
+
     test "ignores sub-agent result events (non-nil parent_tool_use_id)" do
       buffer =
         Enum.map_join(


### PR DESCRIPTION
## Problem

Task `1b792f8c` (test cluster) emailed "waiting for your input" but showed **no question and no PR change**. Investigation on the running app found: the task was `waiting_for_input`/`stage: pr` with **zero assistant messages**, and the last agent session ran 11 min, `completed`, 437 KB of output, but an **empty parsed result** and **no commits**.

Two root causes:

1. **Parser dropped the answer.** `OutputParser.last_result_event/1` takes the *last* top-level `type: "result"` event. On a resumed/multi-turn run, the final turn can be a wake/yield that emits an empty `result`, discarding the real answer from an earlier invocation (still present in the 437 KB log). Executing/PR consumers use `result.text` with no fallback.
2. **Silent `waiting_for_input`.** The `stage: :pr` handler's fallback branch (`agent_process.ex`) called `transition(task, :request_input)` — which fires the `NotifyTaskStateEmail` — **without creating any `TaskMessage`**. So the email had nothing behind it.

## Fix

Per direction: treat a **clean-but-empty run** as retryable on the same footing as a failure, bounded by the agent's **`max_retries`** (the same DB-configured cap used for errors), and mark the session **`:empty`** — instead of parking the task in a message-less `waiting_for_input`. Detection lives in the shared `finalize_runner_exit`, so it covers **all stages**.

- **`output_parser.ex`** — `last_result_event/1` prefers the last **non-blank** top-level result event; falls back to the plain last event only if all are blank. (+ regression test.)
- **`session.ex`** — add `:empty` status + `:mark_empty` action. No migration (status is a text-backed atom with an app-level `one_of`).
- **`agent_process.ex`**:
  - `empty_result?/1` (pure, tested): no result text, no structured payload, no denials, no non-blank assistant turns.
  - `finalize_runner_exit` retries empty runs up to `max_retries` (reusing the existing retry path), marks the session `:empty`, and on exhaustion errors the task with a clear reason — never a message-less waiting-for-input.
  - The `stage: :pr` fallback now surfaces the agent's summary as a visible `TaskMessage`, so a clean PR re-run's email always has context.

## Notes / decisions
- Cap reused = `agent.max_retries` (default 0 → an empty run errors immediately, exactly like an error with no retries).
- Exhausted-empty terminal = task `:error` with a clear message (consistent with error retries), rather than a silent wait.

## Testing
- `mix compile --warnings-as-errors` ✓
- `mix test` → **544 tests, 0 failures** ✓ (new: parser empty-final-turn regression; `empty_result?/1` predicate)
- `mix format --check-formatted` ✓
- `mix credo` ✓
- `mix dialyzer` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)