### PR TITLE
feat(web): Ahrefs Web Analytics in app and docs (prod only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ Follow the [Elixir Style Guide](https://github.com/christopheradams/elixir_style
 - Use `mix precommit` alias when you are done with all changes and fix any pending issues
 - Use the already included `:req` (`Req`) library for HTTP requests
 - `POSTHOG_API_KEY` / `POSTHOG_API_HOST` drive both server-side capture (`Camelot.Telemetry.PostHogHandler`) and browser-side capture (`CamelotWeb.PostHogConfig`, `posthog-js` in `assets/js/app.js`) — both are disabled unless the key is set
+- `AHREFS_ANALYTICS_KEY` renders the Ahrefs Web Analytics snippet in the app and docs layouts (`CamelotWeb.AhrefsConfig`) — set it on the production app only, since the test cluster runs the same `MIX_ENV=prod` release
 
 ### Phoenix v1.8 Guidelines
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -37,6 +37,10 @@ config :camelot, Oban,
   queues: [default: 10, tasks: 5, github: 3, notifications: 5],
   plugins: [{Oban.Plugins.Cron, crontab: []}]
 
+# Ahrefs Web Analytics is production-only — the snippet is rendered only
+# when AHREFS_ANALYTICS_KEY is supplied at runtime (see config/runtime.exs).
+config :camelot, :ahrefs, key: nil
+
 # Attachment store for task file uploads. Overridden in
 # config/runtime.exs alongside the runner backend. Dev/test default
 # to Local (a temp directory), matching the LocalPort runner default.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -136,6 +136,13 @@ if posthog_api_key = System.get_env("POSTHOG_API_KEY") do
     api_host: System.get_env("POSTHOG_API_HOST", "https://us.i.posthog.com")
 end
 
+# Ahrefs Web Analytics. Set AHREFS_ANALYTICS_KEY on the production app
+# only: the test cluster runs the same MIX_ENV=prod release, so leaving
+# the var unset there is what keeps its traffic out of the report.
+if ahrefs_key = System.get_env("AHREFS_ANALYTICS_KEY") do
+  config :camelot, :ahrefs, key: ahrefs_key
+end
+
 # DATABASE_URL is required in prod (below) but only an optional override
 # in dev/test, where config/dev.exs and config/test.exs already set up a
 # working default. When set, the parsed URL fields take precedence over

--- a/lib/camelot_web/ahrefs_config.ex
+++ b/lib/camelot_web/ahrefs_config.ex
@@ -1,0 +1,17 @@
+defmodule CamelotWeb.AhrefsConfig do
+  @moduledoc """
+  Exposes the Ahrefs Web Analytics site key to the page layouts.
+
+  Ahrefs is a production-only concern: both the app and the docs site
+  render its snippet only when a site key is configured via
+  `AHREFS_ANALYTICS_KEY` at runtime (see `config/runtime.exs`). Test and
+  dev deployments run the same `MIX_ENV=prod` release, so the env var —
+  not `config_env/0` — is what keeps their traffic out of the report.
+  """
+
+  @doc """
+  The configured Ahrefs site key, or `nil` when analytics is disabled.
+  """
+  @spec key() :: String.t() | nil
+  def key, do: Application.get_env(:camelot, :ahrefs, [])[:key]
+end

--- a/lib/camelot_web/components/layouts/docs_root.html.heex
+++ b/lib/camelot_web/components/layouts/docs_root.html.heex
@@ -24,6 +24,13 @@
       data-distinct-id={config.distinct_id}
       data-email={config.email}
     />
+    <script
+      :if={ahrefs_key = CamelotWeb.AhrefsConfig.key()}
+      src="https://analytics.ahrefs.com/analytics.js"
+      data-key={ahrefs_key}
+      async
+    >
+    </script>
     <script>
       (() => {
         const setTheme = (theme) => {

--- a/lib/camelot_web/components/layouts/root.html.heex
+++ b/lib/camelot_web/components/layouts/root.html.heex
@@ -30,6 +30,13 @@
       data-distinct-id={config.distinct_id}
       data-email={config.email}
     />
+    <script
+      :if={ahrefs_key = CamelotWeb.AhrefsConfig.key()}
+      src="https://analytics.ahrefs.com/analytics.js"
+      data-key={ahrefs_key}
+      async
+    >
+    </script>
     <script defer phx-track-static type="text/javascript" src={~p"/assets/js/app.js"}>
     </script>
     <script>

--- a/test/camelot_web/ahrefs_config_test.exs
+++ b/test/camelot_web/ahrefs_config_test.exs
@@ -1,0 +1,69 @@
+defmodule CamelotWeb.AhrefsConfigTest do
+  use CamelotWeb.ConnCase, async: false
+
+  alias CamelotWeb.AhrefsConfig
+
+  @snippet_src "https://analytics.ahrefs.com/analytics.js"
+
+  setup do
+    ahrefs = Application.get_env(:camelot, :ahrefs)
+
+    on_exit(fn -> Application.put_env(:camelot, :ahrefs, ahrefs) end)
+
+    :ok
+  end
+
+  defp put_key(key), do: Application.put_env(:camelot, :ahrefs, key: key)
+
+  describe "key/0" do
+    test "returns nil when no site key is configured" do
+      put_key(nil)
+
+      assert AhrefsConfig.key() == nil
+    end
+
+    test "returns the configured site key" do
+      put_key("test-site-key")
+
+      assert AhrefsConfig.key() == "test-site-key"
+    end
+  end
+
+  describe "app layout" do
+    test "omits the snippet when no site key is configured", %{conn: conn} do
+      put_key(nil)
+
+      refute conn |> get(~p"/sign-in") |> html_response(200) =~ @snippet_src
+    end
+
+    test "renders the snippet with the configured key", %{conn: conn} do
+      put_key("test-site-key")
+
+      body = conn |> get(~p"/sign-in") |> html_response(200)
+
+      assert body =~ @snippet_src
+      assert body =~ ~s(data-key="test-site-key")
+    end
+  end
+
+  describe "docs layout" do
+    setup %{conn: conn} do
+      {:ok, conn: %{conn | host: "docs.localhost"}}
+    end
+
+    test "omits the snippet when no site key is configured", %{conn: conn} do
+      put_key(nil)
+
+      refute conn |> get("/") |> html_response(200) =~ @snippet_src
+    end
+
+    test "renders the snippet with the configured key", %{conn: conn} do
+      put_key("test-site-key")
+
+      body = conn |> get("/") |> html_response(200)
+
+      assert body =~ @snippet_src
+      assert body =~ ~s(data-key="test-site-key")
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds the Ahrefs Web Analytics snippet to both page layouts:

- `lib/camelot_web/components/layouts/root.html.heex` — the app
- `lib/camelot_web/components/layouts/docs_root.html.heex` — the public docs site (prod docs are served directly by this app via CloudFront)

## Prod-only gating

Both test and prod run the same `MIX_ENV=prod` release, so `config_env/0` can't tell them apart. Instead the snippet renders only when `AHREFS_ANALYTICS_KEY` is set at runtime (`CamelotWeb.AhrefsConfig`), mirroring how `POSTHOG_API_KEY` gates PostHog. Leaving the var unset on test/dev keeps their traffic out of the report.

**Deploy step:** set on the *production* CapRover app only:

```
AHREFS_ANALYTICS_KEY=tAw1I5zvk4g/kSLGBfTeZg
```

## Notes

- The site key is not baked into the repo — it lives in prod app config, so analytics can be turned off by unsetting the var without a deploy of code.
- Ahrefs' loader reads `data-key` off its own `<script>` tag, so it can't be bundled into `app.js`; the external `src` matches how the Google Fonts stylesheet is already loaded in these layouts.

## Verification

- `mix test` — 735 tests, 0 failures (6 new in `test/camelot_web/ahrefs_config_test.exs` covering key config plus presence/absence of the snippet in both layouts)
- `mix compile --force --warnings-as-errors`, `mix credo --strict`, `mix dialyzer`, `mix format --check-formatted` — all clean
- Ran `mix phx.server` with and without the env var and curled `/sign-in` and the docs host: snippet present with the real key when set, absent when unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)