### PR TITLE
fix(board): distinguish tasks waiting for a runner slot from running ones

### DIFF
--- a/lib/camelot/board/task.ex
+++ b/lib/camelot/board/task.ex
@@ -195,6 +195,21 @@ defmodule Camelot.Board.Task do
     has_many(:attachments, Camelot.Board.TaskAttachment)
   end
 
+  aggregates do
+    exists :waiting_for_slot?, :sessions do
+      public?(true)
+      filter(expr(status == :queued))
+
+      description(
+        "True while one of this task's sessions sits in the " <>
+          "`Camelot.Runtime.RunnerPool` queue. Dispatch flips a task to " <>
+          "`:in_progress` before its session asks for a slot, so an " <>
+          "`:in_progress` task is not necessarily executing — it may be " <>
+          "waiting for its creator to drop under `per_user_max`."
+      )
+    end
+  end
+
   actions do
     defaults([:read, :destroy])
 

--- a/lib/camelot_web/components/board_components.ex
+++ b/lib/camelot_web/components/board_components.ex
@@ -66,7 +66,7 @@ defmodule CamelotWeb.BoardComponents do
           {@task.description}
         </p>
         <div class="flex items-center gap-2 mt-1">
-          <.state_badge :if={@task.state} state={@task.state} />
+          <.state_badge :if={@task.state} state={display_state(@task)} />
           <span
             :if={@task.pr_url}
             class="badge badge-xs badge-outline"
@@ -113,12 +113,23 @@ defmodule CamelotWeb.BoardComponents do
     """
   end
 
+  # A task is flipped to :in_progress at dispatch, before its session
+  # is granted a runner slot, so :in_progress alone would report a
+  # task as running while it is still queued in the RunnerPool.
+  defp display_state(%{state: :in_progress, waiting_for_slot?: true}) do
+    :waiting_for_slot
+  end
+
+  defp display_state(%{state: state}), do: state
+
   defp format_stage(stage) do
     stage
     |> Atom.to_string()
     |> String.replace("_", " ")
     |> String.capitalize()
   end
+
+  defp format_state(:waiting_for_slot), do: "Waiting for a runner slot"
 
   defp format_state(state) do
     state
@@ -136,12 +147,14 @@ defmodule CamelotWeb.BoardComponents do
   defp stage_badge_class(_stage), do: "badge-ghost"
 
   defp state_badge_class(:queued), do: "badge-ghost"
+  defp state_badge_class(:waiting_for_slot), do: "badge-ghost"
   defp state_badge_class(:in_progress), do: "badge-primary"
   defp state_badge_class(:waiting_for_input), do: "badge-warning"
   defp state_badge_class(:error), do: "badge-error"
   defp state_badge_class(_state), do: "badge-ghost"
 
   defp state_emoji(:queued), do: "⏳"
+  defp state_emoji(:waiting_for_slot), do: "⏳"
   defp state_emoji(:in_progress), do: "🔃"
   defp state_emoji(:waiting_for_input), do: "💬"
   defp state_emoji(:error), do: "⚠️"

--- a/lib/camelot_web/live/board_live.ex
+++ b/lib/camelot_web/live/board_live.ex
@@ -126,7 +126,7 @@ defmodule CamelotWeb.BoardLive do
     tasks =
       Task
       |> Scope.maybe_scope(user, see_all, &Scope.scope_tasks/2)
-      |> Ash.read!(load: [:project, :sessions])
+      |> Ash.read!(load: [:project, :waiting_for_slot?])
 
     projects =
       Project

--- a/test/camelot_web/components/board_components_test.exs
+++ b/test/camelot_web/components/board_components_test.exs
@@ -38,5 +38,71 @@ defmodule CamelotWeb.BoardComponentsTest do
       assert html =~ ~s(title="Error")
       assert html =~ "badge-error"
     end
+
+    test "renders the waiting_for_slot emoji with its own title" do
+      html =
+        render_component(&BoardComponents.state_badge/1, state: :waiting_for_slot)
+
+      assert html =~ "⏳"
+      assert html =~ ~s(title="Waiting for a runner slot")
+      assert html =~ "badge-ghost"
+    end
+  end
+
+  describe "task_card/1" do
+    defp task(attrs) do
+      Map.merge(
+        %{
+          id: "11111111-1111-1111-1111-111111111111",
+          title: "Some task",
+          description: nil,
+          state: :in_progress,
+          stage: :executing,
+          priority: 0,
+          pr_url: nil,
+          pr_number: nil,
+          last_error: nil,
+          waiting_for_slot?: false
+        },
+        attrs
+      )
+    end
+
+    test "shows the running badge for a task holding a runner slot" do
+      html = render_component(&BoardComponents.task_card/1, task: task(%{}))
+
+      assert html =~ "🔃"
+      assert html =~ ~s(title="In progress")
+    end
+
+    test "shows the waiting badge for a dispatched task with no runner slot" do
+      html =
+        render_component(&BoardComponents.task_card/1,
+          task: task(%{waiting_for_slot?: true})
+        )
+
+      assert html =~ "⏳"
+      assert html =~ ~s(title="Waiting for a runner slot")
+      refute html =~ "🔃"
+    end
+
+    test "ignores the waiting flag for a task that is not in progress" do
+      html =
+        render_component(&BoardComponents.task_card/1,
+          task: task(%{state: :waiting_for_input, waiting_for_slot?: true})
+        )
+
+      assert html =~ "💬"
+      refute html =~ "⏳"
+    end
+
+    test "falls back to the task state when the aggregate was not loaded" do
+      html =
+        render_component(&BoardComponents.task_card/1,
+          task: task(%{waiting_for_slot?: %Ash.NotLoaded{type: :aggregate}})
+        )
+
+      assert html =~ "🔃"
+    end
   end
 end

--- a/test/camelot_web/live/board_live_test.exs
+++ b/test/camelot_web/live/board_live_test.exs
@@ -3,6 +3,7 @@ defmodule CamelotWeb.BoardLiveTest do
 
   import Phoenix.LiveViewTest
 
+  alias Camelot.Agents.Session
   alias Camelot.Board.Task
   alias Camelot.Projects.Project
 
@@ -219,6 +220,69 @@ defmodule CamelotWeb.BoardLiveTest do
       render_submit(task_form)
 
       refute Task |> Ash.Query.filter(title == ^title) |> Ash.read_one!()
+    end
+  end
+
+  describe "runner slot badge" do
+    setup %{user: user} do
+      {:ok, project} =
+        Ash.create(
+          Project,
+          %{name: "slot-#{System.unique_integer()}", path: "/tmp/slot"},
+          actor: user
+        )
+
+      %{project: project}
+    end
+
+    test "a dispatched task waiting on a runner slot shows the waiting badge", %{
+      conn: conn,
+      user: user,
+      project: project
+    } do
+      task =
+        Ash.Seed.seed!(Task, %{
+          title: "waiting-task-#{System.unique_integer()}",
+          project_id: project.id,
+          creator_id: user.id,
+          agent_id: agent!("claude_code").id,
+          stage: :executing,
+          state: :in_progress
+        })
+
+      {:ok, _session} =
+        Ash.create(Session, %{agent_id: task.agent_id, task_id: task.id})
+
+      {:ok, _view, html} = live(conn, ~p"/")
+
+      assert html =~ "Waiting for a runner slot"
+    end
+
+    test "a task whose session is running shows the in progress badge", %{
+      conn: conn,
+      user: user,
+      project: project
+    } do
+      task =
+        Ash.Seed.seed!(Task, %{
+          title: "running-task-#{System.unique_integer()}",
+          project_id: project.id,
+          creator_id: user.id,
+          agent_id: agent!("claude_code").id,
+          stage: :executing,
+          state: :in_progress
+        })
+
+      Ash.Seed.seed!(Session, %{
+        agent_id: task.agent_id,
+        task_id: task.id,
+        status: :running
+      })
+
+      {:ok, _view, html} = live(conn, ~p"/")
+
+      refute html =~ "Waiting for a runner slot"
+      assert html =~ ~s(title="In progress")
     end
   end
 


### PR DESCRIPTION
## Problem

The board showed **3 running** tasks while Profile reported **2 running, 1 queued**.

Both were correct — they measure different things. Confirmed against test:

| Task | Board (`task.state`) | Session status |
|---|---|---|
| Fix and publish get started to docs | in_progress 🔃 | **running** |
| Add timestamps and other data | in_progress 🔃 | **running** |
| Branding | in_progress 🔃 | **queued** (`started_at` NULL, no runner) |

`dispatch_task/1` flips the task to `:in_progress` via `begin_work` *before* `TaskRunner.dispatch` hands its session to the pool (`lib/camelot/board/changes/dispatch_tasks.ex:52`). And `RunnerPool` deliberately admits everything:

> Sessions enqueue immediately and wait their turn — the pool never refuses a dispatch. Per-user and global caps control concurrency, not admission.

So with `RUNNER_PER_USER_MAX=2`, the third task sits in the queue while still rendering as running. The card had no way to know — it rendered `task.state` alone.

## Changes

- Add a `waiting_for_slot?` `exists` aggregate on `Task` (any session still `:queued`). Query-time subquery — `mix ash.codegen --check` confirms **no migration**.
- Render it as a distinct **"Waiting for a runner slot"** badge (⏳) instead of the running badge (🔃), so the board agrees with Profile's pool snapshot.
- Load that aggregate on the board **instead of `:sessions`** — which was loaded but never used anywhere in the board or its components. That pulled every session row, `output_log` included, into LiveView state for every card.

Only presentation changes; dispatch, pool behaviour and the caps are untouched.

## Testing

- `mix test` — **635 tests, 0 failures** (7 new: badge rendering incl. the not-loaded-aggregate fallback, plus LiveView tests covering a queued-session task and a running-session task).
- `mix credo` — no issues. `mix dialyzer` — passed. `mix format --check-formatted` — clean. `mix ash.codegen --check` — exit 0.
- `mix phx.server` boots clean, `/sign-in` → 200, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)