### PR TITLE
fix(web): point the docs nav link at docs.camelotai.tech in prod

### DIFF
--- a/lib/camelot_web/components/layouts.ex
+++ b/lib/camelot_web/components/layouts.ex
@@ -55,12 +55,29 @@ defmodule CamelotWeb.Layouts do
   end
 
   @doc """
-  Builds the docs site URL by prefixing the endpoint host with `docs.`.
+  Builds the docs site URL for the current endpoint.
   """
   @spec docs_url() :: String.t()
-  def docs_url do
-    String.replace(CamelotWeb.Endpoint.url(), "://", "://docs.")
+  def docs_url, do: docs_url(CamelotWeb.Endpoint.url())
+
+  @doc """
+  Builds the docs site URL from a base URL.
+
+  The docs live on the `docs.` subdomain of the deployment's base domain.
+  Production serves the app from `app.camelotai.tech` while the docs are on
+  `docs.camelotai.tech`, so a leading `app.` label is replaced rather than
+  prefixed.
+  """
+  @spec docs_url(String.t()) :: String.t()
+  def docs_url(base_url) do
+    uri = URI.parse(base_url)
+
+    URI.to_string(%{uri | host: docs_host(uri.host)})
   end
+
+  @spec docs_host(String.t()) :: String.t()
+  defp docs_host("app." <> base), do: "docs." <> base
+  defp docs_host(host), do: "docs." <> host
 
   @doc """
   Provides dark vs light theme toggle based on themes defined in app.css.

--- a/test/camelot_web/components/layouts_test.exs
+++ b/test/camelot_web/components/layouts_test.exs
@@ -1,0 +1,22 @@
+defmodule CamelotWeb.LayoutsTest do
+  use ExUnit.Case, async: true
+
+  alias CamelotWeb.Layouts
+
+  describe "docs_url/1" do
+    test "replaces a leading app. label with docs." do
+      assert Layouts.docs_url("https://app.camelotai.tech") ==
+               "https://docs.camelotai.tech"
+    end
+
+    test "prefixes docs. on hosts without an app. label" do
+      assert Layouts.docs_url("https://test.camelotai.tech") ==
+               "https://docs.test.camelotai.tech"
+    end
+
+    test "keeps a non-default port" do
+      assert Layouts.docs_url("http://localhost:4000") ==
+               "http://docs.localhost:4000"
+    end
+  end
+end


### PR DESCRIPTION
## Problem

In production the nav bar "Docs" link points at `docs.app.camelotai.tech`, which does not exist — the docs site is served at `docs.camelotai.tech`. Test is fine (`test.camelotai.tech` → `docs.test.camelotai.tech`).

The helper prefixed the whole endpoint host with a `docs.` label:

```elixir
String.replace(CamelotWeb.Endpoint.url(), "://", "://docs.")
```

Production's `PHX_HOST` is `app.camelotai.tech`, so that yields `docs.app.camelotai.tech`.

## Fix

Parse the URL and replace a leading `app.` label instead of prefixing it:

| endpoint URL | docs URL |
|---|---|
| `https://app.camelotai.tech` | `https://docs.camelotai.tech` |
| `https://test.camelotai.tech` | `https://docs.test.camelotai.tech` (unchanged) |
| `http://localhost:4000` | `http://docs.localhost:4000` (unchanged) |

`docs_url/1` is public so the mapping is testable without an endpoint.

## Testing

- New `test/camelot_web/components/layouts_test.exs` covers all three cases.
- `mix test` could not run in full locally: port 5432 is held by an unrelated container whose Postgres fails with `could not write init file`, so the `ecto.create/migrate` test alias aborts. The new test file was run directly through ExUnit (`mix run --no-start` + `ExUnit.run()`): 3 tests, 0 failures. CI will run the full suite.
- `mix format` and `mix credo` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)