### PR TITLE
feat(docs-proxy): CapRover app to serve docs on docs. subdomain

### DIFF
--- a/.github/workflows/deploy-docs-proxy.yml
+++ b/.github/workflows/deploy-docs-proxy.yml
@@ -1,0 +1,48 @@
+name: Deploy docs proxy
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - "docs-proxy/**"
+      - ".github/workflows/deploy-docs-proxy.yml"
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    name: Deploy docs proxy to test
+    runs-on: ubuntu-24.04
+    environment: test
+    # Opt-in: set repo/environment variable DEPLOY_DOCS_PROXY=true once the
+    # 'docs' app + DOCS_PROXY_APP_TOKEN exist (see docs-proxy/README.md).
+    if: ${{ vars.DEPLOY_DOCS_PROXY == 'true' }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      # The docs proxy is a standalone nginx app (see docs-proxy/README.md).
+      # CapRover builds it from the tarball's Dockerfile — no registry push.
+      # Pin the caprover CLI to 2.3.1 (2.4.0 crashes on deploy).
+      - name: Deploy docs proxy to CapRover (test)
+        env:
+          CAPROVER_URL: "${{ vars.CAPROVER_SERVER }}"
+          CAPROVER_APP_TOKEN: "${{ secrets.DOCS_PROXY_APP_TOKEN }}"
+          APP_NAME: "${{ vars.DOCS_PROXY_APP_NAME || 'docs' }}"
+        run: |
+          if [ -z "$CAPROVER_APP_TOKEN" ]; then
+            echo "::error::DOCS_PROXY_APP_TOKEN is not set for the 'test'" \
+                 "environment. Create the '$APP_NAME' app in CapRover and add" \
+                 "its app token as the DOCS_PROXY_APP_TOKEN secret." \
+                 "See docs-proxy/README.md."
+            exit 1
+          fi
+          tar -czf "$RUNNER_TEMP/docs-proxy.tar.gz" -C docs-proxy .
+          npx --yes caprover@2.3.1 deploy \
+            --caproverUrl "$CAPROVER_URL" \
+            --appToken "$CAPROVER_APP_TOKEN" \
+            --appName "$APP_NAME" \
+            --tarFile "$RUNNER_TEMP/docs-proxy.tar.gz"

--- a/docs-proxy/Dockerfile
+++ b/docs-proxy/Dockerfile
@@ -1,0 +1,17 @@
+# Tiny reverse proxy that lets CapRover serve the Camelot docs site on a
+# `docs.` hostname.
+#
+# CapRover rejects `docs.<caprover-root-domain>` as a *custom domain*, but it
+# freely gives an app named `docs` the subdomain `docs.<root>` with auto-SSL.
+# This image is that `docs` app: it forwards every request to the main Camelot
+# app with the Host header rewritten to a `docs.` value, which is what
+# Phoenix's docs host-route matches. See docs/docs-site-deployment.md.
+FROM nginx:alpine
+
+# Overridable per environment via the CapRover app's env vars.
+#   DOCS_UPSTREAM — the main app's internal service:port on the swarm overlay
+#   DOCS_HOST     — a hostname starting with "docs." (Phoenix host-matches this)
+ENV DOCS_UPSTREAM=srv-captain--camelotai:4000
+ENV DOCS_HOST=docs.test.camelotai.tech
+
+COPY templates/docs.conf.template /etc/nginx/templates/docs.conf.template

--- a/docs-proxy/README.md
+++ b/docs-proxy/README.md
@@ -1,0 +1,61 @@
+# docs-proxy
+
+A tiny `nginx:alpine` reverse proxy deployed as a **separate CapRover app**
+named `docs`, so the Camelot documentation site is reachable at
+`docs.<caprover-root-domain>` (e.g. `docs.test.camelotai.tech`).
+
+## Why this exists
+
+The docs site is served by the **main** Camelot app, gated to hosts starting
+with `docs.` (see `CamelotWeb.Router`). On CapRover you cannot attach
+`docs.<root>` as a *custom domain* to the main app — CapRover reserves
+subdomains of its own root domain and rejects them
+("Custom domain cannot be subdomain of root domain"). But CapRover **does**
+give an app named `docs` the subdomain `docs.<root>` automatically, with
+auto-SSL. This proxy is that app: it forwards to the main app with the `Host`
+header rewritten to a `docs.` value so Phoenix serves the docs.
+
+```
+browser → docs.<root> (CapRover edge, TLS)
+        → srv-captain--docs (this proxy)
+        → ${DOCS_UPSTREAM}  with  Host: ${DOCS_HOST}
+        → Phoenix docs host-route
+```
+
+## One-time CapRover setup
+
+1. **Create New App** named `docs` (no persistent data).
+2. Generate an **App Token** (App → Deployment) and store it as the
+   `DOCS_PROXY_APP_TOKEN` secret in the matching GitHub environment (`test`).
+3. **Enable HTTPS** on the app's default `docs.<root>` domain.
+4. Container HTTP Port is `80` (nginx default) — the CapRover default, so no
+   change needed.
+5. Set the GitHub variable `DEPLOY_DOCS_PROXY=true` to enable the CI workflow
+   (it is opt-in so it stays green until the app + token exist).
+
+Optionally override the defaults via the app's **Environmental Variables**:
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `DOCS_UPSTREAM` | `srv-captain--camelotai:4000` | main app service:port on the overlay |
+| `DOCS_HOST` | `docs.test.camelotai.tech` | Host header sent upstream (must start with `docs.`) |
+
+## Deploy
+
+CI deploys this on pushes to `develop` that touch `docs-proxy/**` (see
+`.github/workflows/deploy-docs-proxy.yml`), and it can be run manually
+(workflow_dispatch).
+
+Locally / by hand:
+
+```sh
+tar -czf /tmp/docs-proxy.tar.gz -C docs-proxy .
+npx --yes caprover@2.3.1 deploy \
+  --caproverUrl "$CAPROVER_SERVER" \
+  --appToken "$DOCS_PROXY_APP_TOKEN" \
+  --appName docs \
+  --tarFile /tmp/docs-proxy.tar.gz
+```
+
+CapRover builds the image from `Dockerfile` server-side (just an nginx config
+copy), so no registry push is needed.

--- a/docs-proxy/captain-definition
+++ b/docs-proxy/captain-definition
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": 2,
+  "dockerfilePath": "./Dockerfile"
+}

--- a/docs-proxy/templates/docs.conf.template
+++ b/docs-proxy/templates/docs.conf.template
@@ -1,0 +1,28 @@
+# Rendered by the nginx entrypoint (envsubst) at container start.
+# The entrypoint substitutes ONLY real env vars (DOCS_UPSTREAM, DOCS_HOST),
+# so nginx runtime vars like $proxy_add_x_forwarded_for are left untouched.
+server {
+  listen 80;
+  server_name _;
+
+  # Re-resolve the upstream via Docker's embedded DNS (127.0.0.11) so a
+  # rescheduled main-app container (new overlay IP) is picked up without a
+  # proxy restart. Using a variable in proxy_pass defers resolution to
+  # request time instead of pinning the IP at startup.
+  resolver 127.0.0.11 valid=10s ipv6=off;
+  set $docs_upstream ${DOCS_UPSTREAM};
+
+  location / {
+    proxy_pass http://$docs_upstream;
+    proxy_http_version 1.1;
+
+    # Phoenix serves the docs site only for hosts starting with "docs.".
+    proxy_set_header Host ${DOCS_HOST};
+
+    # The main app has force_ssl; tell it the original request was https so
+    # it doesn't redirect-loop behind the CapRover TLS terminator.
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Real-IP $remote_addr;
+  }
+}

--- a/docs/docs-site-deployment.md
+++ b/docs/docs-site-deployment.md
@@ -50,6 +50,21 @@ them at the edge and only hit the origin on a miss or revalidation.
 Internal-only docs stay **flat** under `docs/` (like this file) and are
 never globbed or published.
 
+## Serving on CapRover directly (test): the `docs` proxy app
+
+CapRover rejects `docs.<root-domain>` as a *custom domain* on the main app
+("Custom domain cannot be subdomain of root domain"), so on the test cluster
+the docs site is exposed via a small companion app named `docs` (an app
+subdomain, which CapRover allows and auto-SSLs). It is a one-container
+`nginx:alpine` reverse proxy that forwards to the main app with the `Host`
+rewritten to a `docs.` value. Definition and setup live in
+[`docs-proxy/`](../docs-proxy/README.md); CI deploys it via
+`.github/workflows/deploy-docs-proxy.yml`.
+
+This gives `https://docs.test.camelotai.tech`. Production instead fronts the
+same app with CloudFront (below), so the proxy app is a test/staging
+convenience, not the production path.
+
 ## One-time infrastructure (AWS)
 
 DNS is in Route53; the origin is the CapRover-hosted app.


### PR DESCRIPTION
## What

A small, repo-tracked CapRover app (`docs-proxy/`) that makes the docs site reachable at `docs.<caprover-root>` (e.g. `https://docs.test.camelotai.tech`) — deployable by CLI/CI.

## Why

CapRover rejects `docs.test.camelotai.tech` as a **custom domain** on the main app (*"Custom domain cannot be subdomain of root domain"*). But an app **named `docs`** automatically owns that subdomain with auto-SSL. So instead of a second full Camelot instance, this is a one-container `nginx:alpine` reverse proxy that forwards to the main app with:
- `Host: docs.…` — so Phoenix's `docs.`-host route serves the docs;
- `X-Forwarded-Proto: https` — so the app's `force_ssl` doesn't redirect-loop behind CapRover's TLS terminator.

## Contents

- **`docs-proxy/`** — `captain-definition` + `Dockerfile` + an envsubst nginx template. `DOCS_UPSTREAM` (default `srv-captain--camelotai:4000`) and `DOCS_HOST` (default `docs.test.camelotai.tech`) are overridable via the app's env vars. Uses Docker's embedded resolver (`127.0.0.11`) with a variable `proxy_pass` so a **rescheduled** main-app container (new overlay IP) is re-resolved at request time rather than pinned at startup — important on this rescheduling-prone cluster.
- **`.github/workflows/deploy-docs-proxy.yml`** — on `docs-proxy/**` changes (or manual dispatch), tars the folder and `caprover deploy`s it (CapRover builds the image server-side; no registry push). **Opt-in** via `DEPLOY_DOCS_PROXY=true` so it stays green until the app + token exist.
- **`docs/docs-site-deployment.md`** — documents the proxy (test path) vs CloudFront (prod path).

## One-time setup (documented in `docs-proxy/README.md`)

1. CapRover → Create New App `docs`.
2. Generate its app token → GitHub `test` env secret `DOCS_PROXY_APP_TOKEN`.
3. Enable HTTPS on `docs.test.camelotai.tech`.
4. Set `DEPLOY_DOCS_PROXY=true`.

## Verification

- Built the image locally; confirmed envsubst substitutes only `DOCS_UPSTREAM`/`DOCS_HOST` (nginx's own `$proxy_add_x_forwarded_for`/`$remote_addr` left intact) and `nginx -t` passes.
- Workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)