### PR TITLE
fix(docker): copy docs/ into build so the docs site isn't empty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,11 @@ COPY priv priv
 
 COPY lib lib
 
+# Public docs content: NimblePublisher (Camelot.Docs) globs docs/<category>/
+# markdown at compile time and bakes the rendered HTML into the release, so
+# docs/ must be present before `mix compile` or the docs site ships empty.
+COPY docs docs
+
 # Compile the release
 RUN mix compile
 


### PR DESCRIPTION
## Problem (found while validating the test deploy via CLI)

The deployed test app serves the `docs.` host, but every doc page 404s and the index lists no categories — `Camelot.Docs.all_pages/0` is **empty in the release**.

Cause: `Camelot.Docs` (NimblePublisher) globs `docs/<category>/**/*.md` **at compile time** and bakes the HTML into the BEAM. The Dockerfile copies `lib/ priv/ config/ assets/` before `mix compile` but **not `docs/`**, so the image compiles with zero docs. (`.dockerignore` excludes `/doc/` but not `/docs/`, so the dir was simply never copied.) This affects production too.

## Fix

`COPY docs docs` before `mix compile`.

## Verification (local, via CLI)

Built the `builder` stage locally and inspected the compiled beam:

```
$ strings _build/prod/lib/camelot/ebin/Elixir.Camelot.Docs.beam | grep ...
FOUND runners/cluster-runners
FOUND runners/env-vars
FOUND runners/local-docker-runners
FOUND integrations/github-app
```

Empty before the fix; all four published docs present after.

Merging rebuilds the main app image (with docs) and deploys it to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)