### PR TITLE
fix(github): resolve PR merge conflicts via agent; configurable auto-fix cap

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -47,6 +47,12 @@ config :camelot, :mail,
   from_name: "Camelot",
   from_address: "noreply@camelot.local"
 
+# Consecutive automatic PR fix re-dispatches (merge conflict / CI
+# failure) before a task is left for human review. Set to `:infinity`
+# to never give up (the attempt counter is still tracked). Overridable
+# at runtime via PR_AUTO_FIX_MAX_ATTEMPTS.
+config :camelot, :pr_auto_fix, max_attempts: 2
+
 # Runner backend for agent CLI execution. Overridden in
 # config/runtime.exs for prod. Dev/test default to LocalPort
 # which preserves the legacy Port.open behaviour.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -88,6 +88,23 @@ config :camelot,
   # var. Default differs by env: prod = swarm, dev/test = local.
   registration_enabled: System.get_env("REGISTRATION_ENABLED", "true") in ~w(true 1)
 
+# Consecutive automatic PR fix re-dispatches before a task is left for
+# human review. Accepts a positive integer, or "infinity"/"unlimited"
+# to never give up. Unset keeps the compile-time default (2).
+case System.get_env("PR_AUTO_FIX_MAX_ATTEMPTS") do
+  nil ->
+    :ok
+
+  value ->
+    max_attempts =
+      case value |> String.trim() |> String.downcase() do
+        unlimited when unlimited in ~w(infinity unlimited none) -> :infinity
+        int -> String.to_integer(int)
+      end
+
+    config :camelot, :pr_auto_fix, max_attempts: max_attempts
+end
+
 if backend_env = System.get_env("RUNNER_BACKEND") do
   runner_backend =
     case backend_env do

--- a/lib/camelot/agents/changes/dispatch_tasks.ex
+++ b/lib/camelot/agents/changes/dispatch_tasks.ex
@@ -7,6 +7,7 @@ defmodule Camelot.Agents.Changes.DispatchTasks do
   use Ash.Resource.Actions.Implementation
 
   alias Camelot.Agents.Agent
+  alias Camelot.Board.Changes.CheckPrStatus
   alias Camelot.Board.Task
   alias Camelot.Github.Client
   alias Camelot.Github.Resolver
@@ -145,7 +146,59 @@ defmodule Camelot.Agents.Changes.DispatchTasks do
 
     base
     |> append_branch_directive(task, slug)
+    |> append_conflict_directive(task)
     |> append_conversation(task.messages)
+  end
+
+  # A PR-stage task whose PR has merge conflicts must be told so
+  # explicitly: the pr_review prompt otherwise only mentions comments and
+  # CI, so the agent inspects those, finds nothing, and concludes there
+  # is nothing to do — leaving the conflict unresolved. The app already
+  # detects the conflict when polling; surface it to the runner with a
+  # concrete resolve-and-push instruction.
+  defp append_conflict_directive(prompt, %{stage: :pr} = task) do
+    prompt <> conflict_note(fetch_pull_request(task), task)
+  end
+
+  defp append_conflict_directive(prompt, _task), do: prompt
+
+  defp fetch_pull_request(task) do
+    project = task.project
+    opts = [installation_id: installation_id(task)]
+
+    case Client.get_pull_request(
+           project.github_owner,
+           project.github_repo,
+           task.pr_number,
+           opts
+         ) do
+      {:ok, pr} -> pr
+      {:error, _reason} -> %{}
+    end
+  end
+
+  @doc """
+  Renders the merge-conflict directive appended to a PR-stage prompt.
+
+  Returns an empty string when the PR is not in conflict (reusing
+  `CheckPrStatus.merge_conflict?/1` so detection stays in one place), and
+  otherwise an explicit instruction to merge the base branch, resolve the
+  conflicts on the task branch, and push.
+  """
+  @spec conflict_note(map(), Task.t()) :: String.t()
+  def conflict_note(pr, task) do
+    if CheckPrStatus.merge_conflict?(pr) do
+      base = get_in(pr, ["base", "ref"]) || "the base branch"
+
+      "\n\n--- Merge Conflict ---\n" <>
+        "This pull request (#{task.pr_url}) has merge conflicts with its " <>
+        "base branch `#{base}` and cannot be merged as-is. Resolve them: " <>
+        "fetch the latest `#{base}`, merge (or rebase) it into the working " <>
+        "branch `camelot/task-#{task.id}`, resolve every conflict, verify " <>
+        "the build and tests pass, and push so the PR becomes mergeable."
+    else
+      ""
+    end
   end
 
   # Pin the working branch to a deterministic, task-scoped name so a

--- a/lib/camelot/board/changes/check_pr_status.ex
+++ b/lib/camelot/board/changes/check_pr_status.ex
@@ -25,10 +25,12 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
   which wedged the auto-fix indefinitely. See git history to restore it
   with a robust identity check.)
 
-  Those automatic re-dispatches are capped at `@max_auto_fix_attempts`
-  consecutive attempts, so a task the agent cannot fix stops looping and
-  is left for human review. The counter resets on explicit human
-  feedback (changes requested / new comments).
+  Those automatic re-dispatches are capped at a configurable number of
+  consecutive attempts (see `max_auto_fix_attempts/0`, default 2), so a
+  task the agent cannot fix stops looping and is left for human review.
+  The cap can be raised, or set to `:infinity` to disable it entirely
+  (never removed — the counter is still tracked). The counter resets on
+  explicit human feedback (changes requested / new comments).
   """
   use Ash.Resource.Change
 
@@ -38,10 +40,12 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
 
   require Logger
 
-  # Cap on consecutive automatic PR fix re-dispatches (merge conflict /
-  # CI failure) before a task is left for human review. Prevents an
-  # unfixable PR from re-queuing the agent every poll forever.
-  @max_auto_fix_attempts 2
+  # Default cap on consecutive automatic PR fix re-dispatches (merge
+  # conflict / CI failure) before a task is left for human review.
+  # Prevents an unfixable PR from re-queuing the agent every poll
+  # forever. Overridable via `config :camelot, :pr_auto_fix,
+  # max_attempts: <pos_integer | :infinity>`.
+  @default_max_auto_fix_attempts 2
 
   @impl true
   @spec change(
@@ -215,19 +219,43 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
   end
 
   @doc """
+  The configured cap on consecutive automatic PR fix re-dispatches.
+
+  Reads `config :camelot, :pr_auto_fix, max_attempts: …`, falling back to
+  `#{@default_max_auto_fix_attempts}`. A positive integer caps the number
+  of attempts; `:infinity` disables the cap (attempts are still tracked,
+  the auto-fixer just never gives up).
+  """
+  @spec max_auto_fix_attempts() :: pos_integer() | :infinity
+  def max_auto_fix_attempts do
+    :camelot
+    |> Application.get_env(:pr_auto_fix, [])
+    |> Keyword.get(:max_attempts, @default_max_auto_fix_attempts)
+  end
+
+  @doc """
   Whether the task still has automatic PR fix attempts left.
 
   Merge-conflict and CI-failure auto-fixes re-dispatch the agent, capped
-  at `#{@max_auto_fix_attempts}` consecutive attempts so a PR the agent
+  at `max_auto_fix_attempts/0` consecutive attempts so a PR the agent
   cannot fix stops looping. The counter resets on explicit human
   feedback (changes requested / new comments).
   """
   @spec auto_fix_available?(Task.t()) :: boolean()
   def auto_fix_available?(%{pr_auto_fix_attempts: attempts}) do
-    attempts < @max_auto_fix_attempts
+    under_cap?(attempts, max_auto_fix_attempts())
   end
 
   def auto_fix_available?(_task), do: true
+
+  @doc """
+  Whether `attempts` is still below the given cap.
+
+  `:infinity` is never exceeded, so the auto-fixer keeps retrying.
+  """
+  @spec under_cap?(integer(), pos_integer() | :infinity) :: boolean()
+  def under_cap?(_attempts, :infinity), do: true
+  def under_cap?(attempts, max) when is_integer(max), do: attempts < max
 
   defp maybe_log_auto_fix_cap(task, true), do: log_auto_fix_cap(task, auto_fix_available?(task))
   defp maybe_log_auto_fix_cap(_task, false), do: :ok
@@ -237,7 +265,7 @@ defmodule Camelot.Board.Changes.CheckPrStatus do
   defp log_auto_fix_cap(task, false) do
     Logger.info(
       "Task #{task.id}: PR issue persists after " <>
-        "#{@max_auto_fix_attempts} auto-fix attempts; " <>
+        "#{max_auto_fix_attempts()} auto-fix attempts; " <>
         "leaving for human review"
     )
   end

--- a/test/camelot/agents/changes/dispatch_tasks_test.exs
+++ b/test/camelot/agents/changes/dispatch_tasks_test.exs
@@ -27,6 +27,48 @@ defmodule Camelot.Agents.Changes.DispatchTasksTest do
     end
   end
 
+  describe "conflict_note/2" do
+    @task %Task{
+      id: "c324c8d8-6e44-42d6-973f-ba8e17f37d2d",
+      pr_url: "https://github.com/T0ha/camelot/pull/100"
+    }
+
+    test "a dirty PR yields an explicit resolve-and-push instruction" do
+      pr = %{
+        "mergeable" => false,
+        "mergeable_state" => "dirty",
+        "base" => %{"ref" => "develop"}
+      }
+
+      note = DispatchTasks.conflict_note(pr, @task)
+
+      assert note =~ "Merge Conflict"
+      assert note =~ "`develop`"
+      assert note =~ "camelot/task-#{@task.id}"
+      assert note =~ @task.pr_url
+    end
+
+    test "a mergeable PR yields no note" do
+      pr = %{"mergeable" => true, "mergeable_state" => "clean"}
+      assert DispatchTasks.conflict_note(pr, @task) == ""
+    end
+
+    test "a PR still being computed by GitHub (mergeable nil) yields no note" do
+      pr = %{"mergeable" => nil, "mergeable_state" => "unknown"}
+      assert DispatchTasks.conflict_note(pr, @task) == ""
+    end
+
+    test "a blocked-but-not-dirty PR yields no note" do
+      pr = %{"mergeable" => false, "mergeable_state" => "blocked"}
+      assert DispatchTasks.conflict_note(pr, @task) == ""
+    end
+
+    test "a dirty PR with no base ref falls back to a generic phrase" do
+      pr = %{"mergeable" => false, "mergeable_state" => "dirty"}
+      assert DispatchTasks.conflict_note(pr, @task) =~ "the base branch"
+    end
+  end
+
   describe "installation_id/1" do
     test "resolves the task creator's connected installation id" do
       task = %Task{creator: %User{github_installations: [%Installation{installation_id: 7, account_login: "acme-org"}]}}

--- a/test/camelot/board/changes/check_pr_status_test.exs
+++ b/test/camelot/board/changes/check_pr_status_test.exs
@@ -210,14 +210,34 @@ defmodule Camelot.Board.Changes.CheckPrStatusTest do
   end
 
   describe "auto_fix_available?/1" do
-    test "allows fixes below the cap of 2" do
+    test "allows fixes below the default cap of 2" do
       assert CheckPrStatus.auto_fix_available?(%Task{pr_auto_fix_attempts: 0})
       assert CheckPrStatus.auto_fix_available?(%Task{pr_auto_fix_attempts: 1})
     end
 
-    test "stops once the cap of 2 is reached" do
+    test "stops once the default cap of 2 is reached" do
       refute CheckPrStatus.auto_fix_available?(%Task{pr_auto_fix_attempts: 2})
       refute CheckPrStatus.auto_fix_available?(%Task{pr_auto_fix_attempts: 3})
+    end
+  end
+
+  describe "under_cap?/2" do
+    test "an integer cap stops at the configured number of attempts" do
+      assert CheckPrStatus.under_cap?(0, 3)
+      assert CheckPrStatus.under_cap?(2, 3)
+      refute CheckPrStatus.under_cap?(3, 3)
+      refute CheckPrStatus.under_cap?(4, 3)
+    end
+
+    test ":infinity never gives up, no matter how many attempts" do
+      assert CheckPrStatus.under_cap?(0, :infinity)
+      assert CheckPrStatus.under_cap?(99, :infinity)
+    end
+  end
+
+  describe "max_auto_fix_attempts/0" do
+    test "defaults to 2 when unconfigured" do
+      assert CheckPrStatus.max_auto_fix_attempts() == 2
     end
   end
 


### PR DESCRIPTION
## Problem

PR-stage tasks with merge conflicts sat in `waiting_for_input` with nothing happening, even when the user explicitly replied "fix conflicts" (observed on task `c324c8d8` / PR #100 on test).

Two root causes:

1. **The runner was never told the PR had a conflict.** The `pr_review` prompt only talks about comments and CI, so a re-dispatched agent checked those, found nothing, concluded "nothing to do," and never resolved the conflict. The app already detects the conflict when polling (`CheckPrStatus.merge_conflict?/1`) — that signal was just never propagated to the prompt.

2. **The auto-fix cap was a hard-coded `2`**, with no way to raise it or disable it.

## Changes

- **`DispatchTasks`**: for a dirty PR, append an explicit merge-conflict directive to the prompt (fetch the base branch, merge/rebase into `camelot/task-<id>`, resolve every conflict, verify build/tests, push). Detection reuses `CheckPrStatus.merge_conflict?/1` so it stays in one place. New pure `conflict_note/2` is unit-tested.
- **`CheckPrStatus`**: `max_auto_fix_attempts` is now configurable via `config :camelot, :pr_auto_fix, max_attempts: …` (default `2`) and the `PR_AUTO_FIX_MAX_ATTEMPTS` env var. Accepts `:infinity` to never give up — the attempt counter is still tracked, the auto-fixer just doesn't stop. New pure `under_cap?/2`.
- Config defaults in `config.exs`; env override in `runtime.exs` (`"infinity"`/`"unlimited"` → `:infinity`).

## Testing

- `mix compile --warnings-as-errors`: clean
- `mix credo` on changed files: no issues
- `mix test test/camelot/board test/camelot/agents`: 127 tests, 0 failures (includes new `conflict_note/2`, `under_cap?/2`, `max_auto_fix_attempts/0` coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)