### PR TITLE
ci: cancel superseded runs, auto-open the develop → main release PR

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -4,6 +4,12 @@ on:
     branches:
       - develop
 
+# Only the newest run per branch survives: merging several PRs in a row
+# should not leave a queue of superseded check/build/deploy runs behind.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash
@@ -126,3 +132,15 @@ jobs:
             --appToken "$CAPROVER_APP_TOKEN" \
             --appName "${{ vars.APP_NAME }}" \
             --imageName "$CAPROVER_IMAGE_NAME"
+
+  # The develop pipeline is green (checks + image + deploy to test), so
+  # refresh the rolling release PR into main.
+  promote:
+    name: Promote develop to main
+    needs: [merge]
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
+    uses: ./.github/workflows/promote-develop.yml
+    secrets: inherit

--- a/.github/workflows/deploy-docs-proxy.yml
+++ b/.github/workflows/deploy-docs-proxy.yml
@@ -8,6 +8,12 @@ on:
       - ".github/workflows/deploy-docs-proxy.yml"
   workflow_dispatch:
 
+# Only the newest run per branch survives: merging several PRs in a row
+# should not leave a queue of superseded check/build/deploy runs behind.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -4,6 +4,12 @@ on:
     branches:
       - main
 
+# Only the newest run per branch survives: merging several PRs in a row
+# should not leave a queue of superseded check/build/deploy runs behind.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/pr-base-guard.yml
+++ b/.github/workflows/pr-base-guard.yml
@@ -1,0 +1,80 @@
+name: PR base guard
+
+# `main` is a release-only branch: it is updated solely through the rolling
+# `develop` → `main` release PR (see promote-develop.yml), so everything
+# landing in production has already passed the develop pipeline and has a
+# built, tested image in the registry.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  # The job name doubles as the status check name and must stay in sync
+  # with GUARD_CONTEXT in promote-develop.yml.
+  main-only-from-develop:
+    name: main-only-from-develop
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR: ${{ github.event.pull_request.number }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+      MARKER: "<!-- camelot:base-guard -->"
+    steps:
+      - name: Verify the PR comes from develop
+        run: |
+          if [ "$HEAD_REF" = "develop" ] \
+             && [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then
+            echo "$HEAD_REPO:$HEAD_REF -> main: allowed."
+            exit 0
+          fi
+
+          echo "::error::main only accepts PRs from develop, got" \
+               "$HEAD_REPO:$HEAD_REF."
+
+          cat > comment.md <<'MD'
+          __MARKER__
+          🚫 **`main` only accepts pull requests from `develop`.**
+
+          This PR targets `main` from `__HEAD__`. `main` is a release-only
+          branch, updated exclusively through the rolling `develop` → `main`
+          release PR that opens automatically once the `develop` pipeline
+          succeeds.
+
+          Please retarget this PR at `develop`:
+
+          ```
+          gh pr edit __PR__ --base develop
+          ```
+
+          See [docs/contributing.md](https://github.com/__REPO__/blob/develop/docs/contributing.md).
+          MD
+
+          # Written via placeholders so the body can be a quoted heredoc
+          # (markdown backticks must not be read as command substitution).
+          sed -e "s|__MARKER__|$MARKER|" \
+              -e "s|__HEAD__|$HEAD_REPO:$HEAD_REF|" \
+              -e "s|__REPO__|$GITHUB_REPOSITORY|" \
+              -e "s|__PR__|$PR|" comment.md > body.md
+
+          gh pr view "$PR" --json comments --jq '.comments[].body' \
+            > comments.txt || : > comments.txt
+          if ! grep -qF "$MARKER" comments.txt; then
+            gh pr comment "$PR" --body-file body.md
+          fi
+
+          exit 1

--- a/.github/workflows/promote-develop.yml
+++ b/.github/workflows/promote-develop.yml
@@ -1,0 +1,170 @@
+name: Promote develop to main
+
+# Runs as the last stage of the `develop` pipeline (see
+# build-docker-image.yml): once the checks, the multi-arch image build and
+# the deploy to test have all succeeded, open - or refresh - the single
+# rolling release PR from `develop` into `main`.
+on:
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+env:
+  BASE: main
+  HEAD: develop
+  TITLE: "Release: develop → main"
+  # Marker that identifies the rolling release PR body on later runs.
+  MARKER: "<!-- camelot:release-pr -->"
+  # Must match the job name in pr-base-guard.yml. GitHub never starts
+  # workflows for PRs opened with GITHUB_TOKEN, so this run publishes the
+  # guard status itself - otherwise the release PR would wait forever for
+  # a required check that can never report.
+  GUARD_CONTEXT: main-only-from-develop
+
+jobs:
+  release_pr:
+    name: Open or update the release PR
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base and head
+        run: |
+          git fetch --no-tags --quiet origin \
+            "+refs/heads/$BASE:refs/remotes/origin/$BASE" \
+            "+refs/heads/$HEAD:refs/remotes/origin/$HEAD"
+
+      - name: Count commits ahead of main
+        id: ahead
+        run: |
+          # --first-parent so the count matches the commit list in the body
+          count=$(git rev-list --count --first-parent \
+                    "origin/$BASE..origin/$HEAD")
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse "origin/$HEAD")" >> "$GITHUB_OUTPUT"
+          if [ "$count" -eq 0 ]; then
+            echo "::notice::$HEAD is not ahead of $BASE - nothing to promote."
+          fi
+
+      # Every PR merged into develop since the last release is listed in the
+      # body, so a release PR that is still open simply accumulates ("stacks")
+      # the PRs of every develop pipeline that ran while it was open.
+      - name: Build PR body
+        if: steps.ahead.outputs.count != '0'
+        id: body
+        env:
+          COUNT: ${{ steps.ahead.outputs.count }}
+          SHA: ${{ steps.ahead.outputs.sha }}
+        run: |
+          range="origin/$BASE..origin/$HEAD"
+          git log --first-parent --pretty=format:'%s' "$range" > subjects.txt
+          prs=$(grep -oE 'Merge pull request #[0-9]+|\(#[0-9]+\)' subjects.txt \
+                  | grep -oE '[0-9]+' | sort -un | tr '\n' ' ')
+          read -ra numbers <<< "$prs"
+
+          {
+            echo "$MARKER"
+            echo
+            echo "Opened automatically: the \`$HEAD\` pipeline (checks →"
+            echo "image build → deploy to test) succeeded for \`$SHA\`."
+            echo
+            echo "## PRs in this release"
+            echo
+            if [ "${#numbers[@]}" -gt 0 ]; then
+              for n in "${numbers[@]}"; do
+                title=$(gh pr view "$n" --json title --jq .title 2>/dev/null) \
+                  || title=""
+                echo "- #$n $title"
+              done
+            else
+              echo "_No merged PRs detected - direct commits only._"
+            fi
+            echo
+            echo "## Commits ($COUNT)"
+            echo
+            # shellcheck disable=SC2016 # backticks are markdown, not a subshell
+            git log --first-parent --pretty=format:'- `%h` %s' "$range" \
+              | head -n 50
+            echo
+            if [ "$COUNT" -gt 50 ]; then
+              echo
+              echo "_Truncated to the 50 most recent commits._"
+            fi
+            echo
+            echo "---"
+            echo
+            echo "⚠️ **Merge with a merge commit** (not squash, not rebase):"
+            echo "the production deploy resolves the already built and tested"
+            echo "image from the merge commit's second parent. See"
+            echo "[docs/contributing.md][doc]."
+            echo
+            echo "[doc]: https://github.com/$GITHUB_REPOSITORY/blob/$HEAD/docs/contributing.md"
+          } > body.md
+
+          printf 'prs=%s\n' "$prs" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update the release PR
+        if: steps.ahead.outputs.count != '0'
+        id: pr
+        env:
+          PRS: ${{ steps.body.outputs.prs }}
+        run: |
+          number=$(gh pr list --base "$BASE" --head "$HEAD" --state open \
+                     --json number --jq '.[0].number // empty')
+
+          if [ -z "$number" ]; then
+            gh pr create --base "$BASE" --head "$HEAD" \
+              --title "$TITLE" --body-file body.md || true
+            number=$(gh pr list --base "$BASE" --head "$HEAD" --state open \
+                       --json number --jq '.[0].number // empty')
+            if [ -z "$number" ]; then
+              echo "::error::Could not open or find the $HEAD -> $BASE PR."
+              exit 1
+            fi
+            echo "::notice::Opened release PR #$number."
+          else
+            gh pr view "$number" --json body --jq .body > old-body.md
+            read -ra numbers <<< "$PRS"
+            added=""
+            for n in "${numbers[@]}"; do
+              grep -qE "#${n}([^0-9]|$)" old-body.md || added="$added #$n"
+            done
+            gh pr edit "$number" --title "$TITLE" --body-file body.md
+            echo "::notice::Updated release PR #$number."
+            if [ -n "$added" ]; then
+              gh pr comment "$number" --body \
+                "Stacked onto this release by the latest \`$HEAD\` pipeline:$added"
+            fi
+          fi
+
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+          echo "Release PR: #$number" >> "$GITHUB_STEP_SUMMARY"
+
+      # Keeps the release PR mergeable when `main-only-from-develop` is a
+      # required status check (see docs/contributing.md).
+      - name: Publish source-branch guard status
+        if: steps.pr.outputs.number != ''
+        env:
+          SHA: ${{ steps.ahead.outputs.sha }}
+        run: |
+          gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$SHA" \
+            -f state=success \
+            -f context="$GUARD_CONTEXT" \
+            -f description="head branch is $HEAD"

--- a/.github/workflows/push-checks.yml
+++ b/.github/workflows/push-checks.yml
@@ -5,6 +5,12 @@ on:
       - main
       - develop
 
+# Only the newest run per branch survives: merging several PRs in a row
+# should not leave a queue of superseded check/build/deploy runs behind.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/runner-images.yml
+++ b/.github/workflows/runner-images.yml
@@ -10,6 +10,12 @@ on:
       - '.github/workflows/runner-images.yml'
   workflow_dispatch:
 
+# Only the newest run per branch survives: merging several PRs in a row
+# should not leave a queue of superseded check/build/deploy runs behind.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Follow the [Elixir Style Guide](https://github.com/christopheradams/elixir_style
 ## Feature Implementation Flow
 
 1. Plan the feature and ask for feedback
-2. Create a new branch from `main` for the feature
+2. Create a new branch from `develop` for the feature
 3. Implement tests first (TDD) and ask for approval
 4. Implement the feature code
 5. Make sure code is compilable by `mix compile` and has no warnings
@@ -52,7 +52,9 @@ Follow the [Elixir Style Guide](https://github.com/christopheradams/elixir_style
 8. Check with `mix dialyzer` for type issues
 9. Update documentation and AGENTS.md if needed
 10. Run `mix format` to ensure code style compliance
-11. Create a pull request and ask for review
+11. Create a pull request **against `develop`** and ask for review
+    (`main` only accepts the automatic `develop` → `main` release PR —
+    see `docs/contributing.md`)
 12. Address any feedback from the review
 
 ## Project Guidelines

--- a/README.md
+++ b/README.md
@@ -188,9 +188,14 @@ Run `docker compose up` to deploy with the included `Dockerfile` and
 
 PRs welcome — see the roadmap above for ideas.
 
+- Branch off `develop` and **open your PR against `develop`** — `main` is
+  release-only and is updated through an automatic `develop` → `main` PR
 - Follow the [Elixir Style Guide](https://github.com/christopheradams/elixir_style_guide)
-- Run `mix precommit` before submitting
+- Run `mix precommit`, `mix credo` and `mix dialyzer` before submitting
 - Open an issue first for large changes
+
+Branching model, CI pipelines and the release flow are documented in
+[docs/contributing.md](docs/contributing.md).
 
 ## License
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,138 @@
+# Contributing
+
+How work flows from a branch to production, and what CI does at each step.
+
+## Branching model
+
+```
+feature / camelot task branch
+        │  PR  ─────────────────────────────► develop        (integration)
+        │                                       │
+        │                          release PR (automatic)
+        │                                       ▼
+        └──────────────────────────────────►  main            (production)
+```
+
+- **`develop`** is the integration branch. **Every** contribution — human or
+  agent — targets `develop`.
+- **`main`** is release-only and mirrors production. It is updated
+  exclusively through the rolling `develop` → `main` release PR that CI
+  opens for you. PRs to `main` from anything other than `develop` fail the
+  `main-only-from-develop` check and get a comment asking you to retarget.
+- Branch names: `feat/*`, `fix/*`, `docs/*`, `chore/*`. Agent branches are
+  created as `camelot/task-<uuid>`.
+
+## Opening a PR
+
+1. Branch off `develop`.
+2. Write tests first, then the code.
+3. Before pushing, run locally:
+
+   ```sh
+   mix precommit        # compile --warnings-as-errors, deps.unlock, format, test
+   mix credo            # style / consistency (CI gate)
+   mix dialyzer         # types (CI gate)
+   ```
+
+4. Push and open the PR **against `develop`**.
+5. Keep the PR green: the same checks run on every push.
+
+## Pipelines
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `push-checks.yml` | push to any branch except `main` / `develop` | Calls `code-checks.yml` |
+| `code-checks.yml` | `workflow_call` | `mix format --check-formatted`, `mix credo`, `mix dialyzer`, `mix test` |
+| `pr-base-guard.yml` | PR targeting `main` | Fails unless the PR head is this repo's `develop` |
+| `build-docker-image.yml` | push to `develop` | Checks → multi-arch image (`ghcr.io/t0ha/camelotai`) → deploy to test → open/refresh the release PR |
+| `promote-develop.yml` | last stage of the `develop` pipeline, or `workflow_dispatch` | Opens or refreshes the `develop` → `main` release PR |
+| `deploy-production.yml` | push to `main` | Resolves the image built for the merged `develop` commit and deploys it to production |
+| `deploy-docs-proxy.yml` | push to `develop` touching `docs-proxy/**` | Builds and deploys the docs proxy (gated on the `DEPLOY_DOCS_PROXY` variable) |
+| `runner-images.yml` | push to `main` / `develop` touching `runner-images/**` | Builds the agent runner images |
+
+### Only the newest run survives
+
+Every push-triggered workflow declares:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Merging several PRs into `develop` in a row therefore leaves exactly one
+live run per pipeline — the one for the newest commit. Superseded runs are
+cancelled instead of queueing up behind it, so you never wait on (or
+deploy) an already-stale commit. Cancelled runs show up as ⏹ "cancelled",
+which is expected and not a failure.
+
+Because a cancellation can in principle land while an older run is inside
+its CapRover deploy step, a newer deploy immediately supersedes it; if a
+test deploy ever looks half-applied, re-run the newest `develop` pipeline.
+
+## The automatic release PR
+
+When the whole `develop` pipeline is green — checks, multi-arch image
+build, deploy to test — `promote-develop.yml` runs and:
+
+1. Finds the open `develop` → `main` PR, or opens one titled
+   `Release: develop → main`.
+2. Rewrites the body with every commit and **every PR merged into
+   `develop` since `main`**. A release PR that is still open therefore
+   accumulates ("stacks") the PRs of each later `develop` pipeline instead
+   of a second, competing PR being opened.
+3. Comments on the PR with the newly stacked PR numbers, so reviewers see
+   what changed since they last looked.
+4. Publishes a successful `main-only-from-develop` status on the `develop`
+   tip (see *Known quirks*).
+
+Nothing is promoted automatically: a human still reviews and merges the
+release PR. That merge is what deploys to production.
+
+### Merge the release PR with a merge commit
+
+`deploy-production.yml` never rebuilds. It takes `HEAD^2` of the new `main`
+commit — the merged `develop` tip — and deploys the image already built and
+tested for that SHA. Squashing or rebasing the release PR produces a commit
+with no second parent, so the deploy fails with
+`main must be updated via a merge commit from develop`.
+
+## Hotfixes
+
+There is no `main`-only hotfix path: a fix must pass through `develop` so
+that an image exists for it and so `main` never diverges. For an urgent
+fix, open the PR against `develop`, get it merged, and merge the release PR
+as soon as the `develop` pipeline goes green.
+
+## Maintainer setup
+
+Repository settings CI depends on:
+
+- **Ruleset on `main`** (Settings → Rules), already configured:
+  - a pull request with at least one approval; deletions and force pushes
+    blocked;
+  - `main-only-from-develop` as a **required status check**, which makes
+    the guard blocking rather than advisory;
+  - *allowed merge methods* restricted to **merge commit** only, so the
+    release PR cannot be squashed (see above).
+
+  Repository admins are bypass actors, so an emergency merge is still
+  possible — at the cost of the production deploy failing to resolve an
+  image (see above).
+- **Actions → Workflow permissions**: "Read and write permissions". The
+  release-PR job needs `pull-requests: write` and `statuses: write`.
+- **Environments** `test` and `production` hold the CapRover credentials
+  (`APP_TOKEN`, `CAPROVER_SERVER`, `APP_NAME`) and the docs CDN variables.
+
+### Known quirks
+
+- **PRs opened with `GITHUB_TOKEN` do not start workflows.** That is why
+  `promote-develop.yml` publishes the `main-only-from-develop` status
+  itself — otherwise a required check that can never report would block the
+  release PR forever. The job name in `pr-base-guard.yml` and
+  `GUARD_CONTEXT` in `promote-develop.yml` must stay identical.
+- `promote-develop.yml` is invoked as a job of `build-docker-image.yml`
+  rather than via `workflow_run`, so it always runs the version of the file
+  that is on `develop` — no waiting for it to reach the default branch.
+- The release PR still needs a human approval; the automation only prepares
+  it.


### PR DESCRIPTION
## What

Three CI changes plus contributor docs.

### 1. Only the newest run per pipeline survives

Every push-triggered workflow (`push-checks`, `build-docker-image`,
`deploy-production`, `deploy-docs-proxy`, `runner-images`) now declares:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Merging several PRs into `develop` in a row cancels the superseded runs
instead of queueing them behind the newest commit.

### 2. Automatic `develop` → `main` release PR

New `promote-develop.yml`, wired as the last job of `build-docker-image.yml`
(so it only runs once checks, the multi-arch build and the test deploy are
all green). It opens — or refreshes — the single rolling release PR:

- body lists every commit and **every PR merged into `develop` since
  `main`**, so a release PR that is still open accumulates ("stacks") the
  PRs of each later `develop` pipeline rather than a second PR being opened;
- comments with the newly stacked PR numbers so reviewers see what changed;
- publishes the `main-only-from-develop` status itself — GitHub never starts
  workflows for PRs opened with `GITHUB_TOKEN`, so a required check would
  otherwise never report and the release PR would be unmergeable.

It is invoked via `workflow_call` rather than `workflow_run` so it always
runs the version of the file on `develop`, with no wait for it to reach the
default branch. Also available via `workflow_dispatch`.

### 3. `main` only accepts PRs from `develop`

New `pr-base-guard.yml` fails — and comments once — on any PR targeting
`main` whose head is not this repo's `develop`.

The `main` ruleset has been updated accordingly:

- `main-only-from-develop` is now a **required status check**;
- allowed merge methods restricted to **merge commit** only, which
  `deploy-production.yml` depends on (it resolves the already built and
  tested image from `HEAD^2`).

Admins remain bypass actors for emergencies.

### 4. Docs

- `docs/contributing.md` — branching model, pipeline table, concurrency
  behaviour, how the release PR works, the merge-commit requirement,
  maintainer setup and known quirks.
- `README.md` — contributors branch off and target `develop`.
- `AGENTS.md` — fixed "create a branch from `main`" → `develop`, and PRs go
  to `develop`.

## Verification

- `actionlint` (via Docker) is clean on all changed/added workflows; the one
  remaining warning is pre-existing and intentional (`SC2046` on the
  digest glob in the manifest step).
- Body-generation and guard shell logic dry-run locally against this repo:
  the release body renders with the 4 PRs currently on `develop` ahead of
  `main`, and the guard passes for `develop` / fails with the retarget
  comment for `fix/foo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)