### PR TITLE
fix(docker): install npm deps so esbuild can bundle posthog-js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ ARG RUNNER_IMAGE="docker.io/debian:${DEBIAN_VERSION}"
 FROM ${BUILDER_IMAGE} AS builder
 
 # install build dependencies
+# nodejs + npm are needed for the JS package deps (e.g. posthog-js) that
+# esbuild bundles from assets/node_modules during `mix assets.deploy`.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends build-essential git \
+  && apt-get install -y --no-install-recommends build-essential git nodejs npm \
   && rm -rf /var/lib/apt/lists/*
 
 # prepare build dir
@@ -46,8 +48,6 @@ RUN mkdir config
 COPY config/config.exs config/${MIX_ENV}.exs config/
 RUN mix deps.compile
 
-RUN mix assets.setup
-
 COPY priv priv
 
 COPY lib lib
@@ -62,7 +62,8 @@ RUN mix compile
 
 COPY assets assets
 
-# compile assets
+# install asset tooling + JS deps (assets/node_modules), then compile assets
+RUN mix assets.setup
 RUN mix assets.deploy
 
 # Changes to config/runtime.exs don't require recompiling the code

--- a/mix.exs
+++ b/mix.exs
@@ -129,7 +129,11 @@ defmodule Camelot.MixProject do
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
-      "assets.setup": ["tailwind.install --if-missing", "esbuild.install --if-missing"],
+      "assets.setup": [
+        "tailwind.install --if-missing",
+        "esbuild.install --if-missing",
+        "cmd --cd assets npm ci"
+      ],
       "assets.build": ["compile", "tailwind camelot", "esbuild camelot"],
       "assets.deploy": [
         "tailwind camelot --minify",


### PR DESCRIPTION
## Problem

The image build ([run 32479695786](https://github.com/T0ha/camelot/actions/runs/32479695786/job/96765303903)) fails on both `linux/amd64` and `linux/arm64` with:

```
✘ [ERROR] Could not resolve "posthog-js"
ERROR: process "/bin/sh -c mix assets.deploy" did not complete successfully: exit code: 1
```

PR #109 (browser-side PostHog) added `posthog-js` as a real npm dependency (`assets/package.json`, `assets/package-lock.json`, and `import posthog from "posthog-js"` in `assets/js/app.js`), but the release build never installed Node/npm deps. esbuild resolves bundled packages from `assets/node_modules`, which was empty, so the bundle failed.

## Fix

- Install `nodejs` + `npm` in the Docker builder stage.
- Add `cmd --cd assets npm ci` to the `assets.setup` mix alias so `assets/node_modules` is populated — one source of truth for both local dev (`mix setup`) and the Docker build.
- Move `mix assets.setup` after `COPY assets assets` in the Dockerfile, since `npm ci` needs `assets/package.json` present.

## Verification

- `mix assets.setup` on a clean tree installs 12 packages including `posthog-js`.
- `mix assets.deploy` bundles successfully (`app.js` 382kb, includes posthog) and digests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)