### PR TITLE
fix(runner): clone GitHub SSH URLs over HTTPS using the App token

### DIFF
--- a/runner-images/base/entrypoint.sh
+++ b/runner-images/base/entrypoint.sh
@@ -97,6 +97,20 @@ materialise_one() {
       # a git credential helper for github.com (and any GH_HOST) so
       # `git clone`/`git push` over HTTPS also authenticate.
       gh auth setup-git || log "gh auth setup-git failed; git HTTPS auth may not work"
+      # A GitHub App gives us an HTTPS installation token, never an SSH
+      # key. When a project's clone URL is `git@github.com:…` (or
+      # `ssh://git@github.com/…`) the transport would go over SSH and
+      # need the user's per-user key registered on GitHub — which App
+      # users haven't done. Rewrite GitHub SSH URLs to HTTPS so every
+      # git op (clone here, plus fetch/push the agent runs) resolves
+      # over HTTPS and authenticates with the token via the helper
+      # above. Only applied when a token is present; the mounted SSH
+      # key still serves non-GitHub hosts and GitHub without an App.
+      # --unset-all first keeps this idempotent across container boots
+      # on a persisted /home/agent cache volume.
+      git config --global --unset-all url."https://github.com/".insteadOf 2>/dev/null || true
+      git config --global --add url."https://github.com/".insteadOf "git@github.com:"
+      git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
       ;;
     ssh_private_key)
       mkdir -p "$HOME/.ssh"


### PR DESCRIPTION
## Problem

Tasks whose project `github_repo_url` is an **SSH** URL (`git@github.com:T0ha/camelot`) fail at clone with:

```
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

Observed on test: tasks `f1a66be1-4279-402b-b26c-198e2ffc9cca` and `f77c49c3-5881-499a-9838-7bb367f15419` (same creator, GitHub App installed).

Root cause: the runner mounts the per-user auto-generated **"camelot" SSH key**, but its public half isn't registered on GitHub — GitHub App users never do that step. The creator *does* have a connected GitHub App installation that mints a working **HTTPS installation token** (already wired into git via `gh auth setup-git`), but because the clone URL is `git@github.com:…` the transport goes over SSH and never uses the token.

## Fix

A GitHub App exposes an HTTPS token, **not** an SSH key — so there's no "App SSH key" to mount. Instead, in the `github_app_token` branch of the runner entrypoint, add git `insteadOf` rewrites:

```sh
git config --global --add url."https://github.com/".insteadOf "git@github.com:"
git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/"
```

Now `git@github.com:owner/repo` and `ssh://git@github.com/owner/repo` transparently resolve to `https://github.com/owner/repo` and authenticate with the installation token via the credential helper. This covers **every** git op — the entrypoint clone *and* the fetch/push the AI agent runs — with no SSH key on GitHub required.

Properties:
- **Gated on token presence** — only runs when an App token is materialised, so the mounted SSH key still serves non-GitHub hosts and GitHub when no App is connected.
- **Idempotent** — `--unset-all` first, so repeated boots on a persisted `/home/agent` cache volume don't accumulate duplicate values.
- **Non-GitHub untouched** — verified `git@gitlab.com:…` resolves unchanged.

## Verification

Ran the exact config block in a scratch `HOME` and resolved URLs with `git ls-remote --get-url`:

| Input | Resolved |
|---|---|
| `git@github.com:T0ha/camelot` | `https://github.com/T0ha/camelot` |
| `ssh://git@github.com/T0ha/camelot` | `https://github.com/T0ha/camelot` |
| `https://github.com/T0ha/camelot` | unchanged |
| `git@gitlab.com:acme/app` | unchanged |

Running the block twice leaves exactly two `insteadOf` values (idempotent). `bash -n` passes.

> [!NOTE]
> Takes effect once the runner base image is rebuilt and the floating tag re-pinned. The two failed tasks above need a retry after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)