### PR TITLE
fix(docs-proxy): make our server the default, drop stock welcome conf

### DIFF
--- a/docs-proxy/Dockerfile
+++ b/docs-proxy/Dockerfile
@@ -14,4 +14,9 @@ FROM nginx:alpine
 ENV DOCS_UPSTREAM=srv-captain--camelotai:4000
 ENV DOCS_HOST=docs.test.camelotai.tech
 
+# Drop the stock welcome server, otherwise it stays the default server on
+# :80 (it loads first, alphabetically) and answers every request instead of
+# our proxy block.
+RUN rm -f /etc/nginx/conf.d/default.conf
+
 COPY templates/docs.conf.template /etc/nginx/templates/docs.conf.template

--- a/docs-proxy/templates/docs.conf.template
+++ b/docs-proxy/templates/docs.conf.template
@@ -2,7 +2,7 @@
 # The entrypoint substitutes ONLY real env vars (DOCS_UPSTREAM, DOCS_HOST),
 # so nginx runtime vars like $proxy_add_x_forwarded_for are left untouched.
 server {
-  listen 80;
+  listen 80 default_server;
   server_name _;
 
   # Re-resolve the upstream via Docker's embedded DNS (127.0.0.11) so a


### PR DESCRIPTION
## Problem

After deploying the proxy, `docs.test.camelotai.tech/` returned 200 but with the **nginx welcome page** (no docs), and every other path 404'd — even though hitting the app directly with `Host: docs.…` returns 200.

Cause: `nginx:alpine` ships `/etc/nginx/conf.d/default.conf` (welcome server, `server_name localhost`). It loads before our `docs.conf` alphabetically and becomes the **default server on :80**; our block used `server_name _` (matches nothing unless it's the default server), so the welcome server handled everything.

## Fix

- `RUN rm -f /etc/nginx/conf.d/default.conf` in the image.
- `listen 80 default_server;` on our block.

## Verification (local)

Built the image, rendered templates, ran it:
- `conf.d` contains only `docs.conf`; `listen 80 default_server`.
- `curl /` → **502** (our proxy block, upstream unreachable locally) — i.e. our block is active, not the welcome page.

Merging rebuilds+redeploys the proxy; `docs.test.camelotai.tech` should then serve the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)