### PR TITLE
fix(migration): drop agent_id FKs before remapping to template_id

### DIFF
--- a/priv/repo/migrations/20260812125622_rename_agent_template_to_agent.exs
+++ b/priv/repo/migrations/20260812125622_rename_agent_template_to_agent.exs
@@ -34,6 +34,17 @@ defmodule Camelot.Repo.Migrations.RenameAgentTemplateToAgent do
       add :max_retries, :bigint, null: false, default: 3
     end
 
+    # The `agent_id` columns on tasks/sessions/env_vars still FK to the
+    # old runtime `agents` rows. Remapping them to `template_id` (an
+    # `agent_templates` id, absent from the old `agents` table) would
+    # violate those constraints mid-migration, so drop the referencing
+    # FKs first; they're re-added at the end pointing at the renamed
+    # `agents` table. (The later `DROP TABLE agents CASCADE` would also
+    # drop them, but only after these UPDATEs — too late.)
+    execute("ALTER TABLE tasks DROP CONSTRAINT IF EXISTS tasks_agent_id_fkey")
+    execute("ALTER TABLE sessions DROP CONSTRAINT IF EXISTS sessions_agent_id_fkey")
+    execute("ALTER TABLE env_vars DROP CONSTRAINT IF EXISTS env_vars_agent_id_fkey")
+
     # Remap FKs off the old `agents` table before it's dropped: those
     # columns currently point at per-project runtime Agent rows, not
     # templates.
@@ -58,10 +69,9 @@ defmodule Camelot.Repo.Migrations.RenameAgentTemplateToAgent do
      WHERE env_vars.agent_id = a.id
     """)
 
-    # CASCADE also drops agents_project_id_fkey/agents_user_id_fkey/
-    # agents_template_id_fkey (owned by this table) and
-    # tasks_agent_id_fkey/sessions_agent_id_fkey/env_vars_agent_id_fkey
-    # (constraints on other tables that reference it).
+    # CASCADE drops agents_project_id_fkey/agents_user_id_fkey/
+    # agents_template_id_fkey (owned by this table). The
+    # tasks/sessions/env_vars referencing FKs were already dropped above.
     execute("DROP TABLE agents CASCADE")
 
     rename table(:agent_templates), to: table(:agents)


### PR DESCRIPTION
## Problem

After #100 deployed to **test.camelotai.tech**, the app crash-loops on boot. Every boot re-attempts the pending `RenameAgentTemplateToAgent` migration, which fails and rolls back:

```
== Running 20260812125622 ... RenameAgentTemplateToAgent.up/0 forward
execute "UPDATE tasks SET agent_id = a.template_id FROM agents a WHERE tasks.agent_id = a.id"
** (Postgrex.Error) ERROR 23503 (foreign_key_violation)
   insert or update on table "tasks" violates foreign key constraint "tasks_agent_id_fkey"
   Key (agent_id)=(2c67de04-...) is not present in table "agents".
```

## Root cause

The migration remaps `tasks`/`sessions`/`env_vars.agent_id` from the old runtime-row ids to their `template_id` **while `tasks_agent_id_fkey` (and the sessions/env_vars equivalents) still reference the old `agents` table**. A `template_id` is an `agent_templates` id, not a valid old-`agents.id`, so the first `UPDATE` trips the FK and the whole migration transaction rolls back.

The `DROP TABLE agents CASCADE` that would remove those referencing FKs runs *after* the UPDATEs — too late.

**Why CI missed it:** dev/test tables were empty, and a 0-row `UPDATE` never evaluates the FK. Test has 54 real tasks with a non-null `agent_id`.

## Fix

Drop the three referencing FKs up front (`DROP CONSTRAINT IF EXISTS`), then remap → `DROP TABLE agents CASCADE` → rename → re-add the FKs against the renamed `agents` table.

## Verification

- Confirmed on test that the failed migration rolled back cleanly (still old schema, `20260812125622` not in `schema_migrations`) — no manual DB repair needed; a corrected redeploy applies cleanly.
- Verified data integrity on test: 0 orphaned `agent_id`s, all map to valid templates — the remap and re-added FKs will succeed.
- Reproduced against a Postgres instance seeded with representative data: **old order → exact 23503 error; new order → completes and remaps correctly.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)