### PR TITLE
docs(ci): note the Actions setting the release PR needs

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -119,8 +119,11 @@ Repository settings CI depends on:
   Repository admins are bypass actors, so an emergency merge is still
   possible — at the cost of the production deploy failing to resolve an
   image (see above).
-- **Actions → Workflow permissions**: "Read and write permissions". The
-  release-PR job needs `pull-requests: write` and `statuses: write`.
+- **Actions → General → Workflow permissions**: "Read and write
+  permissions" *and* "Allow GitHub Actions to create and approve pull
+  requests". The release-PR job needs `pull-requests: write` and
+  `statuses: write`; without the second checkbox `gh pr create` fails with
+  `GitHub Actions is not permitted to create or approve pull requests`.
 - **Environments** `test` and `production` hold the CapRover credentials
   (`APP_TOKEN`, `CAPROVER_SERVER`, `APP_NAME`) and the docs CDN variables.
 


### PR DESCRIPTION
Follow-up to #147. The promote job reached the create call and failed with:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

That is the **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** checkbox, which was off. It is now enabled on this repo, and the release PR (#148) opened successfully on re-run — with the `main-only-from-develop` status published as designed, leaving the PR blocked only on the human approval.

This adds the checkbox to the maintainer-setup list in `docs/contributing.md`, since a fork or a fresh clone would otherwise hit the same error with no hint of the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)