### PR TITLE
fix(docs-proxy): build image in CI, deploy to CapRover by imageName

### DIFF
--- a/.github/workflows/deploy-docs-proxy.yml
+++ b/.github/workflows/deploy-docs-proxy.yml
@@ -12,25 +12,62 @@ defaults:
   run:
     shell: bash
 
+env:
+  IMAGE: ghcr.io/t0ha/camelotai-docs-proxy
+
 jobs:
   deploy:
-    name: Deploy docs proxy to test
+    name: Build & deploy docs proxy to test
     runs-on: ubuntu-24.04
     environment: test
+    permissions:
+      contents: read
+      packages: write
     steps:
+      # DEPLOY_DOCS_PROXY is a `test`-environment variable, so it is only
+      # readable once the job's environment is resolved (not in a job-level
+      # `if:`). Resolve it into a step output the later steps gate on.
+      - name: Gate on DEPLOY_DOCS_PROXY
+        id: gate
+        run: echo "go=${{ vars.DEPLOY_DOCS_PROXY == 'true' }}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repo
+        if: steps.gate.outputs.go == 'true'
         uses: actions/checkout@v4
 
-      # The docs proxy is a standalone nginx app (see docs-proxy/README.md).
-      # CapRover builds it from the tarball's Dockerfile — no registry push.
+      - name: Set up QEMU
+        if: steps.gate.outputs.go == 'true'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: steps.gate.outputs.go == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: steps.gate.outputs.go == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build & push the proxy image ourselves (multi-arch: the test swarm
+      # has amd64 and arm64 nodes). CapRover only pulls by --imageName, which
+      # avoids the "CapRover builds then push fails" registry-scope problem.
+      - name: Build and push proxy image
+        if: steps.gate.outputs.go == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: docs-proxy
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       # Pin the caprover CLI to 2.3.1 (2.4.0 crashes on deploy).
-      #
-      # Opt-in: set the `test` environment variable DEPLOY_DOCS_PROXY=true
-      # once the 'docs' app + DOCS_PROXY_APP_TOKEN exist. The gate is at the
-      # step level (not job level) because environment-scoped variables are
-      # not available to a job-level `if:`.
       - name: Deploy docs proxy to CapRover (test)
-        if: ${{ vars.DEPLOY_DOCS_PROXY == 'true' }}
+        if: steps.gate.outputs.go == 'true'
         env:
           CAPROVER_URL: "${{ vars.CAPROVER_SERVER }}"
           CAPROVER_APP_TOKEN: "${{ secrets.DOCS_PROXY_APP_TOKEN }}"
@@ -38,14 +75,11 @@ jobs:
         run: |
           if [ -z "$CAPROVER_APP_TOKEN" ]; then
             echo "::error::DOCS_PROXY_APP_TOKEN is not set for the 'test'" \
-                 "environment. Create the '$APP_NAME' app in CapRover and add" \
-                 "its app token as the DOCS_PROXY_APP_TOKEN secret." \
-                 "See docs-proxy/README.md."
+                 "environment. See docs-proxy/README.md."
             exit 1
           fi
-          tar -czf "$RUNNER_TEMP/docs-proxy.tar.gz" -C docs-proxy .
           npx --yes caprover@2.3.1 deploy \
             --caproverUrl "$CAPROVER_URL" \
             --appToken "$CAPROVER_APP_TOKEN" \
             --appName "$APP_NAME" \
-            --tarFile "$RUNNER_TEMP/docs-proxy.tar.gz"
+            --imageName "${{ env.IMAGE }}:${{ github.sha }}"

--- a/docs-proxy/README.md
+++ b/docs-proxy/README.md
@@ -22,16 +22,28 @@ browser → docs.<root> (CapRover edge, TLS)
         → Phoenix docs host-route
 ```
 
+## Image build model
+
+The image is **built and pushed by CI** (GitHub Actions →
+`ghcr.io/t0ha/camelotai-docs-proxy`), and CapRover only **pulls it by image
+name**. We do not let CapRover build from source: on this cluster CapRover's
+source-build push to the registry is denied ("token does not match expected
+scopes"), because the registry credentials are read-only for pulling the main
+app. Building in CI (as the main app already does) sidesteps that entirely.
+
 ## One-time CapRover setup
 
 1. **Create New App** named `docs` (no persistent data).
 2. Generate an **App Token** (App → Deployment) and store it as the
    `DOCS_PROXY_APP_TOKEN` secret in the matching GitHub environment (`test`).
-3. **Enable HTTPS** on the app's default `docs.<root>` domain.
+3. **Enable HTTPS** on the app's default `docs.<root>` domain (do this
+   *before* toggling "Force HTTPS", otherwise CapRover errors with
+   "Cannot force SSL without at least one SSL-enabled domain").
 4. Container HTTP Port is `80` (nginx default) — the CapRover default, so no
    change needed.
-5. Set the GitHub variable `DEPLOY_DOCS_PROXY=true` to enable the CI workflow
-   (it is opt-in so it stays green until the app + token exist).
+5. Set the GitHub variable `DEPLOY_DOCS_PROXY=true` (in the `test`
+   environment) to enable the CI workflow (it is opt-in so it stays green
+   until the app + token exist).
 
 Optionally override the defaults via the app's **Environmental Variables**:
 
@@ -46,16 +58,16 @@ CI deploys this on pushes to `develop` that touch `docs-proxy/**` (see
 `.github/workflows/deploy-docs-proxy.yml`), and it can be run manually
 (workflow_dispatch).
 
-Locally / by hand:
+To deploy by hand, build & push the image, then point CapRover at it:
 
 ```sh
-tar -czf /tmp/docs-proxy.tar.gz -C docs-proxy .
+IMAGE=ghcr.io/t0ha/camelotai-docs-proxy:manual
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t "$IMAGE" --push docs-proxy
+
 npx --yes caprover@2.3.1 deploy \
   --caproverUrl "$CAPROVER_SERVER" \
   --appToken "$DOCS_PROXY_APP_TOKEN" \
   --appName docs \
-  --tarFile /tmp/docs-proxy.tar.gz
+  --imageName "$IMAGE"
 ```
-
-CapRover builds the image from `Dockerfile` server-side (just an nginx config
-copy), so no registry push is needed.

--- a/docs-proxy/captain-definition
+++ b/docs-proxy/captain-definition
@@ -1,4 +1,0 @@
-{
-  "schemaVersion": 2,
-  "dockerfilePath": "./Dockerfile"
-}


### PR DESCRIPTION
## Root cause

The docs-proxy deploy ran but the app stayed on CapRover's placeholder (`deployedVersion: 0`). Captain builder logs:

```
Building docker image...
Error: denied: permission_denied: The token provided does not match expected scopes.
Error: PUSH FAILED
```

CapRover **built** the nginx image but couldn't **push** it — the cluster's registry credentials are read-only (they exist to *pull* the main app image). CapRover source-build is therefore unusable here.

## Fix

Mirror the main app's proven model: **GitHub Actions builds & pushes** a multi-arch image (`ghcr.io/t0ha/camelotai-docs-proxy`, amd64+arm64), and CapRover only **pulls it via `--imageName`** — no CapRover-side push.

- Rework `.github/workflows/deploy-docs-proxy.yml`: QEMU + Buildx + GHCR login + `build-push-action` (gha cache) + `caprover deploy --imageName`.
- Remove `docs-proxy/captain-definition` (no CapRover source build).
- Keep the opt-in gate but via a **step output** (the `DEPLOY_DOCS_PROXY` var is `test`-environment-scoped, invisible to a job-level `if:` — the earlier skip cause).
- README: document the image-build model and the Enable-HTTPS-before-Force-HTTPS ordering (the other error in the logs).

Merging this triggers a real build+deploy.

> Note: still needs **Enable HTTPS** on `docs.test.camelotai.tech` in CapRover for the `https://` URL (the logs showed `Cannot force SSL without at least one SSL-enabled domain`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)