### PR TITLE
fix(oban): rescue orphaned jobs; stop background loops on archived projects

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -32,10 +32,26 @@ config :camelot, CamelotWeb.Endpoint,
   pubsub_server: Camelot.PubSub,
   live_view: [signing_salt: "VZXwbZtB"]
 
+# Lifeline is not optional here. AshOban gives every scheduled action
+# `unique: [period: :infinity, states: :incomplete]`, so a single job
+# left in `executing` by a node that died blocks that worker from ever
+# being enqueued again — silently, forever. That is exactly how GitHub
+# issue sync died on the test cluster (orphan from 2026-07-01, no sync
+# for two months). Pruner keeps the table from growing without bound;
+# it had reached 300k rows / 172MB on a 1GB node.
+#
+# 30 minutes is far above any job's real runtime — every Oban job here
+# returns promptly (dispatch hands off to a `TaskRunner` process, the
+# rest are single HTTP round trips), so Lifeline can only ever catch a
+# genuine orphan.
 config :camelot, Oban,
   repo: Camelot.Repo,
   queues: [default: 10, tasks: 5, github: 3, notifications: 5],
-  plugins: [{Oban.Plugins.Cron, crontab: []}]
+  plugins: [
+    {Oban.Plugins.Cron, crontab: []},
+    {Oban.Plugins.Lifeline, rescue_after: to_timeout(minute: 30)},
+    {Oban.Plugins.Pruner, max_age: 7 * 24 * 60 * 60}
+  ]
 
 # Ahrefs Web Analytics is production-only — the snippet is rendered only
 # when AHREFS_ANALYTICS_KEY is supplied at runtime (see config/runtime.exs).

--- a/config/config.exs
+++ b/config/config.exs
@@ -43,7 +43,14 @@ config :camelot, CamelotWeb.Endpoint,
 # 30 minutes is far above any job's real runtime — every Oban job here
 # returns promptly (dispatch hands off to a `TaskRunner` process, the
 # rest are single HTTP round trips), so Lifeline can only ever catch a
-# genuine orphan.
+# genuine orphan. Keep it that way: a job that can legitimately run
+# past `rescue_after` will be rescued out from under itself, so put
+# long work in a supervised process and raise this window if that ever
+# stops being true.
+#
+# Pruner's `max_age` is in SECONDS, unlike Lifeline's `rescue_after`,
+# which is milliseconds — hence the bare arithmetic rather than
+# `to_timeout/1`.
 config :camelot, Oban,
   repo: Camelot.Repo,
   queues: [default: 10, tasks: 5, github: 3, notifications: 5],

--- a/lib/camelot/board/changes/dispatch_tasks.ex
+++ b/lib/camelot/board/changes/dispatch_tasks.ex
@@ -46,7 +46,12 @@ defmodule Camelot.Board.Changes.DispatchTasks do
 
   @doc """
   True when `task` is waiting for an agent and its project is still
-  active. Requires `:project` to be loaded.
+  active.
+
+  `:project` must be loaded. An `%Ash.NotLoaded{}` project reads as
+  inactive and the task is skipped rather than dispatched blind, so a
+  dropped preload would show up as tasks sitting queued — check the
+  load list in `dispatchable_tasks/0` before suspecting the gate.
   """
   @spec dispatchable?(Task.t()) :: boolean()
   def dispatchable?(%Task{state: :queued, stage: stage, project: project}) when stage in @dispatchable_stages do

--- a/lib/camelot/board/changes/dispatch_tasks.ex
+++ b/lib/camelot/board/changes/dispatch_tasks.ex
@@ -12,6 +12,7 @@ defmodule Camelot.Board.Changes.DispatchTasks do
 
   alias Camelot.Board.PromptBuilder
   alias Camelot.Board.Task
+  alias Camelot.Projects.Project
   alias Camelot.Runtime.TaskRegistry
   alias Camelot.Runtime.TaskRunner
   alias Camelot.Runtime.TaskRunnerSupervisor
@@ -40,10 +41,19 @@ defmodule Camelot.Board.Changes.DispatchTasks do
       load: [:messages, :attachments, :project, creator: [:github_installations]],
       authorize?: false
     )
-    |> Enum.filter(fn task ->
-      task.state == :queued and task.stage in @dispatchable_stages
-    end)
+    |> Enum.filter(&dispatchable?/1)
   end
+
+  @doc """
+  True when `task` is waiting for an agent and its project is still
+  active. Requires `:project` to be loaded.
+  """
+  @spec dispatchable?(Task.t()) :: boolean()
+  def dispatchable?(%Task{state: :queued, stage: stage, project: project}) when stage in @dispatchable_stages do
+    Project.active?(project)
+  end
+
+  def dispatchable?(%Task{}), do: false
 
   defp dispatch_task(task) do
     case Ash.update(task, %{}, action: :begin_work) do

--- a/lib/camelot/board/task.ex
+++ b/lib/camelot/board/task.ex
@@ -59,7 +59,8 @@ defmodule Camelot.Board.Task do
         where(
           expr(
             not is_nil(pr_number) and
-              stage == :pr
+              stage == :pr and
+              project.status == :active
           )
         )
       end

--- a/lib/camelot/projects/changes/sync_github_issues.ex
+++ b/lib/camelot/projects/changes/sync_github_issues.ex
@@ -24,17 +24,26 @@ defmodule Camelot.Projects.Changes.SyncGithubIssues do
           Ash.Resource.Actions.Implementation.Context.t()
         ) :: :ok
   def run(_input, _opts, _context) do
-    Enum.each(projects_with_github(), &sync_project_issues/1)
+    Enum.each(syncable_projects(), &sync_project_issues/1)
     :ok
   end
 
-  defp projects_with_github do
+  defp syncable_projects do
     Project
     |> Ash.read!(load: [owner_membership: [user: [:github_installations]]], authorize?: false)
-    |> Enum.filter(fn p ->
-      p.github_owner && p.github_repo && p.owner_membership
-    end)
+    |> Enum.filter(&syncable?/1)
   end
+
+  @doc """
+  True when `project` should have its GitHub issues imported: it is
+  active, points at a repository, and has an owner whose installation
+  can be used to talk to GitHub.
+  """
+  @spec syncable?(Project.t()) :: boolean()
+  def syncable?(%Project{github_owner: nil}), do: false
+  def syncable?(%Project{github_repo: nil}), do: false
+  def syncable?(%Project{owner_membership: nil}), do: false
+  def syncable?(%Project{} = project), do: Project.active?(project)
 
   defp sync_project_issues(project) do
     case Client.list_issues(

--- a/lib/camelot/projects/project.ex
+++ b/lib/camelot/projects/project.ex
@@ -232,4 +232,18 @@ defmodule Camelot.Projects.Project do
       run(Camelot.Projects.Changes.SyncGithubIssues)
     end
   end
+
+  @doc """
+  True when the project has not been archived.
+
+  Archiving is the switch that takes a project out of every background
+  loop — issue sync, task dispatch and PR polling all consult this.
+
+  Matching the bare map rather than `%__MODULE__{}` is deliberate: Ash
+  defines the struct in a transformer that has not run yet at this
+  point in the module body.
+  """
+  @spec active?(t() | nil) :: boolean()
+  def active?(%{status: :active}), do: true
+  def active?(_project), do: false
 end

--- a/lib/camelot/projects/project.ex
+++ b/lib/camelot/projects/project.ex
@@ -242,6 +242,12 @@ defmodule Camelot.Projects.Project do
   Matching the bare map rather than `%__MODULE__{}` is deliberate: Ash
   defines the struct in a transformer that has not run yet at this
   point in the module body.
+
+  Anything that is not a project carrying `status: :active` — `nil`, an
+  unloaded relationship, a record read with `status` deselected — is
+  reported as inactive. Failing closed is the safe direction here: the
+  cost is a background loop skipping a project, not one running against
+  an archived board.
   """
   @spec active?(t() | nil) :: boolean()
   def active?(%{status: :active}), do: true

--- a/test/camelot/board/changes/dispatch_tasks_test.exs
+++ b/test/camelot/board/changes/dispatch_tasks_test.exs
@@ -1,0 +1,44 @@
+defmodule Camelot.Board.Changes.DispatchTasksTest do
+  use ExUnit.Case, async: true
+
+  alias Camelot.Board.Changes.DispatchTasks
+  alias Camelot.Board.Task
+  alias Camelot.Projects.Project
+
+  defp task(attrs) do
+    defaults = %{
+      state: :queued,
+      stage: :todo,
+      project: %Project{status: :active}
+    }
+
+    struct!(Task, Map.merge(defaults, attrs))
+  end
+
+  describe "dispatchable?/1" do
+    test "a queued task in a dispatchable stage dispatches" do
+      for stage <- [:todo, :planning, :executing, :pr] do
+        assert DispatchTasks.dispatchable?(task(%{stage: stage}))
+      end
+    end
+
+    test "a task that is not queued does not dispatch" do
+      for state <- [:in_progress, :waiting_for_input, :error] do
+        refute DispatchTasks.dispatchable?(task(%{state: state}))
+      end
+    end
+
+    test "a task outside the dispatchable stages does not dispatch" do
+      for stage <- [:draft, :done, :cancelled] do
+        refute DispatchTasks.dispatchable?(task(%{stage: stage}))
+      end
+    end
+
+    test "a task in an archived project does not dispatch" do
+      # Archiving a project has to stop its agents; otherwise the
+      # every-minute dispatcher keeps burning runner slots on a board
+      # that has been retired.
+      refute DispatchTasks.dispatchable?(task(%{project: %Project{status: :archived}}))
+    end
+  end
+end

--- a/test/camelot/board/task_test.exs
+++ b/test/camelot/board/task_test.exs
@@ -726,4 +726,44 @@ defmodule Camelot.Board.TaskTest do
       )
     end
   end
+
+  describe "check_pr_status trigger scope" do
+    # The trigger's `where` is what AshOban runs to decide which tasks
+    # to poll, so the test applies that same expression rather than
+    # restating the filter.
+    defp pr_stage_tasks do
+      require Ash.Query
+
+      trigger = AshOban.Info.oban_trigger(Task, :check_pr_status)
+
+      Task
+      |> Ash.Query.do_filter(trigger.where)
+      |> Ash.read!()
+    end
+
+    defp seed_pr_task(project, user) do
+      Ash.Seed.seed!(Task, %{
+        title: "pr task",
+        stage: :pr,
+        state: :waiting_for_input,
+        pr_number: 7,
+        project_id: project.id,
+        creator_id: user.id,
+        agent_id: agent!("claude_code").id
+      })
+    end
+
+    test "polls a PR-stage task in an active project", ctx do
+      task = seed_pr_task(ctx.project, ctx.user)
+
+      assert Enum.map(pr_stage_tasks(), & &1.id) == [task.id]
+    end
+
+    test "skips a PR-stage task in an archived project", ctx do
+      seed_pr_task(ctx.project, ctx.user)
+      {:ok, _} = Ash.update(ctx.project, %{}, action: :archive)
+
+      assert pr_stage_tasks() == []
+    end
+  end
 end

--- a/test/camelot/projects/changes/sync_github_issues_test.exs
+++ b/test/camelot/projects/changes/sync_github_issues_test.exs
@@ -47,4 +47,39 @@ defmodule Camelot.Projects.Changes.SyncGithubIssuesTest do
       assert SyncGithubIssues.installation_id(project) == 2
     end
   end
+
+  describe "syncable?/1" do
+    defp syncable_project(attrs \\ %{}) do
+      defaults = %{
+        status: :active,
+        github_owner: "acme-org",
+        github_repo: "widgets",
+        owner_membership: %Membership{user: %User{}}
+      }
+
+      struct!(Project, Map.merge(defaults, attrs))
+    end
+
+    test "an active project with a repo and an owner syncs" do
+      assert SyncGithubIssues.syncable?(syncable_project())
+    end
+
+    test "an archived project does not sync" do
+      # Archiving a project used to stop nothing: issues kept being
+      # imported into a board nobody looks at any more.
+      refute SyncGithubIssues.syncable?(syncable_project(%{status: :archived}))
+    end
+
+    test "a project without a github owner does not sync" do
+      refute SyncGithubIssues.syncable?(syncable_project(%{github_owner: nil}))
+    end
+
+    test "a project without a github repo does not sync" do
+      refute SyncGithubIssues.syncable?(syncable_project(%{github_repo: nil}))
+    end
+
+    test "a project without an owner membership does not sync" do
+      refute SyncGithubIssues.syncable?(syncable_project(%{owner_membership: nil}))
+    end
+  end
 end

--- a/test/camelot/projects/project_test.exs
+++ b/test/camelot/projects/project_test.exs
@@ -270,4 +270,22 @@ defmodule Camelot.Projects.ProjectTest do
       assert {:ok, []} = Ash.read(Project)
     end
   end
+
+  describe "active?/1" do
+    test "a freshly created project is active" do
+      {:ok, project} = Ash.create(Project, @valid_attrs)
+      assert Project.active?(project)
+    end
+
+    test "an archived project is not active" do
+      {:ok, project} = Ash.create(Project, @valid_attrs)
+      {:ok, archived} = Ash.update(project, %{}, action: :archive)
+
+      refute Project.active?(archived)
+    end
+
+    test "a nil project is not active" do
+      refute Project.active?(nil)
+    end
+  end
 end


### PR DESCRIPTION
Two unrelated bugs, both found while working out why issue #138 was picked up by `app.camelotai.tech` (where the CamelotAI project is **archived**) but not by `test.camelotai.tech` (where it is **active**).

## 1. Orphaned Oban job wedged issue sync on test — forever

```
id           | 80713
state        | executing          ← since 2026-07-01 12:10
worker       | …ActionWorker.SyncGithubIssues
attempt      | 1  / max_attempts 1
attempted_by | {camelot@0f9709b6b2b5, …}    ← node long gone
```

AshOban generates every scheduled-action worker with `unique: [period: :infinity, states: :incomplete]` (`deps/ash_oban/lib/transformers/define_action_workers.ex:68`). `:incomplete` includes `:executing`, so one orphan blocks that worker from ever being enqueued again. The Cron plugin has been silently skipping the insert every 5 minutes for two months, and `tasks` on test contains no `GH#…` rows at all.

The orphan exists because `config/config.exs` ran `plugins: [{Oban.Plugins.Cron, crontab: []}]` and nothing else — no `Oban.Plugins.Lifeline` to rescue a job whose node died, on a cluster of OOM-prone 1GB nodes. `Camelot.Board.Task.AshOban.ActionWorker.DispatchTasks` carries the same uniqueness and was one bad OOM away from dying the same way.

Adds `Lifeline` (`rescue_after: 30m` — far above any real job runtime here; dispatch hands off to a `TaskRunner` process, the rest are single HTTP round trips) and `Pruner` (`max_age: 7d`; `oban_jobs` on test had reached **305,922 rows / 172 MB**).

**Deploying this self-heals test** — Lifeline moves job 80713 out of `executing`, the uniqueness conflict clears, and the next `*/5` tick enqueues a real sync. No manual DB surgery needed.

## 2. Archiving a project stopped nothing

`Project.status` (`:active | :archived`) was only ever read for a UI badge. `SyncGithubIssues.projects_with_github/0` filtered on repo + owner membership and never looked at it, so an archived board kept importing issues — which is exactly what happened to #138 on prod. Same blind spot in `DispatchTasks` (kept dispatching agents and burning runner slots) and in the `check_pr_status` trigger (kept polling GitHub).

Adds `Project.active?/1` and consults it in all three.

## Tests

- `Project.active?/1` — active, archived, nil
- `SyncGithubIssues.syncable?/1` — archived / no owner / no repo / no membership
- `DispatchTasks.dispatchable?/1` — new file; state, stage and archived-project cases
- `check_pr_status` trigger scope — applies the trigger's own `where` expression via `AshOban.Info.oban_trigger/2` rather than restating the filter, and asserts a PR-stage task disappears once its project is archived

`mix compile --warnings-as-errors`, `mix test` (752 tests + 1 doctest, 0 failures), `mix format`, `mix credo --strict` (no issues), `mix dialyzer` (clean) all pass.

## Note

Archiving now genuinely halts a project's agents. Any queued task in an archived project will sit queued rather than run — intended, but worth knowing before archiving something with work in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)