### PR TITLE
fix(board): surface New Task validation errors instead of a bare flash

### DIFF
--- a/lib/camelot_web/live/board_live.ex
+++ b/lib/camelot_web/live/board_live.ex
@@ -8,6 +8,7 @@ defmodule CamelotWeb.BoardLive do
 
   import CamelotWeb.BoardComponents
 
+  alias AshPhoenix.Form
   alias Camelot.Agents.Agent
   alias Camelot.Board.Task
   alias Camelot.Projects.Project
@@ -16,6 +17,7 @@ defmodule CamelotWeb.BoardLive do
   alias Phoenix.LiveView.Socket
 
   require Ash.Query
+  require Logger
 
   @impl true
   @spec mount(map(), map(), Socket.t()) ::
@@ -27,7 +29,7 @@ defmodule CamelotWeb.BoardLive do
 
     socket =
       socket
-      |> assign(see_all: params["scope"] == "all")
+      |> assign(see_all: params["scope"] == "all", new_task_open?: false)
       |> load_board()
       |> allow_upload(:attachment, accept: :any, max_entries: 5, max_file_size: 25_000_000)
 
@@ -47,17 +49,20 @@ defmodule CamelotWeb.BoardLive do
   def handle_info(_msg, socket), do: {:noreply, socket}
 
   @impl true
-  @task_fields ~w(title description priority project_id agent_id)
-
-  def handle_event("validate_task", params, socket) do
-    {:noreply, assign(socket, task_form: to_form(Map.take(params, @task_fields)))}
+  def handle_event("open_new_task", _params, socket) do
+    {:noreply, assign(socket, new_task_open?: true)}
   end
 
-  def handle_event("create_task", params, socket) do
-    user = socket.assigns.current_user
-    task_params = Map.take(params, @task_fields)
+  def handle_event("close_new_task", _params, socket) do
+    {:noreply, assign(socket, new_task_open?: false)}
+  end
 
-    case Ash.create(Task, Map.put(task_params, "creator_id", user.id)) do
+  def handle_event("validate_task", %{"task" => params}, socket) do
+    {:noreply, assign(socket, task_form: Form.validate(socket.assigns.task_form, params))}
+  end
+
+  def handle_event("create_task", %{"task" => params}, socket) do
+    case Form.submit(socket.assigns.task_form, params: params) do
       {:ok, task} ->
         consume_uploaded_entries(socket, :attachment, fn %{path: tmp_path}, entry ->
           {:ok, TaskAttachments.store!(task.id, tmp_path, entry)}
@@ -67,11 +72,20 @@ defmodule CamelotWeb.BoardLive do
 
         {:noreply,
          socket
+         |> assign(
+           new_task_open?: false,
+           task_form: new_task_form(socket.assigns.current_user)
+         )
          |> put_flash(:info, "Task created")
          |> load_board()}
 
-      {:error, _changeset} ->
-        {:noreply, put_flash(socket, :error, "Failed to create task")}
+      {:error, form} ->
+        Logger.warning("Task creation failed: #{inspect(Form.errors(form, format: :simple))}")
+
+        {:noreply,
+         socket
+         |> assign(task_form: form)
+         |> put_flash(:error, "Failed to create task")}
     end
   end
 
@@ -129,21 +143,39 @@ defmodule CamelotWeb.BoardLive do
          end)}
       end)
 
-    assign(socket,
+    socket
+    |> assign(
       page_title: "Board",
       columns: columns,
       projects: projects,
-      agents: agents,
-      task_form:
-        to_form(%{
-          "title" => "",
-          "description" => "",
-          "priority" => "0",
-          "project_id" => "",
-          "agent_id" => ""
-        })
+      agents: agents
     )
+    |> assign_new(:task_form, fn -> new_task_form(user) end)
   end
+
+  @spec new_task_form(Camelot.Accounts.User.t()) :: Phoenix.HTML.Form.t()
+  defp new_task_form(user) do
+    Task
+    |> Form.for_create(:create,
+      as: "task",
+      actor: user,
+      forms: [auto?: false],
+      params: %{"priority" => "0"},
+      prepare_params: &drop_blank_priority/2,
+      prepare_source: &Ash.Changeset.set_argument(&1, :creator_id, user.id)
+    )
+    |> to_form()
+  end
+
+  # A cleared number input arrives as "", which would fail the
+  # non-nillable `priority` attribute instead of falling back to
+  # its default.
+  @spec drop_blank_priority(map(), atom()) :: map()
+  defp drop_blank_priority(%{"priority" => ""} = params, _type) do
+    Map.delete(params, "priority")
+  end
+
+  defp drop_blank_priority(params, _type), do: params
 
   defp broadcast_task_event(event, task) do
     Phoenix.PubSub.broadcast(
@@ -169,7 +201,7 @@ defmodule CamelotWeb.BoardLive do
           </button>
           <button
             class="btn btn-primary btn-sm"
-            phx-click={show_modal("new-task-modal")}
+            phx-click={show_modal("new-task-modal") |> JS.push("open_new_task")}
           >
             New Task
           </button>
@@ -190,15 +222,16 @@ defmodule CamelotWeb.BoardLive do
         </.column>
       </div>
 
-      <.modal id="new-task-modal">
+      <.modal
+        id="new-task-modal"
+        show={@new_task_open?}
+        on_cancel={hide_modal("new-task-modal") |> JS.push("close_new_task")}
+      >
         <h3 class="font-bold text-lg mb-4">New Task</h3>
         <.simple_form
           for={@task_form}
           phx-change="validate_task"
-          phx-submit={
-            hide_modal("new-task-modal")
-            |> JS.push("create_task")
-          }
+          phx-submit="create_task"
           id="new-task-form"
         >
           <.input
@@ -218,6 +251,7 @@ defmodule CamelotWeb.BoardLive do
             label="Project"
             prompt="Select project"
             options={Enum.map(@projects, &{&1.name, &1.id})}
+            required
           />
           <.input
             field={@task_form[:agent_id]}
@@ -225,6 +259,7 @@ defmodule CamelotWeb.BoardLive do
             label="CLI Agent"
             prompt="Select agent CLI"
             options={Enum.map(@agents, &{&1.name, &1.id})}
+            required
           />
           <.input
             field={@task_form[:priority]}

--- a/test/camelot_web/live/board_live_test.exs
+++ b/test/camelot_web/live/board_live_test.exs
@@ -38,21 +38,83 @@ defmodule CamelotWeb.BoardLiveTest do
 
     {:ok, view, _html} = live(conn, ~p"/")
 
+    render_click(view, "open_new_task")
+
     task_form =
       form(view, "#new-task-form", %{
-        "title" => "Write the plan",
-        "description" => "some details",
-        "project_id" => project.id,
-        "agent_id" => agent!("claude_code").id,
-        "priority" => "2"
+        "task" => %{
+          "title" => "Write the plan",
+          "description" => "some details",
+          "project_id" => project.id,
+          "agent_id" => agent!("claude_code").id,
+          "priority" => "2"
+        }
       })
 
     render_change(task_form)
-    render_submit(task_form)
+    html = render_submit(task_form)
 
     form_html = view |> element("#new-task-form") |> render()
     refute form_html =~ "Write the plan"
     refute form_html =~ "some details"
+    refute html =~ ~r/<dialog[^>]*id="new-task-modal"[^>]*\sopen/
+  end
+
+  test "New Task form reports missing project and agent inline", %{conn: conn} do
+    title = "missing-selects-#{System.unique_integer()}"
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    render_click(view, "open_new_task")
+
+    html =
+      view
+      |> form("#new-task-form", %{
+        "task" => %{
+          "title" => title,
+          "description" => "some details",
+          "project_id" => "",
+          "agent_id" => "",
+          "priority" => "2"
+        }
+      })
+      |> render_submit()
+
+    assert html =~ "is required"
+    assert html =~ ~r/<dialog[^>]*id="new-task-modal"[^>]*\sopen/
+    refute Task |> Ash.Query.filter(title == ^title) |> Ash.read_one!()
+  end
+
+  test "New Task form falls back to the default priority when it is cleared", %{
+    conn: conn,
+    user: user
+  } do
+    title = "blank-priority-#{System.unique_integer()}"
+
+    {:ok, project} =
+      Ash.create(
+        Project,
+        %{name: "p-#{System.unique_integer()}", path: "/tmp/prio"},
+        actor: user
+      )
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    render_click(view, "open_new_task")
+
+    view
+    |> form("#new-task-form", %{
+      "task" => %{
+        "title" => title,
+        "description" => "some details",
+        "project_id" => project.id,
+        "agent_id" => agent!("claude_code").id,
+        "priority" => ""
+      }
+    })
+    |> render_submit()
+
+    task = Task |> Ash.Query.filter(title == ^title) |> Ash.read_one!()
+    assert task.priority == 0
   end
 
   test "restart_task resets an errored task back to queued", %{conn: conn, user: user} do
@@ -113,11 +175,13 @@ defmodule CamelotWeb.BoardLiveTest do
 
       task_form =
         form(view, "#new-task-form", %{
-          "title" => title,
-          "description" => "some details",
-          "project_id" => project.id,
-          "agent_id" => agent!("claude_code").id,
-          "priority" => "2"
+          "task" => %{
+            "title" => title,
+            "description" => "some details",
+            "project_id" => project.id,
+            "agent_id" => agent!("claude_code").id,
+            "priority" => "2"
+          }
         })
 
       render_submit(task_form)
@@ -143,11 +207,13 @@ defmodule CamelotWeb.BoardLiveTest do
 
       task_form =
         form(view, "#new-task-form", %{
-          "title" => title,
-          "description" => "some details",
-          "project_id" => "",
-          "agent_id" => "",
-          "priority" => "2"
+          "task" => %{
+            "title" => title,
+            "description" => "some details",
+            "project_id" => "",
+            "agent_id" => "",
+            "priority" => "2"
+          }
         })
 
       render_submit(task_form)


### PR DESCRIPTION
## Problem

Creating a task on `test.camelotai.tech` failed with only a generic **"Failed to create task"** flash.

Investigating on the cluster showed the create action itself is healthy — a task was created and dispatched successfully minutes before. Probing `Camelot.Board.Task.create` directly on the running node (inside a rolled-back transaction) showed three inputs that fail:

| Submitted value | Result |
|---|---|
| all fields filled | `OK` |
| `project_id` = `""` | `Required{field: :project_id, type: :argument}` |
| `agent_id` = `""` | `Required{field: :agent_id, type: :argument}` |
| `priority` = `""` | `Required{field: :priority, type: :attribute}` |

Two defects made that invisible:

1. The Project and CLI Agent selects had no `required`, so the browser happily submitted `""` against arguments declared `allow_nil?(false)`.
2. The error branch discarded the changeset entirely — `{:error, _changeset} -> put_flash(...)` — so there were no field errors and nothing in the logs. 8h of production logs contained zero trace of the failure.

The modal also hid itself client-side from `phx-submit`, so inline errors could never have been seen anyway.

## Changes

- Build the New Task form with `AshPhoenix.Form` so Ash's errors render inline on the offending input.
- Mark the Project and CLI Agent selects `required`.
- Keep the modal open on failure — open state is now server-owned and closes only on success.
- Fall back to the default priority when the number input is cleared, instead of failing the non-nillable attribute.
- Log the changeset errors on failure, e.g. `Task creation failed: [agent_id: "is required", project_id: "is required"]`.
- `load_board/1` now uses `assign_new` for the form, so an unrelated board refresh no longer wipes in-progress input.

## Testing

- `mix test` — 628 tests, 0 failures (3 new board tests: inline errors + modal stays open, modal closes on success, cleared priority falls back to the default).
- `mix credo` — no issues. `mix dialyzer` — passed. `mix format --check-formatted` — clean.
- `mix phx.server` boots clean; `/` → 302, `/sign-in` → 200, no errors in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)