### PR TITLE
fix(runtime): rotate task secrets after clearing the stale service

### DIFF
--- a/docs/self-hosting/cluster-runners.md
+++ b/docs/self-hosting/cluster-runners.md
@@ -139,6 +139,16 @@ the every-minute dispatcher runs the task again from its current stage.
 | `RUNNER_MAX_INTERRUPT_REQUEUES` | 3 | Consecutive automatic re-queues before a task is errored instead. Reset on any forward progress, so only a task that can *never* run exhausts it. |
 | `RUNNER_REDEPLOY_WAIT_MS` | 60000 | How long a force-redeployed service has to produce a runnable replica before its runner is treated as lost. Raise it if your runner images are large and cold pulls are slow. |
 
+Re-running a task reuses its service name, and Swarm will not delete a
+secret that any service still references. Because a secret can only be
+rotated by deleting and recreating it, 🏰 Camelot AI removes the previous
+run's service *before* refreshing the task's secrets — otherwise the new
+runner would mount the old GitHub App installation token, which expires
+an hour after it is minted and shows up as
+`remote: Invalid username or token` from `git clone` at container boot.
+If you delete runner services by hand, delete the matching
+`camelot_task_<task-id>_gh_token` secret too.
+
 ## Runner networking
 
 A task-runner container joins the Swarm bridge network for outbound

--- a/lib/camelot/runtime/reconciler.ex
+++ b/lib/camelot/runtime/reconciler.ex
@@ -616,10 +616,29 @@ defmodule Camelot.Runtime.Reconciler do
 
     list_github_app_secret_task_ids()
     |> Enum.reject(&MapSet.member?(valid, &1))
-    |> Enum.each(fn task_id ->
-      Logger.info("Reconciler: removing orphan github_app_token secret for task #{task_id}")
-      delete_by_name(SecretSync.task_secret_name(task_id, :github_app_token))
-    end)
+    |> Enum.each(&delete_orphan_github_app_secret/1)
+  end
+
+  # `delete_by_name/1` speaks to `/services` — pointing it at a secret
+  # name deleted nothing and re-logged the same "removing orphan" line
+  # every tick, forever, while the secrets piled up. Secrets have their
+  # own endpoint, and their own reasons to refuse.
+  defp delete_orphan_github_app_secret(task_id) do
+    name = SecretSync.task_secret_name(task_id, :github_app_token)
+
+    case SecretSync.delete_secret_by_name(name) do
+      :ok ->
+        Logger.info(
+          "Reconciler: removed orphan github_app_token secret " <>
+            "for task #{task_id}"
+        )
+
+      {:error, reason} ->
+        Logger.warning(
+          "Reconciler: could not remove orphan github_app_token " <>
+            "secret for task #{task_id}: #{inspect(reason)}"
+        )
+    end
   end
 
   @github_app_secret_prefix "camelot_task_"

--- a/lib/camelot/runtime/runner/swarm/task_service.ex
+++ b/lib/camelot/runtime/runner/swarm/task_service.ex
@@ -43,6 +43,11 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
     "Delay" => 5_000_000_000
   }
 
+  # Bounded wait for Swarm to finish tearing a stale service down
+  # before its secrets can be rotated (~2s worst case).
+  @stale_service_attempts 8
+  @stale_service_poll_ms 250
+
   defstruct task_id: nil,
             spec: nil,
             service_id: nil,
@@ -321,6 +326,14 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
   # no-op unless a newer image really was published.
   defp create_service(task_id, %Spec{} = spec) do
     name = Spec.task_runner_name(task_id)
+
+    with :ok <- clear_stale_service(task_id, name),
+         :ok <- rotate_task_secrets(task_id, spec) do
+      post_create_named(task_id, name, spec)
+    end
+  end
+
+  defp post_create_named(task_id, name, spec) do
     payload = service_create_payload(pin_image(spec), name)
 
     case post_create(payload) do
@@ -340,6 +353,90 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
       {:error, _} = err ->
         err
     end
+  end
+
+  # Docker refuses to delete a secret while any service still
+  # references it, and a Swarm secret can only be rotated by
+  # delete-then-create. So a re-dispatch that finds the previous run's
+  # service still registered under this name cannot refresh the task's
+  # secrets — and a GitHub App installation token is dead an hour after
+  # it was minted, which the runner only discovers as a `git clone`
+  # 401 that kills the container at boot. Sweep the corpse first, then
+  # rotate, then build the payload that resolves the SecretIDs.
+  defp clear_stale_service(task_id, name) do
+    case fetch_service(name) do
+      {:error, :not_found} ->
+        :ok
+
+      _ ->
+        Logger.info(
+          "Swarm.TaskService #{task_id}: removing stale service " <>
+            "#{name} so its secrets can be rotated"
+        )
+
+        delete_service_by_name(name)
+        await_service_gone(name, @stale_service_attempts)
+    end
+  end
+
+  # `DELETE /services` returns before Swarm has released the service's
+  # hold on its secrets, so poll until the service is really gone.
+  # Bounded — give up and report rather than block the create forever.
+  defp await_service_gone(name, 0), do: {:error, {:stale_service_present, name}}
+
+  defp await_service_gone(name, attempts) do
+    case fetch_service(name) do
+      {:error, :not_found} ->
+        :ok
+
+      _ ->
+        Process.sleep(@stale_service_poll_ms)
+        await_service_gone(name, attempts - 1)
+    end
+  end
+
+  # Only the task's own secrets are rotated here. Per-user secrets are
+  # owned by `SecretSync.reconcile/2` and may legitimately be pinned by
+  # another task's live runner — not this task's problem, and unlike an
+  # installation token they do not expire on their own.
+  defp rotate_task_secrets(task_id, %Spec{} = spec) do
+    spec
+    |> task_scoped_secrets(task_id)
+    |> Enum.reduce_while(:ok, fn secret, _acc ->
+      case rotate_secret(secret) do
+        :ok -> {:cont, :ok}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp rotate_secret(%{kind: kind, name: name, value: value}) do
+    case SecretSync.put_secret(name, value) do
+      {:ok, _id} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "Swarm.TaskService: rotating #{name} failed " <>
+            "(#{inspect(reason)}); refusing to start a runner that " <>
+            "would mount a stale #{kind}"
+        )
+
+        {:error, {:secret_rotation_failed, name, reason}}
+    end
+  end
+
+  @doc false
+  # The secrets this task owns — the ones named after the task rather
+  # than after its user. Public (with `@doc false`) so the ownership
+  # rule is unit-testable without a Docker API.
+  @spec task_scoped_secrets(Spec.t(), String.t()) :: [Spec.secret()]
+  def task_scoped_secrets(%Spec{secrets: secrets}, task_id) do
+    Enum.filter(secrets, &task_scoped?(&1, task_id))
+  end
+
+  defp task_scoped?(%{kind: kind, name: name}, task_id) do
+    name == SecretSync.task_secret_name(task_id, kind)
   end
 
   defp pin_image(%Spec{image: image} = spec) do

--- a/lib/camelot/runtime/runner/swarm/task_service.ex
+++ b/lib/camelot/runtime/runner/swarm/task_service.ex
@@ -365,10 +365,7 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
   # rotate, then build the payload that resolves the SecretIDs.
   defp clear_stale_service(task_id, name) do
     case fetch_service(name) do
-      {:error, :not_found} ->
-        :ok
-
-      _ ->
+      {:ok, _service} ->
         Logger.info(
           "Swarm.TaskService #{task_id}: removing stale service " <>
             "#{name} so its secrets can be rotated"
@@ -376,6 +373,13 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskService do
 
         delete_service_by_name(name)
         await_service_gone(name, @stale_service_attempts)
+
+      # Absent, or a read we could not complete. Never delete a service
+      # we failed to look up: if one really is there, the create below
+      # still 409s onto the delete-and-retry path, and the rotation
+      # aborts loudly rather than us guessing against a blind Docker.
+      _ ->
+        :ok
     end
   end
 

--- a/lib/camelot/runtime/secret_sync.ex
+++ b/lib/camelot/runtime/secret_sync.ex
@@ -260,15 +260,27 @@ defmodule Camelot.Runtime.SecretSync do
     }
 
     case Req.post(DockerApi.request(), url: "/secrets/create", json: payload) do
-      {:ok, %Req.Response{status: status, body: %{"ID" => id}}}
-      when status in 200..299 ->
-        {:ok, id}
+      {:ok, %Req.Response{status: status, body: body}} when status in 200..299 ->
+        created_id(name, body)
 
       {:ok, resp} ->
         {:error, {:create_failed, resp.status, resp.body}}
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  # Docker answers a create with `201 {"ID" => …}`. Read the id back by
+  # name if the body ever arrives without one — a proxy that strips it
+  # must not turn a secret we did create into a rotation failure, which
+  # now aborts the runner that was waiting on it.
+  defp created_id(_name, %{"ID" => id}), do: {:ok, id}
+
+  defp created_id(name, body) do
+    case fetch_secret_by_name(name) do
+      {:ok, id} -> {:ok, id}
+      :error -> {:error, {:create_failed, :no_id_in_response, body}}
     end
   end
 

--- a/lib/camelot/runtime/secret_sync.ex
+++ b/lib/camelot/runtime/secret_sync.ex
@@ -7,10 +7,19 @@ defmodule Camelot.Runtime.SecretSync do
   can mount it at `/run/secrets/<kind>`.
 
   Swarm secrets are immutable, so "update" means
-  create-new / rotate-service-references / delete-old.
-  This GenServer owns that dance. For the LocalPort and
-  DockerEngine backends it's effectively a no-op —
-  those modes pass credentials via env vars.
+  delete-then-create under the same name. This GenServer
+  owns that dance. For the LocalPort and DockerEngine
+  backends it's effectively a no-op — those modes pass
+  credentials via env vars.
+
+  The delete half only succeeds while no service
+  references the secret, so a rotation can fail for
+  reasons that have nothing to do with the new value.
+  Every entry point therefore reports that failure
+  rather than returning a bare `:ok`: a caller that
+  assumes success would hand a runner the *previous*
+  value, which for a GitHub App installation token means
+  an hour-old, dead credential.
   """
   use GenServer
 
@@ -69,9 +78,38 @@ defmodule Camelot.Runtime.SecretSync do
   isn't tied to a `Credential` row, so callers minting a
   transient token (e.g. a GitHub App installation token)
   can publish it directly.
+
+  Returns the new secret's id, or `{:error, reason}` when the
+  rotation could not be completed. Callers must not treat an
+  error as harmless: Swarm secrets are immutable, so "replace"
+  is delete-then-create, and a rotation that fails leaves the
+  *previous* value in place for every service that mounts it.
   """
-  @spec put_secret(String.t(), String.t()) :: :ok
+  @spec put_secret(String.t(), String.t()) ::
+          {:ok, String.t()} | {:error, term()}
   def put_secret(name, value), do: upsert_secret(name, value)
+
+  @doc """
+  Removes the Swarm secret with the given name. Already-absent
+  counts as success; a Docker refusal (most often "secret is in
+  use by the following service") comes back as `{:error, _}`.
+  """
+  @spec delete_secret_by_name(String.t()) :: :ok | {:error, term()}
+  def delete_secret_by_name(name), do: delete_secret(name)
+
+  @doc false
+  # Classifies a Docker `DELETE /secrets/<id>` response. 404 counts as
+  # success — the secret is gone, which is all the caller wanted.
+  # Everything else non-2xx is a real failure, most importantly the 400
+  # Docker returns while a service still references the secret: that
+  # case used to be swallowed, so the create below failed with
+  # `AlreadyExists` and the runner mounted the previous, expired token.
+  # Public (with `@doc false`) so the rule is unit-testable without a
+  # Docker API.
+  @spec delete_result(pos_integer(), term()) :: :ok | {:error, term()}
+  def delete_result(status, _body) when status in 200..299, do: :ok
+  def delete_result(404, _body), do: :ok
+  def delete_result(status, body), do: {:error, {:delete_failed, status, body}}
 
   defp kind_suffix(:ssh_private_key), do: "ssh_pk"
   defp kind_suffix(:github_app_token), do: "gh_token"
@@ -162,12 +200,14 @@ defmodule Camelot.Runtime.SecretSync do
       |> Ash.Query.load(:value)
       |> Ash.read_first()
 
+    name = secret_name(user_id, kind)
+
     case cred do
       {:ok, nil} ->
-        delete_secret(secret_name(user_id, kind))
+        warn_on_failure(name, delete_secret(name))
 
       {:ok, %Credential{value: value}} when is_binary(value) ->
-        upsert_secret(secret_name(user_id, kind), value)
+        warn_on_failure(name, upsert_secret(name, value))
 
       {:ok, %Credential{value: nil}} ->
         Logger.warning(
@@ -184,14 +224,25 @@ defmodule Camelot.Runtime.SecretSync do
       :ok
   end
 
-  defp upsert_secret(name, value) do
-    case fetch_secret_by_name(name) do
-      {:ok, old_id} ->
-        delete_secret_by_id(old_id)
-        create_secret(name, value)
+  # A per-user credential rarely changes value, so a failed rotation
+  # here is worth a warning rather than a crash — but never silence.
+  # The fatal case is the per-task GitHub App token, whose caller
+  # (`Swarm.TaskService`) treats the same error as terminal.
+  defp warn_on_failure(_name, :ok), do: :ok
+  defp warn_on_failure(_name, {:ok, _id}), do: :ok
 
-      _ ->
-        create_secret(name, value)
+  defp warn_on_failure(name, {:error, reason}) do
+    Logger.warning(
+      "SecretSync: rotating #{name} failed (#{inspect(reason)}); " <>
+        "services mounting it keep the previous value"
+    )
+
+    :ok
+  end
+
+  defp upsert_secret(name, value) do
+    with :ok <- delete_secret(name) do
+      create_secret(name, value)
     end
   end
 
@@ -209,16 +260,15 @@ defmodule Camelot.Runtime.SecretSync do
     }
 
     case Req.post(DockerApi.request(), url: "/secrets/create", json: payload) do
-      {:ok, %Req.Response{status: status}} when status in 200..299 ->
-        :ok
+      {:ok, %Req.Response{status: status, body: %{"ID" => id}}}
+      when status in 200..299 ->
+        {:ok, id}
 
       {:ok, resp} ->
-        Logger.warning("SecretSync create #{name} failed: #{inspect(resp.body)}")
-        :ok
+        {:error, {:create_failed, resp.status, resp.body}}
 
       {:error, reason} ->
-        Logger.warning("SecretSync create #{name} failed: #{inspect(reason)}")
-        :ok
+        {:error, reason}
     end
   end
 
@@ -230,9 +280,14 @@ defmodule Camelot.Runtime.SecretSync do
   end
 
   defp delete_secret_by_id(id) do
-    Req.delete(DockerApi.request(), url: "/secrets/#{id}")
-    :ok
+    case Req.delete(DockerApi.request(), url: "/secrets/#{id}") do
+      {:ok, %Req.Response{status: status, body: body}} ->
+        delete_result(status, body)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   rescue
-    _ -> :ok
+    e -> {:error, Exception.message(e)}
   end
 end

--- a/lib/camelot/runtime/task_runner.ex
+++ b/lib/camelot/runtime/task_runner.ex
@@ -853,7 +853,7 @@ defmodule Camelot.Runtime.TaskRunner do
     case InstallationTokenCache.refresh(installation_id) do
       {:ok, token} ->
         name = github_app_token_secret_name(task_id)
-        publish_swarm_secret(name, token)
+        publish_swarm_secret(name, token, task_id)
         secrets ++ [%{kind: :github_app_token, name: name, value: token}]
 
       {:error, reason} ->
@@ -870,9 +870,21 @@ defmodule Camelot.Runtime.TaskRunner do
   defp github_app_token_secret_name(nil), do: "camelot_github_app_token"
   defp github_app_token_secret_name(task_id), do: SecretSync.task_secret_name(task_id, :github_app_token)
 
-  defp publish_swarm_secret(name, value) do
-    if Runner.backend() == Swarm, do: SecretSync.put_secret(name, value)
+  # On the Swarm backend a task's secret is published by
+  # `Swarm.TaskService`, which must do it *after* removing any stale
+  # service left under the task's name — Docker will not delete (and so
+  # cannot rotate) a secret a service still references. Publishing here
+  # too would just fail against that same stale service and log a
+  # misleading `AlreadyExists`. Sessions with no task id never reach
+  # TaskService, so they still publish from here.
+  defp publish_swarm_secret(name, value, nil) do
+    case Runner.backend() do
+      Swarm -> SecretSync.put_secret(name, value)
+      _ -> :ok
+    end
   end
+
+  defp publish_swarm_secret(_name, _value, _task_id), do: :ok
 
   defp fetch_credential(user_id, kind_atom, name \\ nil)
 

--- a/test/camelot/runtime/runner/swarm/task_service_test.exs
+++ b/test/camelot/runtime/runner/swarm/task_service_test.exs
@@ -27,6 +27,8 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskServiceTest do
     }
   end
 
+  defp secret(kind, name), do: %{kind: kind, name: name, value: "v"}
+
   describe "service_create_payload/2 — networks" do
     test "omits Networks when the list is empty" do
       put_networks([])
@@ -125,6 +127,47 @@ defmodule Camelot.Runtime.Runner.Swarm.TaskServiceTest do
 
       assert :unchanged =
                TaskService.plan_pinned_update(spec, "ghcr.io/acme/runner:latest@sha256:same", "sha256:same")
+    end
+  end
+
+  describe "task_scoped_secrets/2" do
+    test "picks the secrets named after the task" do
+      spec = %{
+        spec()
+        | secrets: [secret(:github_app_token, "camelot_task_task-1_gh_token")]
+      }
+
+      assert TaskService.task_scoped_secrets(spec, "task-1") == spec.secrets
+    end
+
+    test "leaves per-user secrets alone" do
+      # Rotating these from a task create would fail whenever another
+      # task's live runner pins them — not this task's problem, and
+      # they do not expire the way an installation token does.
+      spec = %{
+        spec()
+        | secrets: [
+            secret(:ssh_private_key, "camelot_user_user-1_ssh_pk"),
+            secret(:claude_api_key, "camelot_user_user-1_claude_api_key")
+          ]
+      }
+
+      assert TaskService.task_scoped_secrets(spec, "task-1") == []
+    end
+
+    test "ignores the env-only github_token_clear marker" do
+      spec = %{spec() | secrets: [secret(:github_token_clear, "")]}
+
+      assert TaskService.task_scoped_secrets(spec, "task-1") == []
+    end
+
+    test "ignores another task's secret" do
+      spec = %{
+        spec()
+        | secrets: [secret(:github_app_token, "camelot_task_task-2_gh_token")]
+      }
+
+      assert TaskService.task_scoped_secrets(spec, "task-1") == []
     end
   end
 end

--- a/test/camelot/runtime/secret_sync_test.exs
+++ b/test/camelot/runtime/secret_sync_test.exs
@@ -18,4 +18,28 @@ defmodule Camelot.Runtime.SecretSyncTest do
       assert SecretSync.task_secret_name("task-1", :github_app_token) == "camelot_task_task-1_gh_token"
     end
   end
+
+  describe "delete_result/2" do
+    test "a 2xx delete succeeds" do
+      assert SecretSync.delete_result(200, %{}) == :ok
+      assert SecretSync.delete_result(204, %{}) == :ok
+    end
+
+    test "an already-absent secret counts as deleted" do
+      assert SecretSync.delete_result(404, %{"message" => "no such secret"}) == :ok
+    end
+
+    test "an in-use secret is an error, not a silent no-op" do
+      # The regression: Docker refuses to delete a secret while a
+      # service still references it. Swallowing that left the previous
+      # (expired) value mounted on the next runner.
+      body = %{"message" => "secret is in use by the following service: camelot-task-x"}
+
+      assert SecretSync.delete_result(400, body) == {:error, {:delete_failed, 400, body}}
+    end
+
+    test "any other non-2xx is an error" do
+      assert SecretSync.delete_result(500, %{}) == {:error, {:delete_failed, 500, %{}}}
+    end
+  end
 end


### PR DESCRIPTION
## The bug

Task [b2541932](https://app.camelotai.tech/tasks/b2541932-1c1f-4da5-8385-a5a6be9d1ebe) sat in a dispatch → crash → retry loop in production. Its runner died at boot:

```
[entrypoint] cloning git@github.com:rollhub-tech/teek.git into /workspace
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed
```

`entrypoint.sh` runs `set -euo pipefail`, so the container exited 128 before `mark_ready`. Every exec into it then came back `409 container is not running`, which the app reports as `runner died without sending exit`.

## Root cause

The runner was handed a **two-day-old GitHub App installation token**. They expire after an hour.

```
camelot_task_b2541932-…_gh_token :: created 2 days ago :: updated 2 days ago
```

Swarm secrets are immutable, so `SecretSync.upsert_secret/2` rotates by delete-then-create. Docker refuses to delete a secret while any service references it — and on a re-dispatch the previous run's service is still registered under the task's name. Both failures were swallowed:

- `delete_secret_by_id/1` ignored the response status and returned `:ok` unconditionally
- `create_secret/2` logged the resulting `AlreadyExists` as a warning and also returned `:ok`

So the payload resolved the *old* SecretID and mounted a dead token.

The ordering made it unrecoverable: `create_service/1` built the full payload — SecretID lookup included — *before* discovering the name conflict and deleting the stale service.

Confirmation from prod: at boot reconcile exactly three secrets failed to rotate, and they are exactly the three the lingering service referenced. Every other secret rotated fine in the same pass.

```
docker service inspect camelot-task-b2541932… → Secrets:
  camelot_user_815bcb7e…_claude_api_key   (6 days old — rotation failed)
  camelot_user_815bcb7e…_ssh_pk           (6 days old — rotation failed)
  camelot_task_b2541932…_gh_token         (2 days old — rotation failed)
```

### Why it surfaced now

#129 changed deploy-interrupted runs from *erroring the card* to *re-queueing* it. That re-dispatch path was always broken, but nothing used to exercise it.

## The fix

- `SecretSync.put_secret/2` returns `{:ok, id} | {:error, reason}`. `delete_result/2` classifies the Docker DELETE — 404 is success, an in-use 400 is not. Per-user rotations warn rather than going quiet.
- `Swarm.TaskService` clears any stale service under the task's name, waits (bounded, ~2s) for Swarm to release its hold, rotates the task's own secrets, and only then builds the payload. A rotation that still fails aborts the create instead of starting a runner with a dead credential.
- Only *task-scoped* secrets are rotated here. Per-user secrets belong to `SecretSync.reconcile/2` and may legitimately be pinned by another task's live runner.
- `TaskRunner` no longer double-publishes on the Swarm path, where the publish was guaranteed to hit that same stale service and log a misleading `AlreadyExists`.

## Second bug, also fixed

`Reconciler.sweep_orphan_github_app_secrets/0` passed a **secret** name to `delete_by_name/1`, which deletes a **service** (`DELETE /services/<name>`). It removed nothing, re-logged the same two lines every 60s forever, and leaked one secret per finished task:

```
07:04:26 Reconciler: removing orphan github_app_token secret for task 9289a4e5…   (still present, 4 weeks old)
07:04:26 Reconciler: removing orphan github_app_token secret for task 30cf32e8…   (still present, 9 days old)
```

Now uses `SecretSync.delete_secret_by_name/1`, and only claims success when the secret actually went away.

## Tests

New unit coverage on the two pure seams, in the codebase's existing `@doc false` style:

- `SecretSync.delete_result/2` — 2xx and 404 succeed; an in-use 400 is an error, not a silent no-op
- `TaskService.task_scoped_secrets/2` — picks the task's own secrets, leaves per-user ones and the `:github_token_clear` marker alone

## Checks

`mix compile --warnings-as-errors`, `mix test` (729 tests, 0 failures), `mix credo --strict` (no issues), `mix dialyzer` (clean), `mix format`, app boots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)