### PR TITLE
fix(runtime): stop stamping successful sessions with a failure message

### DIFF
--- a/lib/camelot/runtime/task_runner.ex
+++ b/lib/camelot/runtime/task_runner.ex
@@ -942,9 +942,12 @@ defmodule Camelot.Runtime.TaskRunner do
     end
   end
 
+  # `reason` is never nil: both callers pass a built message, and
+  # `parsed_error/1` falls back to `@unexplained_failure` rather than
+  # returning nil, so an error card always carries an explanation.
   defp mark_task_error(task_id, reason) do
     task = Ash.get!(Task, task_id)
-    transition(task, :mark_error, %{last_error: reason || @unexplained_failure})
+    transition(task, :mark_error, %{last_error: reason})
   end
 
   # Variant used by paths where the CLI exited cleanly but the
@@ -1411,7 +1414,7 @@ defmodule Camelot.Runtime.TaskRunner do
            %{
              output_log: state.output_buffer,
              exit_code: exit_code,
-             error_message: parsed_error(parsed),
+             error_message: session_error(exit_code, parsed),
              permission_denials: denials,
              cost_usd: parsed_field(parsed, :cost_usd),
              duration_ms: parsed_field(parsed, :duration_ms),
@@ -1449,6 +1452,17 @@ defmodule Camelot.Runtime.TaskRunner do
   # Never nil: a non-zero exit with a parsable-but-resultless buffer
   # would otherwise produce an error card with no explanation at all.
   defp parsed_error(_parsed), do: @unexplained_failure
+
+  # Session-level variant of `parsed_error/1`. The fallback above is a
+  # statement about the *exit status*, so it must never be written for a
+  # clean exit — doing so stamped every successful session with a
+  # "non-zero status" error the task page then rendered. A clean exit
+  # whose buffer would not parse still reaches the card through
+  # `mark_task_error/2`, so nothing is lost by leaving the row nil.
+  @spec session_error(integer(), term()) :: String.t() | nil
+  defp session_error(0, _parsed), do: nil
+  defp session_error(_exit_code, {:error, msg}), do: msg
+  defp session_error(_exit_code, _parsed), do: @unexplained_failure
 
   defp parsed_field({:ok, parsed}, key), do: Map.get(parsed, key)
   defp parsed_field(_parsed, _key), do: nil

--- a/test/camelot/runtime/task_runner_test.exs
+++ b/test/camelot/runtime/task_runner_test.exs
@@ -566,6 +566,67 @@ defmodule Camelot.Runtime.TaskRunnerTest do
       assert reloaded.duration_api_ms == 5000
       assert reloaded.num_turns == 7
       assert reloaded.usage == %{"input_tokens" => 200, "output_tokens" => 80}
+      assert is_nil(reloaded.error_message)
+    end
+
+    test "leaves no error message on a clean exit with an unparsable buffer", ctx do
+      {:ok, session} =
+        Ash.create(Session, %{
+          agent_id: ctx.task.agent_id,
+          task_id: ctx.task.id
+        })
+
+      state = %TaskRunner{
+        task_id: ctx.task.id,
+        current_session_id: session.id,
+        output_buffer: ""
+      }
+
+      assert :ok = TaskRunner.finish_session(state, 0, {:error, "empty output"}, [])
+
+      reloaded = Ash.get!(Session, session.id)
+      assert reloaded.status == :completed
+      assert is_nil(reloaded.error_message)
+    end
+
+    test "records the parsed reason on a non-zero exit", ctx do
+      {:ok, session} =
+        Ash.create(Session, %{
+          agent_id: ctx.task.agent_id,
+          task_id: ctx.task.id
+        })
+
+      state = %TaskRunner{
+        task_id: ctx.task.id,
+        current_session_id: session.id,
+        output_buffer: "boom"
+      }
+
+      assert :ok = TaskRunner.finish_session(state, 1, {:error, "runner died"}, [])
+
+      reloaded = Ash.get!(Session, session.id)
+      assert reloaded.status == :failed
+      assert reloaded.error_message == "runner died"
+    end
+
+    test "falls back to a generic reason on a non-zero exit with no parsed error", ctx do
+      {:ok, session} =
+        Ash.create(Session, %{
+          agent_id: ctx.task.agent_id,
+          task_id: ctx.task.id
+        })
+
+      state = %TaskRunner{
+        task_id: ctx.task.id,
+        current_session_id: session.id,
+        output_buffer: "partial"
+      }
+
+      assert :ok = TaskRunner.finish_session(state, 1, nil, [])
+
+      reloaded = Ash.get!(Session, session.id)
+      assert reloaded.status == :failed
+      assert reloaded.error_message =~ "non-zero status"
     end
   end
 


### PR DESCRIPTION
## Problem

Every session finished since `dd98441` deployed carries

> The runner exited with a non-zero status without reporting a reason.

**including clean, successful ones.** `task_live.ex:708` renders `session.error_message` with no status guard, so a run that exited 0 with 188 turns and \$9.41 of real work shows a red error box.

Observed on prod task `b2541932-1c1f-4da5-8385-a5a6be9d1ebe` — the three most recent sessions are all `status=completed exit=0` with real turn counts and spend, and all three carry the message. The two sessions predating the deploy have `error_message = nil`, which pins the regression to that change.

## Cause

`dd98441` gave `parsed_error/1` a catch-all so a *failed* run could never produce a message-less error card:

```elixir
defp parsed_error({:error, msg}), do: msg
defp parsed_error(_parsed), do: @unexplained_failure
```

There is no `{:ok, _}` clause, and `finish_session/5` called it unconditionally without consulting `exit_code`. The fallback is a statement about the exit status, so writing it on a clean exit is always wrong.

## Fix

`session_error/2` takes the exit code into account:

```elixir
defp session_error(0, _parsed), do: nil
defp session_error(_exit_code, {:error, msg}), do: msg
defp session_error(_exit_code, _parsed), do: @unexplained_failure
```

`parsed_error/1` is untouched for the `mark_task_error/2` path, which still needs the non-nil guarantee. A clean exit whose buffer would not parse (`{:error, "empty output"}`, `"claude error: …"`) still reaches the card through `mark_task_error/2` at line 383, so nothing is lost by leaving the session row nil.

With the success path no longer routed through `parsed_error/1`, its inferred return narrows to a plain binary and dialyzer proves the `reason || @unexplained_failure` fallback in `mark_task_error/2` dead — dropped, since both callers already pass a built message.

## Tests

The existing success-path test asserted cost/duration/turns/usage but never `error_message`, which is how this slipped through. Added there, plus three cases covering the clean-exit-unparsable, non-zero-with-reason, and non-zero-fallback paths.

- `mix test` — 738 tests, 0 failures
- `mix compile --warnings-as-errors` — clean
- `mix dialyzer` — clean (3 pre-existing skips)
- `mix credo --strict` — no issues

## Follow-up (not in this PR)

Existing rows keep the stale message; a backfill of `error_message = NULL WHERE status = 'completed' AND exit_code = 0` is needed for cards already on the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)