### PR TITLE
fix(ci): drop the concurrency group from the called promote workflow

### DIFF
--- a/.github/workflows/promote-develop.yml
+++ b/.github/workflows/promote-develop.yml
@@ -4,13 +4,19 @@ name: Promote develop to main
 # build-docker-image.yml): once the checks, the multi-arch image build and
 # the deploy to test have all succeeded, open - or refresh - the single
 # rolling release PR from `develop` into `main`.
+#
+# No `concurrency:` key here on purpose. In a called workflow the group is
+# evaluated in the CALLER's context - `github.workflow` is the caller's
+# name - so `${{ github.workflow }}-${{ github.ref }}` resolves to exactly
+# the group the calling run already holds. The job can then never be
+# scheduled and the whole run fails without it ever being created. The
+# caller's group already serialises this workflow.
+#
+# `workflow_dispatch` only becomes usable once this file is on the default
+# branch (`main`).
 on:
   workflow_call:
   workflow_dispatch:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 defaults:
   run:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -45,7 +45,7 @@ feature / camelot task branch
 | `code-checks.yml` | `workflow_call` | `mix format --check-formatted`, `mix credo`, `mix dialyzer`, `mix test` |
 | `pr-base-guard.yml` | PR targeting `main` | Fails unless the PR head is this repo's `develop` |
 | `build-docker-image.yml` | push to `develop` | Checks → multi-arch image (`ghcr.io/t0ha/camelotai`) → deploy to test → open/refresh the release PR |
-| `promote-develop.yml` | last stage of the `develop` pipeline, or `workflow_dispatch` | Opens or refreshes the `develop` → `main` release PR |
+| `promote-develop.yml` | last stage of the `develop` pipeline (also `workflow_dispatch`, once the file is on `main`) | Opens or refreshes the `develop` → `main` release PR |
 | `deploy-production.yml` | push to `main` | Resolves the image built for the merged `develop` commit and deploys it to production |
 | `deploy-docs-proxy.yml` | push to `develop` touching `docs-proxy/**` | Builds and deploys the docs proxy (gated on the `DEPLOY_DOCS_PROXY` variable) |
 | `runner-images.yml` | push to `main` / `develop` touching `runner-images/**` | Builds the agent runner images |
@@ -134,5 +134,16 @@ Repository settings CI depends on:
 - `promote-develop.yml` is invoked as a job of `build-docker-image.yml`
   rather than via `workflow_run`, so it always runs the version of the file
   that is on `develop` — no waiting for it to reach the default branch.
+  `workflow_dispatch` on it, by contrast, only works once the file has
+  reached `main`: GitHub lists dispatchable workflows from the default
+  branch only.
+- **Never add a `concurrency:` key to `promote-develop.yml`** (or to any
+  other `workflow_call` workflow) that is derived from `github.workflow`.
+  In a called workflow the group is evaluated in the *caller's* context —
+  `github.workflow` is the calling workflow's name — so
+  `${{ github.workflow }}-${{ github.ref }}` resolves to the exact group
+  the calling run already holds. The job then can never be scheduled: it is
+  never created at all, and the whole run ends as a failure with every
+  visible job green. The caller's concurrency group already covers it.
 - The release PR still needs a human approval; the automation only prepares
   it.


### PR DESCRIPTION
## Symptom

The first `develop` run after #146 ([run 34588987639](https://github.com/T0ha/camelot/actions/runs/34588987639)) concluded **failure** while all six visible jobs were green — checks, both image builds, and the test deploy. The `promote` job does not appear in the run at all: no job, no check run, no log.

## Cause

In a `workflow_call` workflow, the `concurrency` group is evaluated in the **caller's** context — `github.workflow` is the *calling* workflow's name. So this block in `promote-develop.yml`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

resolved to `Build Docker Image-refs/heads/develop` — the exact group the calling run already held. The child job could never be scheduled, so it was never created and the run ended as a failure.

Confirmed with a minimal caller/callee pair on a throwaway branch (since deleted):

| callee | result |
|---|---|
| with the `concurrency` block | run **failed**, `called` job never created — identical signature |
| same, block removed | run **succeeded**, and the callee logged `github.workflow=ZZ Test Caller` |

That last line is the direct proof of the context evaluation.

## Fix

Remove the block. The caller (`build-docker-image.yml`) already declares `concurrency` for the whole develop pipeline, so the promote job is serialised with it — nothing is lost. Workflow-level concurrency on the other five push-triggered workflows is unaffected; none of them are `workflow_call` targets.

Also documented in `docs/contributing.md`:

- never derive a `concurrency` group from `github.workflow` in a `workflow_call` workflow, and why;
- `workflow_dispatch` on `promote-develop.yml` only works once the file has reached `main` — GitHub lists dispatchable workflows from the default branch only.

## Verification

`actionlint` clean (only the pre-existing intentional `SC2046`). The real end-to-end check is the next `develop` pipeline: the `promote` job should run and open the `develop` → `main` release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)